### PR TITLE
Move git_init check into it's own block under have_git

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -43,11 +43,13 @@ template "#{cookbook_dir}/recipes/default.rb" do
 end
 
 # git
-if context.have_git && !context.skip_git_init
+if context.have_git
+  if !context.skip_git_init
 
-  execute("initialize-git") do
-    command("git init .")
-    cwd cookbook_dir
+    execute("initialize-git") do
+      command("git init .")
+      cwd cookbook_dir
+    end
   end
 
   cookbook_file "#{cookbook_dir}/.gitignore" do


### PR DESCRIPTION
This allows gitignore to be generated even if we don't wish to initialize the cookbook as it's own git repo
This is a quick fix for Issue #145 

I'm not 100% sure but this likely falls under Obvious Fix policy.
