### PR TITLE
Policyfile attributes

### DIFF
--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -38,6 +38,9 @@ module ChefDK
   class CachedCookbookModified < StandardError
   end
 
+  class InvalidPolicyfileAttribute < StandardError
+  end
+
   class MissingComponentError < RuntimeError
     def initialize(component_name, path_checked)
       super("Component #{component_name} is missing. \nReason: Could not find #{path_checked}.")

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -19,6 +19,8 @@ require 'chef-dk/policyfile/cookbook_sources'
 require 'chef-dk/policyfile/cookbook_location_specification'
 require 'chef-dk/policyfile/storage_config'
 
+require 'chef/node/attribute'
+
 module ChefDK
   module Policyfile
     class DSL
@@ -33,6 +35,7 @@ module ChefDK
       attr_reader :cookbook_location_specs
 
       attr_reader :named_run_lists
+      attr_reader :node_attributes
 
       attr_reader :storage_config
 
@@ -44,6 +47,8 @@ module ChefDK
         @default_source = NullCookbookSource.new
         @cookbook_location_specs = {}
         @storage_config = storage_config
+
+        @node_attributes = Chef::Node::Attribute.new({}, {}, {}, {})
       end
 
       def name(name = nil)
@@ -96,6 +101,14 @@ module ChefDK
           @cookbook_location_specs[name] = spec
           @errors += spec.errors
         end
+      end
+
+      def default
+        @node_attributes.default
+      end
+
+      def override
+        @node_attributes.override
       end
 
       def eval_policyfile(policyfile_string)

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -102,7 +102,7 @@ module ChefDK
     end
 
     def override_attributes
-      dsl.node_attributes.combined_default.to_hash
+      dsl.node_attributes.combined_override.to_hash
     end
 
     def lock

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -97,6 +97,14 @@ module ChefDK
       end
     end
 
+    def default_attributes
+      dsl.node_attributes.combined_default.to_hash
+    end
+
+    def override_attributes
+      dsl.node_attributes.combined_default.to_hash
+    end
+
     def lock
       @policyfile_lock ||= PolicyfileLock.build_from_compiler(self, storage_config)
     end

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require 'digest/sha1'
+require 'digest/sha2'
 
 require 'chef-dk/policyfile/storage_config'
 require 'chef-dk/policyfile/cookbook_locks'
@@ -146,7 +146,7 @@ module ChefDK
     # Returns a fingerprint of the PolicyfileLock by computing the SHA1 hash of
     # #canonical_revision_string
     def revision_id
-      Digest::SHA1.new.hexdigest(canonical_revision_string)
+      Digest::SHA256.new.hexdigest(canonical_revision_string)
     end
 
     # Generates a string representation of the lock data in a specialized

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -313,6 +313,8 @@ module ChefDK
       when Array
         elements = item.map { |i| canonicalize_elements(i) }
         '[' << elements.join(',') << ']'
+      when Integer
+        item.to_s
       when Float
         unless item.finite?
           raise InvalidPolicyfileAttribute, "Floating point numbers cannot be infinite or NaN. You gave #{item.inspect}"
@@ -326,7 +328,7 @@ module ChefDK
         "false"
       else
         raise InvalidPolicyfileAttribute,
-          "Invalid type in attributes. Only Hash, Array, String, Float, true, false, and nil are accepted. You gave #{item.inspect} (#{item.class})"
+          "Invalid type in attributes. Only Hash, Array, String, Integer, Float, true, false, and nil are accepted. You gave #{item.inspect} (#{item.class})"
       end
     end
 

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -83,6 +83,8 @@ module ChefDK
     attr_accessor :name
     attr_accessor :run_list
     attr_accessor :named_run_lists
+    attr_accessor :default_attributes
+    attr_accessor :override_attributes
 
     attr_reader :solution_dependencies
 
@@ -100,6 +102,9 @@ module ChefDK
       @relative_paths_root = Dir.pwd
       @storage_config = storage_config
       @ui = ui || UI.null
+
+      @default_attributes = {}
+      @override_attributes = {}
 
       @solution_dependencies = Policyfile::SolutionDependencies.new
       @install_report = InstallReport.new(ui: @ui, policyfile_lock: self)
