### PR TITLE
Don't treat git local remotes as "remote"

### DIFF
--- a/lib/chef-dk/cookbook_profiler/git.rb
+++ b/lib/chef-dk/cookbook_profiler/git.rb
@@ -74,7 +74,7 @@ module ChefDK
       end
 
       def have_remote?
-        !remote_name.empty?
+        !remote_name.empty? && remote_name != '.'
       end
 
       def current_branch

--- a/spec/unit/cookbook_profiler/git_spec.rb
+++ b/spec/unit/cookbook_profiler/git_spec.rb
@@ -59,6 +59,18 @@ describe ChefDK::CookbookProfiler::Git do
 
   end
 
+  context "when the remote is a local branch" do
+
+    before do
+      allow(git_profiler).to receive(:remote_name).and_return(".")
+    end
+
+    it "reports that the repo doesn't have a remote" do
+      expect(git_profiler.have_remote?).to be(false)
+    end
+
+  end
+
   context "with a remote configured" do
 
     include_context "setup git cookbook remote"


### PR DESCRIPTION
When creating a branch with `git checkout -t -b BRANCH`, the upstream
"remote" is the starting branch on disk, so a command like
`config --get branch.$current_branch.remote` returns "."
In this case the "remote" isn't really "remote," so we shouldn't try to
query an upstream system to determine whether code has been sync'd to
the remote.

This has been trolling me because it makes tests fail locally when working on a branch that tracks local master (e.g., `git checkout -t -b my-feature`).

@opscode/client-engineers 
