### PR TITLE
Upload to Cookbook Artifacts API when Native Mode is Enabled

### DIFF
--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -106,7 +106,7 @@ DRAGONS
 
       def uploader
         # TODO: uploader runs cookbook validation; we want to do this at a different time.
-        @uploader ||= Chef::CookbookUploader.new(cookbook_versions_to_upload, :rest => http_client)
+        @uploader ||= Chef::CookbookUploader.new(cookbook_versions_to_upload, rest: http_client, policy_mode: using_policy_document_native_api?)
       end
 
       def cookbook_versions_to_upload

--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -126,7 +126,7 @@ DRAGONS
       end
 
       def existing_cookbook_on_remote
-        @existing_cookbook_on_remote ||= http_client.get('cookbooks?num_versions=all')
+        @existing_cookbook_on_remote ||= http_client.get(list_cookbooks_url)
       end
 
       # An Array of Chef::CookbookVersion objects representing the full set that
@@ -145,6 +145,14 @@ DRAGONS
       end
 
       private
+
+      def list_cookbooks_url
+        if using_policy_document_native_api?
+          'cookbook_artifacts?num_versions=all'
+        else
+          'cookbooks?num_versions=all'
+        end
+      end
 
       def upload_cookbooks
         ui.msg("WARN: Uploading cookbooks using semver compat mode")

--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -86,7 +86,7 @@ describe ChefDK::Policyfile::Uploader do
     expect(uploader.http_client).to eq(http_client)
   end
 
-  describe "uploading documents in compat mode" do
+  describe "uploading policies and cookbooks" do
 
     let(:cookbook_locks) { {} }
     let(:cookbook_versions) { {} }
@@ -261,7 +261,7 @@ describe ChefDK::Policyfile::Uploader do
 
         cookbook_uploader = instance_double("Chef::CookbookUploader")
         expect(Chef::CookbookUploader).to receive(:new).
-          with(cookbook_versions.values, :rest => http_client).
+          with(cookbook_versions.values, rest: http_client, policy_mode: false).
           and_return(cookbook_uploader)
         expect(cookbook_uploader).to receive(:upload_cookbooks)
 
@@ -306,7 +306,7 @@ describe ChefDK::Policyfile::Uploader do
 
         cookbook_uploader = instance_double("Chef::CookbookUploader")
         expect(Chef::CookbookUploader).to receive(:new).
-          with(expected_cookbooks_for_upload, :rest => http_client).
+          with(expected_cookbooks_for_upload, rest: http_client, policy_mode: false).
           and_return(cookbook_uploader)
         expect(cookbook_uploader).to receive(:upload_cookbooks)
 


### PR DESCRIPTION
When `policy_document_native_api` is `true`, upload cookbooks to the new `cookbook_artifacts` API. Also reorganizes the tests to better separate common and divergent behavior for compatibility vs. native modes.

@chef/client-engineers @chef/delivery 