### PR TITLE
debugger/pry-debugger no likey ruby 2.1.x

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -49,5 +49,4 @@ Gem::Specification.new do |gem|
   %w(rspec-core rspec-expectations rspec-mocks).each do |dev_gem|
     gem.add_development_dependency dev_gem, "~> 2.14.0"
   end
-  gem.add_development_dependency "pry-debugger"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@
 
 require 'rubygems'
 require 'rspec/mocks'
-require 'pry-debugger'
 require 'test_helpers'
 
 RSpec.configure do |c|


### PR DESCRIPTION
fails to compile the debugger gem at all.  pry-byebug and the
byebug gem are the replacements if we really need this...
