### PR TITLE
Add verification of linked scripts on *nix

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -143,6 +143,47 @@ require 'spec_helper'
         end
       end
 
+      add_component "package installation" do |c|
+
+        c.base_dir = "chef-dk"
+
+        c.smoke_test do
+
+          if File.directory?("/usr/bin")
+            sh!("/usr/bin/berks -v")
+
+            sh!("/usr/bin/chef -v")
+
+            sh!("/usr/bin/chef-client -v")
+            sh!("/usr/bin/chef-solo -v")
+
+            # In `knife`, `knife -v` follows a different code path that skips
+            # command/plugin loading; `knife -h` loads commands and plugins, but
+            # it exits with code 1, which is the same as a load error. Running
+            # `knife exec` forces command loading to happen and this command
+            # exits 0, which runs most of the code.
+            #
+            # See also: https://github.com/opscode/chef-dk/issues/227
+            sh!("/usr/bin/knife exec -E true")
+
+            tmpdir do |dir|
+              # Kitchen tries to create a .kitchen dir even when just running
+              # `kitchen -v`:
+              sh!("/usr/bin/kitchen -v", cwd: dir)
+            end
+
+            sh!("/usr/bin/ohai -v")
+
+            sh!("/usr/bin/foodcritic -V")
+          end
+
+          # Test blocks are expected to return a Mixlib::ShellOut compatible
+          # object:
+          ComponentTest::NullTestResult.new
+        end
+
+      end
+
       attr_reader :verification_threads
       attr_reader :verification_results
       attr_reader :verification_status

--- a/lib/chef-dk/component_test.rb
+++ b/lib/chef-dk/component_test.rb
@@ -88,6 +88,17 @@ module ChefDK
       system_command(command, combined_opts)
     end
 
+    # Just like #sh but raises an error if the the command returns an
+    # unexpected exit code.
+    #
+    # Most verification steps just run a single command, then
+    # ChefDK::Command::Verify#invoke_tests handles the results by inspecting
+    # the return value of the test block. For tests that run a lot of commands,
+    # this is inconvenient so you can use #sh! instead.
+    def sh!(*args)
+      sh(*args).tap { |result| result.error! }
+    end
+
     def run_in_tmpdir(command, options={})
       tmpdir do |dir|
         options[:cwd] = dir

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -34,13 +34,24 @@ describe ChefDK::Command::Verify do
 
   let(:components) { {} }
 
+  let(:default_components) do
+    [
+      "berkshelf",
+      "test-kitchen",
+      "chef-client",
+      "chef-dk",
+      "chefspec",
+      "package installation"
+    ]
+  end
+
   def run_command(expected_exit_code)
     expect(command_instance.run(command_options)).to eq(expected_exit_code)
   end
 
   it "defines berks, tk, chef and chef-dk components by default" do
     expect(command_instance.components).not_to be_empty
-    expect(command_instance.components.map(&:name)).to match_array(%w{berkshelf test-kitchen chef-client chef-dk chefspec})
+    expect(command_instance.components.map(&:name)).to match_array(default_components)
   end
 
   it "has a usage banner" do


### PR DESCRIPTION
Runs a bunch of `/usr/bin/foo -v` type commands. This tests a few things:
- The post install script created the symlinks
- The symlink targets (executables in `/opb/chefdk/bin` exist)
- The executables work correctly when symlinked from outside `/opt/chefdk/bin`
- `knife` loads subcommands without blowing up.

@opscode/client-engineers 
