### PR TITLE
Set GEM_HOME to Gem.user_dir instead of Gem.paths.home

### DIFF
--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -85,7 +85,7 @@ module ChefDK
           {
             'PATH' => "#{omnibus_bin_dir}:#{user_bin_dir}:#{omnibus_embedded_bin_dir}:#{ENV['PATH']}",
             'GEM_ROOT' => Gem.default_dir.inspect,
-            'GEM_HOME' => Gem.paths.home,
+            'GEM_HOME' => Gem.user_dir,
             'GEM_PATH' => Gem.path.join(':'),
           }
         end

--- a/spec/unit/command/exec_spec.rb
+++ b/spec/unit/command/exec_spec.rb
@@ -73,7 +73,7 @@ describe ChefDK::Command::Exec do
 
       let(:expected_GEM_ROOT) { Gem.default_dir.inspect }
 
-      let(:expected_GEM_HOME) { ENV['GEM_HOME'] }
+      let(:expected_GEM_HOME) { Gem.user_dir }
 
       let(:expected_GEM_PATH) { Gem.path.join(':') }
 
@@ -107,7 +107,7 @@ describe ChefDK::Command::Exec do
 
       let(:expected_GEM_ROOT) { Gem.default_dir.inspect }
 
-      let(:expected_GEM_HOME) { ENV['GEM_HOME'] }
+      let(:expected_GEM_HOME) { Gem.user_dir }
 
       let(:expected_GEM_PATH) { Gem.path.join(':') }
 

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -38,7 +38,7 @@ describe ChefDK::Command::ShellInit do
 
   let(:expected_gem_root) { Gem.default_dir.to_s }
 
-  let(:expected_gem_home) { ENV['GEM_HOME'] }
+  let(:expected_gem_home) { Gem.user_dir }
 
   let(:expected_gem_path) { Gem.path.join(':') }
 


### PR DESCRIPTION
Changed ChefDK::Helpers.omnibus_env to set GEM_HOME to Gem.user_dir instead of GEM_HOME. Also changed the tests to expect that as well. 

It works for me, but really not clear where Gem.user_dir comes from and if this may cause other people other problems.

Before this change `GEM_HOME` would be set to `/opt/chefdk/embedded/lib/ruby/gems/2.1.0` I wasn't really clear how `Gem.paths.home` ever got set to that. 

After this change `GEM_HOME` gets set to `/Users/rberger/.chefdk/gem/ruby/2.1.0` (Obviously it will be someone elses home on another system)
