### PR TITLE
Handle GemRunner returning nil on success

### DIFF
--- a/lib/chef-dk/command/gem.rb
+++ b/lib/chef-dk/command/gem.rb
@@ -29,7 +29,8 @@ module ChefDK
       banner "Usage: chef gem GEM_COMMANDS_AND_OPTIONS"
 
       def run(params)
-        Gem::GemRunner.new.run( params.clone )
+        retval = Gem::GemRunner.new.run( params.clone )
+        retval.nil? ? true : retval
       rescue Gem::SystemExitException => e
         exit( e.exit_code )
       end


### PR DESCRIPTION
`Gem::GemRunner` returns `nil` on success for some commands (`gem update` is what gave me trouble). In such case, `ChefDK::CLI#run` goes ahead and tries to understand global `chef` command's options, which in turn doesn't recognize `gem`'s options and fails.

This patch translates `nil` return value to `true`, which indicates success.