@@ -132,6 +137,8 @@ module ChefDK
         lock["run_list"] = run_list
         lock["named_run_lists"] = named_run_lists unless named_run_lists.empty?
         lock["cookbook_locks"] = cookbook_locks_for_lockfile
+        lock["default_attributes"] = default_attributes
+        lock["override_attributes"] = override_attributes
         lock["solution_dependencies"] = solution_dependencies.to_lock
       end
     end
@@ -231,6 +238,9 @@ module ChefDK
           end
         end
       end
+
+      @default_attributes = compiler.default_attributes
+      @override_attributes = compiler.override_attributes
 
       @solution_dependencies = compiler.solution_dependencies
 

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -323,6 +323,63 @@ EOH
 
     end
 
+    describe "defining attributes" do
+
+      let(:policyfile_rb) do
+        <<-EOH
+          name "policy-with-attrs"
+          run_list "foo"
+
+          # basic attribute setting:
+          default["foo"] = "bar"
+
+          # auto-vivify
+          default["abc"]["def"]["ghi"] = "xyz"
+
+          # literal data structures
+          default["baz"] = {
+            "more_nested_stuff" => "yup"
+          }
+
+          # Array literals work and we merge rather than overwrite:
+          default["baz"]["an_array"] = ["a", "b", "c"]
+
+          # all the same stuff works with overrides:
+
+          override["foo"] = "bar"
+
+          override["abc"]["def"]["ghi"] = "xyz"
+
+          override["baz"] = {
+            "more_nested_stuff" => "yup"
+          }
+
+          override["baz"]["an_array"] = ["a", "b", "c"]
+        EOH
+      end
+
+      let(:expected_merged_attrs) do
+        {
+          "foo" => "bar",
+          "abc" => { "def" => { "ghi" => "xyz" } },
+          "baz" => {
+            "more_nested_stuff" => "yup",
+            "an_array" => ["a", "b", "c"]
+          }
+        }
+      end
+
+      it "defines default attributes" do
+        expect(policyfile.errors).to eq([])
+        expect(policyfile.default_attributes).to eq(expected_merged_attrs)
+      end
+
+      it "defines override attributes" do
+        expect(policyfile.errors).to eq([])
+        expect(policyfile.override_attributes).to eq(expected_merged_attrs)
+      end
+    end
+
   end
 
 end

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -350,15 +350,15 @@ EOH
 
           override["abc"]["def"]["ghi"] = "xyz"
 
