### PR TITLE
Empty Cookbook Options Fix

### DIFF
--- a/lib/chef-dk/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-dk/policyfile/cookbook_location_specification.rb
@@ -80,7 +80,7 @@ module ChefDK
 
       def errors
         error_messages = []
-        if installer.nil?
+        if source_options_invalid?
           error_messages << "Cookbook `#{name}' has invalid source options `#{source_options.inspect}'"
         end
         error_messages
@@ -122,6 +122,10 @@ module ChefDK
 
       def source_options_for_lock
         installer.lock_data
+      end
+
+      def source_options_invalid?
+        !source_options.empty? && installer.nil?
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,9 @@ require 'rubygems'
 require 'rspec/mocks'
 require 'test_helpers'
 
+# needed since we stub it for every test
+require 'chef/workstation_config_loader'
+
 RSpec.configure do |c|
   c.include ChefDK
   c.include TestHelpers

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -206,6 +206,22 @@ E
 
         end
 
+        context "with an added cookbook with no options" do
+
+          let(:policyfile_rb) do
+            <<-EOH
+              run_list "foo", "bar"
+              cookbook "baz"
+            EOH
+          end
+
+          it "adds the cookbook to the list of location specs" do
+            expect(policyfile.errors).to eq([])
+            expected_cb_spec = ChefDK::Policyfile::CookbookLocationSpecification.new("baz", ">= 0.0.0", {}, storage_config)
+            expect(policyfile.cookbook_location_specs).to eq("baz" => expected_cb_spec)
+          end
+        end
+
       end
 
       context "with the default source set to a chef server" do


### PR DESCRIPTION
Make just `cookbook "foo"` work correctly in a `Policyfile.rb`.