### PR TITLE
Allow relative paths for generator cookbook config

### DIFF
--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -26,7 +26,7 @@ module ChefDK
     attr_reader :run_list
 
     def initialize(cookbook_path, run_list)
-      @cookbook_path = cookbook_path
+      @cookbook_path = File.expand_path(cookbook_path)
       @run_list = run_list
       @formatter = nil
       @ohai = nil
@@ -39,7 +39,7 @@ module ChefDK
       message = "Could not find cookbook(s) to satisfy run list #{run_list.inspect} in #{cookbook_path}"
       raise CookbookNotFound.new(message, e)
     rescue => e
-      raise ChefConvergeError("Chef failed to converge: #{e}", e)
+      raise ChefConvergeError.new("Chef failed to converge: #{e}", e)
     end
 
     def run_context

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -72,6 +72,32 @@ describe ChefDK::ChefRunner do
     expect(test_state[:loaded_recipes]).to eq([ "recipe_one", "recipe_two" ])
     expect(test_state[:converged_recipes]).to eq([ "recipe_one", "recipe_two" ])
   end
+
+  context "when the embedded chef run fails" do
+
+    let(:embedded_runner) { instance_double("Chef::Runner") }
+
+    before do
+      allow(Chef::Runner).to receive(:new).and_return(embedded_runner)
+      allow(embedded_runner).to receive(:converge).and_raise("oops")
+    end
+
+    it "wraps the exception in a ChefConvergeError" do
+      expect { chef_runner.converge }.to raise_error(ChefDK::ChefConvergeError)
+    end
+
+  end
+
+  context "when cookbook_path is relative" do
+
+    let(:default_cookbook_path) { "~/heres_some_cookbooks" }
+
+    it "expands the path" do
+      expect(chef_runner.cookbook_path).to eq(File.expand_path(default_cookbook_path))
+    end
+
+  end
+
 end
 
 


### PR DESCRIPTION
Fixes an issue where Chef is unable to locate templates when the generator_cookbook is given via a relative path (like `~/something`).
