### PR TITLE
Skip PATH sanity tests outside of omnibus

### DIFF
--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -161,6 +161,8 @@ BANNER
     # when they have the embedded_bin_dir before the omnibus_bin_dir -- both of which will
     # defeat appbundler and interact very badly with our intent.
     def sanity_check!
+      # When installed outside of omnibus, trust the user to configure their PATH
+      return true unless omnibus_install?
       paths = env[path_key].split(File::PATH_SEPARATOR)
       paths.map! { |p| drive_upcase(Chef::Util::PathHelper.cleanpath(p)) }
       embed_index = paths.index(drive_upcase(Chef::Util::PathHelper.cleanpath(omnibus_embedded_bin_dir)))

--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -50,8 +50,12 @@ module ChefDK
     # Locates the omnibus directories
     #
 
+    def omnibus_install?
+      File.exist?(omnibus_chefdk_location)
+    end
+
     def omnibus_root
-      @omnibus_root ||= omnibus_expand_path(Gem.ruby, "..", "..", "..")
+      @omnibus_root ||= omnibus_expand_path(expected_omnibus_root)
     end
 
     def omnibus_apps_dir
@@ -66,12 +70,20 @@ module ChefDK
       @omnibus_embedded_bin_dir ||= omnibus_expand_path(omnibus_root, "embedded", "bin")
     end
 
+    def omnibus_chefdk_location
+      @omnibus_chefdk_location ||= File.expand_path('embedded/apps/chef-dk', expected_omnibus_root)
+    end
+
     private
 
     def omnibus_expand_path(*paths)
       dir = File.expand_path(File.join(paths))
       raise OmnibusInstallNotFound.new() unless ( dir and File.directory?(dir) )
       dir
+    end
+
+    def expected_omnibus_root
+      File.expand_path(File.join(Gem.ruby, "..", "..", ".."))
     end
 
     #


### PR DESCRIPTION
the PATH sanity checks are cool, but they prevent you from running the code directly out of a git clone for dev purposes, and also wouldn't work with Gem installs (which we need to allow to have minimal support for random desktop linux distros). This change makes PATH checks apply only to omnibus installs.
