### PR TITLE
Add a description of policyfile design and status

### DIFF
--- a/POLICYFILE_README.md
+++ b/POLICYFILE_README.md
@@ -388,6 +388,13 @@ this will be added.
 Roles currently cannot be used in the `Policyfile.rb` run list, but will
 be supported in the future.
 
+### Policyfile Attributes
+
+The `Policyfile.rb` run_list will be able to have roles, which have
+attributes. The `Policyfile.rb` will also allow setting attributes
+directly. These will replace the role-level attributes in the precedence
+hierarchy.
+
 ### Multiple Run List Support
 
 This is intended to (at minimum) replace the functionality of override


### PR DESCRIPTION
I've added a readme for the Policyfile feature so we can point people with questions there for additional info. It describes the overall plan and has a list of not-yet-implemented stuff. The idea is we'll update this as we go.

Thoughts? @opscode/client-engineers 
