### PR TITLE
Erchef Policyfile integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Chef Development Kit Changelog
 
 # Unreleased:
+* Updated Policyfile uploads to use the URLs specified in Chef RFC 042.
+  Chef Zero has not yet been updated; Chef Zero users should continue to
+  use compatibility mode (`policy_document_native_api false`) for
+  Policyfiles.
 * [Omnibus-Chef #337](https://github.com/chef/omnibus-chef/pull/337):
   Fix a ruby warning for redefined method in rubygems customization that
   interacted poorly with certain Ruby plugins for text editors.
 * Add support for uploading cookbooks to the cookbook artifacts API when
-  `policy_document_native_api true` is set. This new API is currently
-  unreleased and unstable. It is recommended for testing and
-  demonstration use only.
+  `policy_document_native_api true` is set. This new API will be
+  available in the next version of Chef Server if enabled with a server
+  configuration option. Chef Zero support for this new API is
+  incomplete, so this setting cannot be used with Chef Zero until a
+  future update to Chef Zero enables this functionality.
 
 # Last Release: 0.4.0
 * Add support for uploading Policyfiles via native API rather than as a

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0.0"
   gem.add_dependency "ffi-yajl", "~> 1.0"
 
-  gem.add_dependency "chef", "~> 12.0"
+  gem.add_dependency "chef", "~> 12.0", ">= 12.2.0.rc.2"
 
   gem.add_dependency "solve", "~> 1.2"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,11 @@ RSpec.configure do |c|
   c.include ChefDK
   c.include TestHelpers
 
+  # Avoid loading config.rb/knife.rb unintentionally
+  c.before(:each) do
+    allow_any_instance_of(Chef::WorkstationConfigLoader).to receive(:load)
+  end
+
   c.after(:all) { clear_tempdir }
 
   c.filter_run :focus => true

--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -117,6 +117,11 @@ describe ChefDK::Policyfile::Uploader do
         with(name, dotted_decimal_id, cache_path).
         and_return(cookbook_version)
 
+      allow(ChefDK::Policyfile::CookbookLoaderWithChefignore).
+        to receive(:load).
+        with(name, cache_path).
+        and_return(cookbook_version)
+
       cookbook_versions[name] = cookbook_version
       cookbook_locks[name] = lock
 


### PR DESCRIPTION
Updates ChefDK to interop correctly with Erchef's cookbook artifacts endpoint. Also updates expected Policyfile upload URL to match erchef (and the relevant RFC).