### PR TITLE
Use File::PATH_SEPARATOR for GEM_PATH

### DIFF
--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -98,7 +98,7 @@ module ChefDK
             'PATH' => [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH'] ].join(File::PATH_SEPARATOR),
             'GEM_ROOT' => Gem.default_dir,
             'GEM_HOME' => Gem.user_dir,
-            'GEM_PATH' => Gem.path.join(':'),
+            'GEM_PATH' => Gem.path.join(File::PATH_SEPARATOR),
           }
         end
     end

--- a/spec/unit/command/exec_spec.rb
+++ b/spec/unit/command/exec_spec.rb
@@ -80,7 +80,7 @@ describe ChefDK::Command::Exec do
 
       let(:expected_GEM_HOME) { Gem.user_dir }
 
-      let(:expected_GEM_PATH) { Gem.path.join(':') }
+      let(:expected_GEM_PATH) { Gem.path.join(File::PATH_SEPARATOR) }
 
       before do
         allow(command_instance).to receive(:omnibus_embedded_bin_dir).and_return(omnibus_embedded_bin_dir)
@@ -114,7 +114,7 @@ describe ChefDK::Command::Exec do
 
       let(:expected_GEM_HOME) { Gem.user_dir }
 
-      let(:expected_GEM_PATH) { Gem.path.join(':') }
+      let(:expected_GEM_PATH) { Gem.path.join(File::PATH_SEPARATOR) }
 
 
       before do

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -44,7 +44,7 @@ describe ChefDK::Command::ShellInit do
 
   let(:expected_gem_home) { Gem.user_dir }
 
-  let(:expected_gem_path) { Gem.path.join(':') }
+  let(:expected_gem_path) { Gem.path.join(File::PATH_SEPARATOR) }
 
   let(:expected_environment_commands) do
     <<-EOH


### PR DESCRIPTION
Seems that GEM_PATH uses the path separator of the os
cc @opscode/client-engineers 
