### PR TITLE
Removes ignoring of CHANGELOG

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -77,7 +77,6 @@ tmp
 # Cookbooks #
 #############
 CONTRIBUTING
-CHANGELOG*
 
 # Strainer #
 ############


### PR DESCRIPTION
We now use the CHANGELOG in the cookbook on Supermarket to display it on
the site. Let's remove this in the case that `knife cookbook site share`
obeys chefignore.
