### PR TITLE
Avoid appending a double ".erb" in templates

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/template.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/template.rb
@@ -2,7 +2,14 @@
 context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 template_dir = File.join(cookbook_dir, "templates/default")
-template_path = File.join(cookbook_dir, "templates/default", "#{context.new_file_basename}.erb")
+template_filename = context.new_file_basename
+
+unless File.extname(template_filename) == ".erb"
+  template_filename.concat(".erb")
+end
+
+template_path = File.join(cookbook_dir, "templates/default", template_filename)
+
 
 directory template_dir do
   recursive true


### PR DESCRIPTION
If the user gives a .erb extension to the template, don't add it
