### PR TITLE
Fix appending .erb to template filename.

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/template.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/template.rb
@@ -5,7 +5,9 @@ template_dir = File.join(cookbook_dir, "templates/default")
 template_filename = context.new_file_basename
 
 unless File.extname(template_filename) == ".erb"
-  template_filename.concat(".erb")
+  # new_file_basename is a frozen string, so we have to create an entirely
+  # new string here instead of using concat.
+  template_filename = "#{template_filename}.erb"
 end
 
 template_path = File.join(cookbook_dir, "templates/default", template_filename)


### PR DESCRIPTION
Blocking bug for Learn Chef tutorials -- and anyone using `chef generate template`, heh.

Not sure why this issue wasn't turning up in spec tests. My best guess is that mixlib/cli's option parsing returns frozen strings and our stubs in `spec/unit/command/generator_commands_spec.rb` don't touch the option parsing code. Perhaps we should add functional/integration tests to chef-dk. In the meantime, inserted a comment to (hopefully) prevent regression of this particular case.

Checked other file generators and none try to directly modify `new_file_basename`.

\cc @opscode/client-eng 
