### PR TITLE
Changes link to point to downloads.chef.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ dpkg -P chefdk
 
 [Berkshelf]: http://berkshelf.com "Berkshelf"
 [Chef]: https://www.chef.io "Chef"
-[ChefDK]: https://www.chef.io/downloads/chef-dk "Chef Development Kit"
+[ChefDK]: https://downloads.chef.io/chef-dk "Chef Development Kit"
 [Chef Documentation]: http://docs.chef.io "Chef Documentation"
 [ChefSpec]: http://chefspec.org "ChefSpec"
 [Foodcritic]: http://foodcritic.io "Foodcritic"


### PR DESCRIPTION
Fixes the main link to point at the downloads page instead of at corpsite.