### PR TITLE
Use stronger language when warning about native API.

### DIFF
--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -49,7 +49,16 @@ module ChefDK
       end
 
       def upload
-        ui.msg("WARN: Uploading policy to policy group #{policy_group} in compatibility mode")
+        ui.msg("Uploading policy to policy group #{policy_group}")
+
+        if using_policy_document_native_api?
+          ui.msg(<<-DRAGONS)
+WARN: Using native policy API preview mode. You may be required to delete and
+re-upload this data when upgrading to the final release version of the feature.
+DRAGONS
+        else
+          ui.msg("WARN: Uploading policy to policy group #{policy_group} in compatibility mode")
+        end
 
         upload_cookbooks
         upload_policy


### PR DESCRIPTION
We don't have a clear upgrade path on the server side for folks using
the preview versions of the new policyfile APIs; it's likely that some
data, such as policyfile lock documents, will be missing fields that we
expect to be required in the final version of the API. Therefore it's
unlikely that we'll provide an upgrade mechanism for these documents,
and instead will probably just delete them if a user has any data
created with a preview version of the API. This warning makes that risk
clear for anyone trying the feature.

@sdelano @chef/client-engineers 