### PR TITLE
avoid '# ' <-- extra space after comment character in license headers

### DIFF
--- a/lib/chef-dk/generator.rb
+++ b/lib/chef-dk/generator.rb
@@ -151,7 +151,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 EOH
         end
         if comment
-          result.gsub(/^/m, "#{comment} ")
+          result.gsub(/^(.+)$/, "#{comment} \\1").gsub(/^$/, "#{comment}")
         else
           result
         end


### PR DESCRIPTION
The current logic for inserting comments before the license description in file headers will produce "# " (notice the extra space after the comment) for empty lines in the license description.

This means that newly minted cookbook fails rubocop right out of the gate (there are actually a few other failures as well, but this one seems like low hanging fruit).

Rubocop throws the following complaint:
```
recipes/default.rb:12:2: C: Trailing whitespace detected.
# 
 ^
```

This change yields the same output (visually), but avoids the trailing space after the comment character.