### PR TITLE
Add Rubocop YAML file

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/rubocop.yml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/rubocop.yml
@@ -1,0 +1,20 @@
+AlignParameters:
+  Enabled: false
+
+ClassAndModuleChildren:
+  Enabled: false
+
+Encoding:
+  Enabled: false
+
+LineLength:
+  Max: 200
+
+HashSyntax:
+  EnforcedStyle: hash_rockets
+
+SignalException:
+  Enabled: false
+
+StringLiterals:
+  EnforcedStyle: double_quotes

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -1,5 +1,3 @@
-
-
 context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 
@@ -21,6 +19,11 @@ cookbook_file "#{cookbook_dir}/chefignore"
 
 # Berks
 cookbook_file "#{cookbook_dir}/Berksfile"
+
+# Rubocop Yaml
+cookbook_file "#{cookbook_dir}/.rubocop.yml" do
+  source 'rubocop.yml'
+end
 
 # TK
 template "#{cookbook_dir}/.kitchen.yml" do
@@ -49,5 +52,3 @@ if context.have_git && !context.skip_git_init
     source "gitignore"
   end
 end
-
-

--- a/spec/unit/command/generator_commands_spec.rb
+++ b/spec/unit/command/generator_commands_spec.rb
@@ -99,6 +99,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       README.md
       recipes
       recipes/default.rb
+      .rubocop.yml
     ]
   end
 


### PR DESCRIPTION
This PR addresses [CHEF-5266](https://tickets.opscode.com/browse/CHEF-5266)

The goal of this PR was take the usual `.rubocop.yml` file found in many of the community maintained cookbooks and drop it in the new cookbook generated via `chef generate cookbook foobar` .  By doing so we give the maintainer of the brand new cookbook the ability the enforce the same basic style guides used by some of the getchef cookbooks.

Also, in an unrelated change I have added `rake spec` as a new target for running the unit test suite.
