### PR TITLE
Change location of serverspec spec_helper.rb file

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -22,7 +22,11 @@ directory "#{app_dir}/test/integration/default/serverspec" do
   recursive true
 end
 
-cookbook_file "#{app_dir}/test/integration/default/serverspec/spec_helper.rb" do
+directory "#{app_dir}/test/integration/helpers/serverspec" do
+  recursive true
+end
+
+cookbook_file "#{app_dir}/test/integration/helpers/serverspec/spec_helper.rb" do
   source 'serverspec_spec_helper.rb'
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -36,7 +36,11 @@ directory "#{cookbook_dir}/test/integration/default/serverspec" do
   recursive true
 end
 
-cookbook_file "#{cookbook_dir}/test/integration/default/serverspec/spec_helper.rb" do
+directory "#{cookbook_dir}/test/integration/helpers/serverspec" do
+  recursive true
+end
+
+cookbook_file "#{cookbook_dir}/test/integration/helpers/serverspec/spec_helper.rb" do
   source 'serverspec_spec_helper.rb'
   action :create_if_missing
 end

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -35,7 +35,7 @@ describe ChefDK::Command::GeneratorCommands::App do
       test/integration/default
       test/integration/default/serverspec
       test/integration/default/serverspec/default_spec.rb
-      test/integration/default/serverspec/spec_helper.rb
+      test/integration/helpers/serverspec/spec_helper.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -35,7 +35,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       test/integration/default
       test/integration/default/serverspec
       test/integration/default/serverspec/default_spec.rb
-      test/integration/default/serverspec/spec_helper.rb
+      test/integration/helpers/serverspec/spec_helper.rb
       Berksfile
       chefignore
       metadata.rb


### PR DESCRIPTION
Previously the serverspec spec_helper.rb file was located in the same directory as the default_spec.rb, and while this worked it also made it impossible to write helper functions that were usable across multiple test suites.

The new location will allow for this behavior.