### PR TITLE
Avoid appending a double ".erb" in templates

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/template.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/template.rb
@@ -2,7 +2,13 @@
 context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 template_dir = File.join(cookbook_dir, "templates/default")
-template_path = File.join(cookbook_dir, "templates/default", "#{context.new_file_basename}.erb")
+template_filename = context.new_file_basename
+
+unless File.extname(template_filename) == ".erb"
+  template_filename.concat(".erb")
+end
+
+template_path = File.join(cookbook_dir, "templates/default", template_filename)
 
 directory template_dir do
   recursive true

--- a/spec/unit/command/generator_commands_spec.rb
+++ b/spec/unit/command/generator_commands_spec.rb
@@ -387,6 +387,17 @@ describe ChefDK::Command::GeneratorCommands::Template do
   end
 end
 
+describe ChefDK::Command::GeneratorCommands::Template do
+
+  include_examples "a file generator" do
+
+    let(:generator_name) { "template" }
+    let(:generated_files) { [ "templates/default/new_template.erb" ] }
+    let(:new_file_name) { "new_template.erb" }
+
+  end
+end
+
 describe ChefDK::Command::GeneratorCommands::CookbookFile do
 
   include_examples "a file generator" do


### PR DESCRIPTION
If the user gives a .erb extension to the template, don't add it
