### PR TITLE
Removing things from verify that don't work

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -166,7 +166,6 @@ end
 
       add_component "knife-spork" do |c|
         c.gem_base_dir = "knife-spork"
-        c.unit_test { sh('rake') }
         c.smoke_test { sh('knife spork info')}
       end
 


### PR DESCRIPTION
Fauxhai bin does not run on Windows because it does not load the gem dependencies
Knife-Spork unit tests don't seem to run without chef 11. It looks like it is loading chef 12, and failing with:

```
     Failure/Error: knife.instance_variable_set(:@cookbooks, knife.load_cookbooks(argv))
     Chef::Exceptions::MetadataNotValid:
       Cookbook loaded at path(s) [/tmp/knife-spork20141205-6179-55hr04/cookbooks/example] has invalid metadata: The `name' attribute is required in cookbook metadata
     # ./lib/knife-spork/runner.rb:171:in `load_from_chef'
     # ./lib/knife-spork/runner.rb:164:in `load_cookbook'
     # ./lib/knife-spork/runner.rb:203:in `block in load_cookbooks'
     # ./lib/knife-spork/runner.rb:203:in `collect'
     # ./lib/knife-spork/runner.rb:203:in `load_cookbooks'
     # ./spec/unit/spork_upload_spec.rb:39:in `block (3 levels) in <module:KnifeSpork>'
```

https://github.com/jonlives/knife-spork/issues/161
