### PR TITLE
Check deeper directories for .git when selecting a SCM profiler

### DIFF
--- a/lib/chef-dk/policyfile/cookbook_locks.rb
+++ b/lib/chef-dk/policyfile/cookbook_locks.rb
@@ -279,6 +279,7 @@ module ChefDK
 
         @identifier_updated = false
         @version_updated = false
+        @cookbook_in_git_repo = nil
       end
 
       def cookbook_path
@@ -286,7 +287,7 @@ module ChefDK
       end
 
       def scm_profiler
-        if File.exist?(File.join(cookbook_path, ".git"))
+        if cookbook_in_git_repo?
           CookbookProfiler::Git.new(cookbook_path)
         else
           CookbookProfiler::NullSCM.new(cookbook_path)
@@ -371,6 +372,23 @@ module ChefDK
         unless source.kind_of?(String)
           raise InvalidLockfile, "Lockfile cookbook_lock for #{name} is invalid: `source' attribute must be a String (got: #{source.inspect})"
         end
+      end
+
+      def cookbook_in_git_repo?
+        return @cookbook_in_git_repo unless @cookbook_in_git_repo.nil?
+
+        @cookbook_in_git_repo = false
+
+        dot_git = Pathname.new(".git")
+        Pathname.new(cookbook_path).ascend do |parent_dir|
+          possbile_git_dir = parent_dir + dot_git
+          if possbile_git_dir.exist?
+            @cookbook_in_git_repo = true
+            break
+          end
+        end
+
+        @cookbook_in_git_repo
       end
 
     end

--- a/spec/unit/policyfile/cookbook_locks_spec.rb
+++ b/spec/unit/policyfile/cookbook_locks_spec.rb
@@ -285,7 +285,6 @@ describe ChefDK::Policyfile::LocalCookbook do
         let(:git_dir_path) { File.join(tempdir, "cookbook_repo/.git") }
 
         it "selects the git profiler" do
-          pending
           expect(cookbook_lock.scm_profiler).to be_an_instance_of(ChefDK::CookbookProfiler::Git)
         end
 


### PR DESCRIPTION
Makes the SCM profiling useful when used with a monolithic repo or when using the "app" layout. I tested it with my "policyfile_demo" repo, and ChefDK now collects this git info (where it didn't detect the git repo previously):

``` json
    "policyfile_demo": {
      "version": "0.1.0",
      "identifier": "f04cc40faf628253fe7d9566d66a1733fb1afbe9",
      "dotted_decimal_identifier": "67638399371010690.23642238397896298.25512023620585",
      "source": "cookbooks/policyfile_demo",
      "cache_key": null,
      "scm_info": {
        "scm": "git",
        "remote": "git@github.com:danielsdeleo/policyfile-jenkins-demo.git",
        "revision": "89f497d1f008fd8c0fe0c3dc7ef37de9a09c181d",
        "working_tree_clean": false,
        "published": true,
        "synchronized_remote_branches": [
          "mine/master"
        ]
      },
      "source_options": {
        "path": "cookbooks/policyfile_demo"
      }
    },
```

@opscode/client-engineers 
