### PR TITLE
add chef_repo cookbook source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   * chef-provisioning-aws - 0.5.0
   * test-kitchen - 1.4.0
   * kitchen-vagrant - 0.17.0
+* [#263](https://github.com/chef/chef-dk/pull/263) Add a `chef_repo` cookbook
+  source which can be used in place of supermarket/berks-like depsolving to
+  support a single monolithic git repo with its 'universe' of cookbooks entirely
+  contained within it.  Cookbook dependencies will be determined only from the
+  filesystem.  Cannot be combined with supermarket/berks-apis as a source.
 
 # Last Release: 0.4.0
 * Add support for uploading Policyfiles via native API rather than as a

--- a/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
@@ -1,0 +1,81 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/exceptions'
+require 'chef/cookbook_loader'
+require 'chef/cookbook/file_system_file_vendor'
+require 'chef-dk/ui'
+
+module ChefDK
+  module Policyfile
+    class ChefRepoCookbookSource
+
+      attr_reader :path
+      attr_accessor :ui
+
+      def initialize(path)
+        @path = path
+        @ui = UI.new
+      end
+
+      def ==(other)
+        other.kind_of?(self.class) && other.path == path
+      end
+
+      def universe_graph
+        slurp_metadata! if @universe_graph.nil?
+        @universe_graph
+      end
+
+      def source_options_for(cookbook_name, cookbook_version)
+        { path: cookbook_version_paths[cookbook_name][cookbook_version], version: cookbook_version }
+      end
+
+      private
+
+      def cookbook_version_paths
+        slurp_metadata! if @cookbook_version_paths.nil?
+        @cookbook_version_paths
+      end
+
+      def slurp_metadata!
+        @universe_graph = {}
+        @cookbook_version_paths = {}
+        cookbook_repo.load_cookbooks
+        cookbook_repo.each do |cookbook_name, cookbook_version|
+          metadata = cookbook_version.metadata
+          if metadata.name.nil?
+            ui.err("WARN: #{cookbook_name} cookbook missing metadata or no name field, skipping")
+            next
+          end
+          @universe_graph[metadata.name] ||= {}
+          @universe_graph[metadata.name][metadata.version] = metadata.dependencies.to_a
+          @cookbook_version_paths[metadata.name] ||= {}
+          @cookbook_version_paths[metadata.name][metadata.version] = cookbook_version.root_dir
+        end
+      end
+
+      def cookbook_repo
+        @cookbook_repo ||= begin
+          Chef::Cookbook::FileVendor.fetch_from_disk(path)
+          Chef::CookbookLoader.new(path)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
@@ -24,11 +24,16 @@ module ChefDK
   module Policyfile
     class ChefRepoCookbookSource
 
+      # path to a chef-repo or the cookbook path under it
       attr_reader :path
+      # UI object for output
       attr_accessor :ui
 
+      # Constructor
+      #
+      # @param path [String] path to a chef-repo or the cookbook path under it
       def initialize(path)
-        @path = path
+        self.path = path
         @ui = UI.new
       end
 
@@ -36,22 +41,49 @@ module ChefDK
         other.kind_of?(self.class) && other.path == path
       end
 
+      # Calls the slurp_metadata! helper once to calculate the @universe_graph
+      # and @cookbook_version_paths metadata.  Returns the @universe_graph.
+      #
+      # @return [Hash] universe_graph
       def universe_graph
         slurp_metadata! if @universe_graph.nil?
         @universe_graph
       end
 
+      # Returns the metadata (path and version) for an individual cookbook
+      #
+      # @return [Hash] metadata for a single cookbook version
       def source_options_for(cookbook_name, cookbook_version)
         { path: cookbook_version_paths[cookbook_name][cookbook_version], version: cookbook_version }
       end
 
       private
 
+      # Setter for setting the path.  It may either be a full chef-repo with
+      # a cookbooks directory in it, or only a path to the cookbooks directory,
+      # and it autodetects which it is passed.
+      #
+      # @param path [String] path to a chef-repo or the cookbook path under it
+      def path=(path)
+        cookbooks_path = "#{path}/cookbooks"
+        if Dir.exist?(cookbooks_path)
+          @path = cookbooks_path
+        else
+          @path = path
+        end
+      end
+
+      # Calls the slurp_metadata! helper once to calculate the @universe_graph
+      # and @cookbook_version_paths metadata.  Returns the @cookbook_version_paths.
+      #
+      # @return [Hash] cookbook_version_paths
       def cookbook_version_paths
         slurp_metadata! if @cookbook_version_paths.nil?
         @cookbook_version_paths
       end
 
+      # Helper to compute the @universe_graph and @cookbook_version_paths once
+      # from the Chef::CookbookLoader on-disk cookbook repo.
       def slurp_metadata!
         @universe_graph = {}
         @cookbook_version_paths = {}
@@ -69,6 +101,7 @@ module ChefDK
         end
       end
 
+      # @return [Chef::CookbookLoader] cookbook loader using on disk FileVendor
       def cookbook_repo
         @cookbook_repo ||= begin
           Chef::Cookbook::FileVendor.fetch_from_disk(path)

--- a/lib/chef-dk/policyfile/cookbook_sources.rb
+++ b/lib/chef-dk/policyfile/cookbook_sources.rb
@@ -18,3 +18,4 @@
 require 'chef-dk/policyfile/null_cookbook_source'
 require 'chef-dk/policyfile/community_cookbook_source'
 require 'chef-dk/policyfile/chef_server_cookbook_source'
+require 'chef-dk/policyfile/chef_repo_cookbook_source'

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -68,13 +68,15 @@ module ChefDK
         @named_run_lists[name] = run_list_items.flatten
       end
 
-      def default_source(source_type = nil, source_uri = nil)
+      def default_source(source_type = nil, source_argument = nil)
         return @default_source if source_type.nil?
         case source_type
         when :community
-          set_default_community_source(source_uri)
+          set_default_community_source(source_argument)
         when :chef_server
-          set_default_chef_server_source(source_uri)
+          set_default_chef_server_source(source_argument)
+        when :chef_repo
+          set_default_chef_repo_source(source_argument)
         else
           @errors << "Invalid default_source type '#{source_type.inspect}'"
         end
@@ -146,6 +148,14 @@ module ChefDK
           @errors << "You must specify the server's URI when using a default_source :chef_server"
         else
           @default_source = ChefServerCookbookSource.new(source_uri)
+        end
+      end
+
+      def set_default_chef_repo_source(path)
+        if path.nil?
+          @errors << "You must specify the path to the chef-repo when using a default_source :chef_repo"
+        else
+          @default_source = ChefRepoCookbookSource.new(path)
         end
       end
 

--- a/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/Berksfile
+++ b/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/README.md
+++ b/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/README.md
@@ -1,0 +1,4 @@
+# local-cookbook
+
+TODO: Enter the cookbook description here.
+

--- a/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/chefignore
+++ b/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/chefignore
@@ -1,0 +1,96 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+CHANGELOG*
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/metadata.rb
+++ b/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/metadata.rb
@@ -1,0 +1,9 @@
+name             'cookbook-with-a-dep'
+maintainer       ''
+maintainer_email ''
+license          ''
+description      'Installs/Configures local-cookbook'
+long_description 'Installs/Configures local-cookbook'
+version          '9.9.9'
+
+depends 'another-local-cookbook', '~> 0.1'

--- a/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/recipes/default.rb
+++ b/spec/unit/fixtures/local_path_cookbooks/cookbook-with-a-dep/recipes/default.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: local-cookbook
+# Recipe:: default
+#
+# Copyright (C) 2014 
+#
+# 
+#

--- a/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
@@ -1,0 +1,55 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile/chef_repo_cookbook_source'
+
+describe ChefDK::Policyfile::ChefRepoCookbookSource do
+
+  let(:repo_path) {
+    File.expand_path("spec/unit/fixtures/local_path_cookbooks", project_root)
+  }
+
+  let(:cookbook_source) { ChefDK::Policyfile::ChefRepoCookbookSource.new(repo_path) }
+
+  let(:local_repo_universe) {
+    {
+      "another-local-cookbook"=>{
+        "0.1.0"=>[],
+      },
+      "local-cookbook"=>{
+        "2.3.4"=>[],
+      },
+      "cookbook-with-a-dep"=>{
+        "9.9.9"=>[["another-local-cookbook", "~> 0.1"]],
+      },
+      "noignore"=>{
+        "0.1.0"=>[],
+      },
+    }
+  }
+  it "fetches the universe graph" do
+    actual_universe = cookbook_source.universe_graph
+    expect(actual_universe).to eql(local_repo_universe)
+  end
+
+  it "generates location options for a cookbook from the given graph" do
+    expected_opts = { path: File.join(repo_path, "local-cookbook"), version: "2.3.4" }
+    expect(cookbook_source.source_options_for("local-cookbook", "2.3.4")).to eq(expected_opts)
+  end
+
+end

--- a/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
@@ -52,4 +52,15 @@ describe ChefDK::Policyfile::ChefRepoCookbookSource do
     expect(cookbook_source.source_options_for("local-cookbook", "2.3.4")).to eq(expected_opts)
   end
 
+  it "will append a cookbooks directory to the path if it finds it" do
+    expect(Dir).to receive(:exist?).with("#{repo_path}/cookbooks").and_return(true)
+    expect(cookbook_source.path).to eql("#{repo_path}/cookbooks")
+  end
+
+  it "the private setter will append a cookbooks directory to the path if finds it" do
+    expect(cookbook_source.path).to eql(repo_path)
+    expect(Dir).to receive(:exist?).with("#{repo_path}/cookbooks").and_return(true)
+    cookbook_source.send(:path=, repo_path)
+    expect(cookbook_source.path).to eql("#{repo_path}/cookbooks")
+  end
 end

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -243,6 +243,25 @@ E
 
       end
 
+      context "with the default source set to a chef-repo path" do
+
+        let(:chef_repo) { File.expand_path("spec/unit/fixtures/local_path_cookbooks", project_root) }
+
+        let(:policyfile_rb) do
+          <<-EOH
+            run_list "foo", "bar"
+            default_source :chef_repo, "#{chef_repo}"
+          EOH
+        end
+
+        it "has a default source" do
+          expect(policyfile.errors).to eq([])
+          expected = ChefDK::Policyfile::ChefRepoCookbookSource.new(chef_repo)
+          expect(policyfile.default_source).to eq(expected)
+        end
+
+      end
+
     end
 
     describe "assigning cookbooks to specific sources" do


### PR DESCRIPTION
allows pulling the universe to depsolve from a local monolithic chef_repo path.