### PR TITLE
install specific gem version

### DIFF
--- a/lib/chef-dk/command/gem.rb
+++ b/lib/chef-dk/command/gem.rb
@@ -34,8 +34,12 @@ module ChefDK
         exit( e.exit_code )
       end
 
+      # Lazy solution: By automatically returning false, we force ChefDK::Base to
+      # call this class' run method, so that Gem::GemRunner can handle the -v flag
+      # appropriately (showing the gem version, or installing a specific version
+      # of a gem).
       def needs_version?(params)
-        !params.empty? && (params[0] == "-v" || params[0] == "--version")
+        false
       end
     end
   end


### PR DESCRIPTION
https://github.com/opscode/chef-dk/issues/46

Adds the ability to install specific versions of gems through chef-dk. Previously, the command `chef gem install kitty -v 0.0.1` would print the chef-dk version and not intall version 0.0.1 of the kitty gem.

@opscode/client-eng 
