### PR TITLE
Disable atomic file updates on Windows

### DIFF
--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -62,7 +62,9 @@ module ChefDK
       Chef::Config.diff_disabled = true
 
       # atomic file operations on Windows require Administrator privileges to be able to read the SACL from a file
+      # Using file_staging_uses_destdir(true) will get us inherited permissions indirectly on tempfile creation
       Chef::Config.file_atomic_update = false if Chef::Platform.windows?
+      Chef::Config.file_staging_uses_destdir = true # Default in Chef 12+
     end
 
     def ohai

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -44,6 +44,7 @@ describe ChefDK::ChefRunner do
     expect(Chef::Config.cookbook_path).to eq(default_cookbook_path)
     expect(Chef::Config.color).to be true
     expect(Chef::Config.diff_disabled).to be true
+    expect(Chef::Config.file_staging_uses_destdir).to be true
   end
 
   it "disables atomic file updates on Windows" do


### PR DESCRIPTION
Utilizing atomic file updates (via Chef, e.g. templates) means needing
Administrator permissions to read the SACL from files. While we expect
chef-client to be run as Administrator or with equivlanet permissions, we
expect chef-dk (chef) to be run as a regular user. Even when logged in as
an Administrator, you need to be running your shell with elevated
privileges for atomic file updates to work.

Fixes #109.
