### PR TITLE
Policyfile Native API support for `chef push`

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0.0"
   gem.add_dependency "ffi-yajl", "~> 1.0"
 
-  gem.add_dependency "chef", "~> 12.0.0.alpha.2"
+  gem.add_dependency "chef", "~> 12.0"
 
   gem.add_dependency "solve", "~> 1.2"
 

--- a/lib/chef-dk/configurable.rb
+++ b/lib/chef-dk/configurable.rb
@@ -20,6 +20,9 @@ require 'chef/workstation_config_loader'
 
 # Define a config context for ChefDK
 class Chef::Config
+
+  default(:policy_document_native_api, false)
+
   config_context(:chefdk) do
 
     default(:generator_cookbook, File.expand_path("../skeletons/code_generator", __FILE__))

--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -34,7 +34,7 @@ module ChefDK
       attr_reader :http_client
       attr_reader :ui
 
-      def initialize(policyfile_lock, policy_group, ui: nil, http_client: nil)
+      def initialize(policyfile_lock, policy_group, ui: nil, http_client: nil, policy_document_native_api: false)
         @policyfile_lock = policyfile_lock
         @policy_group = policy_group
         @http_client = http_client
@@ -47,6 +47,10 @@ module ChefDK
         ui.msg("WARN: Uploading policy to policy group #{policy_group} in compatibility mode")
 
         upload_cookbooks
+        upload_policy
+      end
+
+      def upload_policy
         data_bag_create
         data_bag_item_create
       end

--- a/lib/chef-dk/policyfile_services/push.rb
+++ b/lib/chef-dk/policyfile_services/push.rb
@@ -63,7 +63,10 @@ module ChefDK
       end
 
       def uploader
-        ChefDK::Policyfile::Uploader.new(policyfile_lock, policy_group, ui: ui, http_client: http_client)
+        ChefDK::Policyfile::Uploader.new(policyfile_lock, policy_group,
+                                         ui: ui,
+                                         http_client: http_client,
+                                         policy_document_native_api: config.policy_document_native_api)
       end
 
       def run

--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -193,11 +193,17 @@ describe ChefDK::Policyfile::Uploader do
 
     context "when configured for policy document native mode" do
 
-      pending "uploads the policyfile to the native API" do
+      let(:policy_document_native_api) { true }
+
+      it "enables native document mode for policyfiles" do
+        expect(uploader.using_policy_document_native_api?).to be(true)
+      end
+
+      it "uploads the policyfile to the native API" do
         expect(http_client).to receive(:put).
           with('/policies/unit-test/example', policyfile_lock_data)
 
-        uploader.data_bag_item_create
+        uploader.upload_policy
       end
 
     end


### PR DESCRIPTION
* Add support for uploading policies to the "native" API rather than as data bag items
* Usage of the native API is configured with `policy_document_native_api true` in `~/.chef/config.rb` (or `knife.rb`). Defaults to false (for now).
* Also updated Chef dependency to `~> 12.0` now that Chef 12.0 is released.
* Tested against Chef Zero w/ https://github.com/opscode/chef-zero/pull/111 (also needed some local modifications to `chef` to make Chef FS happy).
* Chef patch (which is needed to make the feature work end-to-end) is forthcoming.

@chef/client-engineers @chef/delivery 