### PR TITLE
Infer author_name, email, license from knife.rb if it exists when generating a new cookbook.

### DIFF
--- a/lib/chef-dk/command/generator_commands.rb
+++ b/lib/chef-dk/command/generator_commands.rb
@@ -37,19 +37,22 @@ module ChefDK
         :short => "-I LICENSE",
         :long => "--license LICENSE",
         :description => "all_rights, apache2, mit, gplv2, gplv3 - defaults to all_rights",
-        :default => "all_rights"
+        :default => "all_rights",
+        :proc => Proc.new { |key| Chef::Config[:knife][:cookbook_license] = key }
 
       option :copyright_holder,
         :short => "-C COPYRIGHT",
         :long => "--copyright COPYRIGHT",
         :description => "Name of the copyright holder - defaults to 'The Authors'",
-        :default => "The Authors"
+        :default => "The Authors",
+        :proc => Proc.new { |key| Chef::Config[:knife][:cookbook_copyright] = key }
 
       option :email,
         :short => "-m EMAIL",
         :long => "--email EMAIL",
         :description => "Email address of the author - defaults to 'you@example.com'",
-        :default => 'you@example.com'
+        :default => 'you@example.com',
+        :proc => Proc.new { |key| Chef::Config[:knife][:cookbook_email] = key }
 
       option :generator_cookbook,
         :short => "-g GENERATOR_COOKBOOK_PATH",


### PR DESCRIPTION
This will read from cookbook_copyright, cookbook_email, and cookbook_license for config is present.
Please note these are not new config values, and are already defined in the docs.