### PR TITLE
Fix rubocop violations

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/Berksfile
+++ b/lib/chef-dk/skeletons/code_generator/files/default/Berksfile
@@ -1,3 +1,3 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata

--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -53,6 +53,8 @@ test/*
 features/*
 Guardfile
 Procfile
+.kitchen.yml
+.rubocop.yml
 
 # SCM #
 #######

--- a/lib/chef-dk/skeletons/code_generator/files/default/rubocop.yml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/rubocop.yml
@@ -1,0 +1,46 @@
+AllCops:
+  Exclude:
+    - 'Guardfile'
+    - 'vendor/**'
+
+AlignParameters:
+  Enabled: false
+
+ClassLength:
+  Enabled: false
+
+CyclomaticComplexity:
+  Enabled: false
+
+Documentation:
+  Enabled: false
+
+EmptyLinesAroundBlockBody:
+  Enabled: False
+
+Encoding:
+  Enabled: false
+
+HashSyntax:
+  Enabled: false
+
+LineLength:
+  Enabled: false
+
+MethodLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+PerceivedComplexity:
+  Enabled: false
+
+SingleSpaceBeforeFirstArg:
+  Enabled: true
+  Exclude:
+    - '**/metadata.rb'
+    - 'attributes/**'
+
+Style/FileName:
+  Enabled: false

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -58,6 +58,11 @@ end
 # chefignore
 cookbook_file "#{cookbook_dir}/chefignore"
 
+# .rubocop.yml
+cookbook_file "#{app_dir}/.rubocop.yml" do
+  source 'rubocop.yml'
+end
+
 # Berks
 cookbook_file "#{cookbook_dir}/Berksfile"
 

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -20,6 +20,11 @@ end
 # chefignore
 cookbook_file "#{cookbook_dir}/chefignore"
 
+# .rubocop.yml
+cookbook_file "#{cookbook_dir}/.rubocop.yml" do
+  source 'rubocop.yml'
+end
+
 # Berks
 cookbook_file "#{cookbook_dir}/Berksfile" do
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -5,4 +5,3 @@ license          '<%= license %>'
 description      'Installs/Configures <%= cookbook_name %>'
 long_description 'Installs/Configures <%= cookbook_name %>'
 version          '0.1.0'
-

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -1,3 +1,4 @@
+# This Chefspec test was created by Chef generate
 #
 # Cookbook Name:: <%= cookbook_name %>
 # Spec:: default
@@ -7,6 +8,9 @@
 require 'spec_helper'
 
 describe '<%= cookbook_name %>::<%= recipe_name %>' do
+
+  # Chefspec examples can be found at
+  # https://github.com/sethvargo/chefspec/tree/master/examples
 
   context 'When all attributes are default, on an unspecified platform' do
 

--- a/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
@@ -1,10 +1,12 @@
+# This serverspec test was created by Chef generate
+
 require 'spec_helper'
 
 describe '<%= cookbook_name %>::default' do
 
   # Serverspec examples can be found at
   # http://serverspec.org/resource_types.html
-  
+
   it 'does something' do
     skip 'Replace this with meaningful tests'
   end

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -30,6 +30,7 @@ describe ChefDK::Command::GeneratorCommands::App do
     %w[
       .gitignore
       .kitchen.yml
+      .rubocop.yml
       test
       test/integration
       test/integration/default
@@ -135,7 +136,7 @@ describe ChefDK::Command::GeneratorCommands::App do
         let(:file) { File.join(tempdir, "new_app", "test", "integration", "default", "serverspec", "default_spec.rb") }
 
         include_examples "a generated file", :cookbook_name do
-          let(:line) { "describe 'new_app::default' do" }
+          let(:line) { "# This serverspec test was created by Chef generate" }
         end
       end
 
@@ -159,7 +160,7 @@ describe ChefDK::Command::GeneratorCommands::App do
         let(:file) { File.join(tempdir, "new_app", "cookbooks", "new_app", "spec", "unit", "recipes", "default_spec.rb") }
 
         include_examples "a generated file", :cookbook_name do
-          let(:line) { "describe \'new_app::default\' do" }
+          let(:line) { "This Chefspec test was created by Chef generate" }
         end
       end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -30,6 +30,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
     %w[
       .gitignore
       .kitchen.yml
+      .rubocop.yml
       test
       test/integration
       test/integration/default
@@ -164,7 +165,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       let(:file) { File.join(tempdir, "new_cookbook", "test", "integration", "default", "serverspec", "default_spec.rb") }
 
       include_examples "a generated file", :cookbook_name do
-        let(:line) { "describe 'new_cookbook::default' do" }
+        let(:line) { 'This serverspec test was created by Chef generate' }
       end
     end
 
@@ -188,7 +189,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       let(:file) { File.join(tempdir, "new_cookbook", "spec", "unit", "recipes", "default_spec.rb") }
 
       include_examples "a generated file", :cookbook_name do
-        let(:line) { "describe \'new_cookbook::default\' do" }
+        let(:line) { "This Chefspec test was created by Chef generate" }
       end
     end
 


### PR DESCRIPTION
- Add a .rubocop.yml to the generator cookbook_files
- Updated app generator to write out rubocop.yml
- Updated cookbook generator to write out rubocop.yml
- Added .rubocop.yml to chefignore
- Fixed rubocop violation in Berksfile
- Fixed rubocop violations in metadata.rb
- Fixed rubocop violations in serverspec default_spec.rb
- Fixed rubocop violations in chefspec default_spec.rb