-          override["baz"] = {
+          override["baz_override"] = {
             "more_nested_stuff" => "yup"
           }
 
-          override["baz"]["an_array"] = ["a", "b", "c"]
+          override["baz_override"]["an_array"] = ["a", "b", "c"]
         EOH
       end
 
-      let(:expected_merged_attrs) do
+      let(:expected_combined_default_attrs) do
         {
           "foo" => "bar",
           "abc" => { "def" => { "ghi" => "xyz" } },
@@ -369,14 +369,25 @@ EOH
         }
       end
 
+      let(:expected_combined_override_attrs) do
+        {
+          "foo" => "bar",
+          "abc" => { "def" => { "ghi" => "xyz" } },
+          "baz_override" => {
+            "more_nested_stuff" => "yup",
+            "an_array" => ["a", "b", "c"]
+          }
+        }
+      end
+
       it "defines default attributes" do
         expect(policyfile.errors).to eq([])
-        expect(policyfile.default_attributes).to eq(expected_merged_attrs)
+        expect(policyfile.default_attributes).to eq(expected_combined_default_attrs)
       end
 
       it "defines override attributes" do
         expect(policyfile.errors).to eq([])
-        expect(policyfile.override_attributes).to eq(expected_merged_attrs)
+        expect(policyfile.override_attributes).to eq(expected_combined_override_attrs)
       end
     end
 

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 #
 # Copyright:: Copyright (c) 2014 Chef Software Inc.
 # License:: Apache License, Version 2.0
@@ -272,7 +273,7 @@ REVISION_STRING
 
         p.default_attributes = {
           "foo" => "bar",
-          "aaa" => "aaa",
+          "aaa".encode('utf-16') => "aaa".encode('utf-16'),
           "ddd" => true,
           "ccc" => false,
           "bbb" => nil,
@@ -320,7 +321,7 @@ REVISION_STRING
         },
         "default_attributes" => {
           "foo" => "bar",
-          "aaa" => "aaa",
+          "aaa".encode('utf-16') => "aaa".encode('utf-16'),
           "ddd" => true,
           "ccc" => false,
           "bbb" => nil,

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -279,6 +279,7 @@ REVISION_STRING
           "bbb" => nil,
           "e"   => 1.2,
           "f"   => 5,
+          "g"   => 1_000_000_000_000_000.0,
           "nested" => { "a" => "b" }
         }
         p.override_attributes = { "foo2" => "baz" }
@@ -291,7 +292,7 @@ REVISION_STRING
 name:minimal_policyfile
 run-list-item:recipe[foo]
 cookbook:foo;id:467dc855408ce8b74f991c5dc2fd72a6aa369b60
-default_attributes:{"aaa":"aaa","bbb":null,"ccc":false,"ddd":true,"e":1.2,"f":5,"foo":"bar","nested":{"a":"b"}}
+default_attributes:{"aaa":"aaa","bbb":null,"ccc":false,"ddd":true,"e":1.2,"f":5,"foo":"bar","g":1e+15,"nested":{"a":"b"}}
 override_attributes:{"foo2":"baz"}
 REVISION_STRING
     end
@@ -327,6 +328,7 @@ REVISION_STRING
           "bbb" => nil,
           "e"   => 1.2,
           "f"   => 5,
+          "g"   => 1_000_000_000_000_000.0,
           "nested" => { "a" => "b" }
         },
         "override_attributes" => { "foo2" => "baz" },

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -211,7 +211,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -294,7 +294,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -381,7 +381,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -481,7 +481,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -606,7 +606,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -733,7 +733,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -803,7 +803,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do
@@ -947,7 +947,7 @@ REVISION_STRING
     end
 
     let(:expected_revision_id) do
-      Digest::SHA1.new.hexdigest(expected_canonical_revision_string)
+      Digest::SHA256.new.hexdigest(expected_canonical_revision_string)
     end
 
     let(:compiled_policyfile) do

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -276,6 +276,8 @@ REVISION_STRING
           "ddd" => true,
           "ccc" => false,
           "bbb" => nil,
+          "e"   => 1.2,
+          "f"   => 5,
           "nested" => { "a" => "b" }
         }
         p.override_attributes = { "foo2" => "baz" }
@@ -288,7 +290,7 @@ REVISION_STRING
 name:minimal_policyfile
 run-list-item:recipe[foo]
 cookbook:foo;id:467dc855408ce8b74f991c5dc2fd72a6aa369b60
-default_attributes:{"aaa":"aaa","bbb":null,"ccc":false,"ddd":true,"foo":"bar","nested":{"a":"b"}}
+default_attributes:{"aaa":"aaa","bbb":null,"ccc":false,"ddd":true,"e":1.2,"f":5,"foo":"bar","nested":{"a":"b"}}
 override_attributes:{"foo2":"baz"}
 REVISION_STRING
     end
@@ -322,6 +324,8 @@ REVISION_STRING
           "ddd" => true,
           "ccc" => false,
           "bbb" => nil,
+          "e"   => 1.2,
+          "f"   => 5,
           "nested" => { "a" => "b" }
         },
         "override_attributes" => { "foo2" => "baz" },


### PR DESCRIPTION
Implements ChefDK side of adding attributes to policyfiles. For now they will be ignored in Chef Client. Chef Server should preserve them unmodified but not do any checking of the content, though I have not verified this yet. Attributes are included in the revision id computation, using an incomplete implementation of [Canonical JSON](http://wiki.laptop.org/go/Canonical_JSON). Most common user inputs should work fine with the implementation that is there now, though we'll have to make it more solid when we (very eventually) enable server-side verification of the revision id.

Also switched the revision id logic to use SHA2-256, since eventually we want the revision id to ensure data integrity.