### PR TITLE
Consistent quoting for exports

### DIFF
--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -67,9 +67,9 @@ HELP
 
         env = omnibus_env.dup
         path = env.delete("PATH")
-        msg("export PATH=#{path}")
+        msg("export PATH=\"#{path}\"")
         env.each do |var_name, value|
-          msg("export #{var_name}=#{value}")
+          msg("export #{var_name}=\"#{value}\"")
         end
         0
       end

--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -96,7 +96,7 @@ module ChefDK
           user_bin_dir = File.expand_path(File.join(Gem.user_dir, 'bin'))
           {
             'PATH' => [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH'] ].join(File::PATH_SEPARATOR),
-            'GEM_ROOT' => Gem.default_dir.inspect,
+            'GEM_ROOT' => Gem.default_dir,
             'GEM_HOME' => Gem.user_dir,
             'GEM_PATH' => Gem.path.join(':'),
           }

--- a/spec/unit/command/exec_spec.rb
+++ b/spec/unit/command/exec_spec.rb
@@ -76,7 +76,7 @@ describe ChefDK::Command::Exec do
 
       let(:expected_PATH) { [omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH']].join(File::PATH_SEPARATOR) }
 
-      let(:expected_GEM_ROOT) { Gem.default_dir.inspect }
+      let(:expected_GEM_ROOT) { Gem.default_dir }
 
       let(:expected_GEM_HOME) { Gem.user_dir }
 
@@ -110,7 +110,7 @@ describe ChefDK::Command::Exec do
 
       let(:expected_PATH) { [omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH']].join(File::PATH_SEPARATOR) }
 
-      let(:expected_GEM_ROOT) { Gem.default_dir.inspect }
+      let(:expected_GEM_ROOT) { Gem.default_dir }
 
       let(:expected_GEM_HOME) { Gem.user_dir }
 

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -48,10 +48,10 @@ describe ChefDK::Command::ShellInit do
 
   let(:expected_environment_commands) do
     <<-EOH
-export PATH=#{expected_path}
+export PATH="#{expected_path}"
 export GEM_ROOT="#{expected_gem_root}"
-export GEM_HOME=#{expected_gem_home}
-export GEM_PATH=#{expected_gem_path}
+export GEM_HOME="#{expected_gem_home}"
+export GEM_PATH="#{expected_gem_path}"
 EOH
   end
 


### PR DESCRIPTION
It's not clear why GEM_ROOT was being quoted for posix exports, but it was breaking https://github.com/opscode/chef-dk/pull/253
Also, I think ' would be better since none of these should be expanded.
@lamont-granquist could you comment on this
cc @opscode/client-engineers 
