### PR TITLE
fix circular argument reference in Ruby 2.2.0

### DIFF
--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -29,7 +29,7 @@ module ChefDK
       attr_reader :ui
       attr_reader :policyfile_lock
 
-      def initialize(ui: ui, policyfile_lock: nil)
+      def initialize(ui: nil, policyfile_lock: nil)
         @ui = ui
         @policyfile_lock = policyfile_lock
 


### PR DESCRIPTION
warning: circular argument reference - ui
ref: https://bugs.ruby-lang.org/issues/10314