### PR TITLE
Attribute only update

### DIFF
--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -41,12 +41,7 @@ module ChefDK
       end
 
       def run
-        unless File.exist?(policyfile_expanded_path)
-          raise PolicyfileNotFound, "Policyfile not found at path #{policyfile_expanded_path}"
-        end
-        unless File.exist?(policyfile_lock_expanded_path)
-          raise LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
-        end
+        assert_policy_and_lock_present!
 
         if policyfile_compiler.default_attributes != policyfile_lock.default_attributes
           policyfile_lock.default_attributes = policyfile_compiler.default_attributes
@@ -66,7 +61,8 @@ module ChefDK
         else
           ui.msg("Attributes already up to date")
         end
-
+      rescue => error
+        raise PolicyfileUpdateError.new("Failed to update Policyfile lock", error)
       end
 
       def updated_lock?
@@ -91,6 +87,17 @@ module ChefDK
           PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(lock_data)
         end
       end
+
+
+      def assert_policy_and_lock_present!
+        unless File.exist?(policyfile_expanded_path)
+          raise PolicyfileNotFound, "Policyfile not found at path #{policyfile_expanded_path}"
+        end
+        unless File.exist?(policyfile_lock_expanded_path)
+          raise LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
+        end
+      end
+
     end
   end
 end

--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,50 +15,62 @@
 # limitations under the License.
 #
 
-require 'ffi_yajl'
-
 require 'chef-dk/helpers'
+require 'chef-dk/policyfile/storage_config'
 require 'chef-dk/service_exceptions'
 require 'chef-dk/policyfile_compiler'
-require 'chef-dk/policyfile/storage_config'
-require 'chef-dk/policyfile_lock'
 
 module ChefDK
   module PolicyfileServices
 
-    class Install
+    class UpdateAttributes
 
       include Policyfile::StorageConfigDelegation
       include ChefDK::Helpers
 
       attr_reader :ui
       attr_reader :storage_config
-      attr_reader :overwrite
 
-      def initialize(policyfile: nil, ui: nil, root_dir: nil, overwrite: false)
+      def initialize(policyfile: nil, ui: nil, root_dir: nil)
         @ui = ui
-        @overwrite = overwrite
 
         policyfile_rel_path = policyfile || "Policyfile.rb"
         policyfile_full_path = File.expand_path(policyfile_rel_path, root_dir)
         @storage_config = Policyfile::StorageConfig.new.use_policyfile(policyfile_full_path)
-
-        @policyfile_content = nil
-        @policyfile_compiler = nil
+        @updated = false
       end
 
       def run
         unless File.exist?(policyfile_expanded_path)
-          # TODO: suggest next step. Add a generator/init command? Specify path to Policyfile.rb?
-          # See card CC-232
           raise PolicyfileNotFound, "Policyfile not found at path #{policyfile_expanded_path}"
         end
-
-        if installing_from_lock?
-          install_from_lock
-        else
-          generate_lock_and_install
+        unless File.exist?(policyfile_lock_expanded_path)
+          raise LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
         end
+
+        if policyfile_compiler.default_attributes != policyfile_lock.default_attributes
+          policyfile_lock.default_attributes = policyfile_compiler.default_attributes
+          @updated = true
+        end
+
+        if policyfile_compiler.override_attributes != policyfile_lock.override_attributes
+          policyfile_lock.override_attributes = policyfile_compiler.override_attributes
+          @updated = true
+        end
+
+        if updated_lock?
+          with_file(policyfile_lock_expanded_path) do |f|
+            f.print(FFI_Yajl::Encoder.encode(policyfile_lock.to_lock, pretty: true ))
+          end
+          ui.msg("Updated attributes in #{policyfile_lock_expanded_path}")
+        else
+          ui.msg("Attributes already up to date")
+        end
+
+      end
+
+      def updated_lock?
+        @updated
       end
 
       def policyfile_content
@@ -69,57 +81,17 @@ module ChefDK
         @policyfile_compiler ||= ChefDK::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui: ui)
       end
 
-      def expanded_run_list
-        policyfile_compiler.expanded_run_list.to_s
-      end
-
       def policyfile_lock_content
-        @policyfile_lock_content ||= IO.read(policyfile_lock_expanded_path) if File.exist?(policyfile_lock_expanded_path)
+        @policyfile_lock_content ||= IO.read(policyfile_lock_expanded_path)
       end
 
       def policyfile_lock
-        return nil if policyfile_lock_content.nil?
         @policyfile_lock ||= begin
           lock_data = FFI_Yajl::Parser.new.parse(policyfile_lock_content)
           PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(lock_data)
         end
       end
-
-      def generate_lock_and_install
-        policyfile_compiler.error!
-
-        ui.msg "Building policy #{policyfile_compiler.name}"
-        ui.msg "Expanded run list: " + expanded_run_list + "\n"
-
-        ui.msg "Caching Cookbooks..."
-
-        policyfile_compiler.install
-
-        lock_data = policyfile_compiler.lock.to_lock
-
-        with_file(policyfile_lock_expanded_path) do |f|
-          f.print(FFI_Yajl::Encoder.encode(lock_data, pretty: true ))
-        end
-
-        ui.msg ""
-
-        ui.msg "Lockfile written to #{policyfile_lock_expanded_path}"
-      rescue => error
-        raise PolicyfileInstallError.new("Failed to generate Policyfile.lock", error)
-      end
-
-      def install_from_lock
-        ui.msg "Installing cookbooks from lock"
-
-        policyfile_lock.install_cookbooks
-      rescue => error
-        raise PolicyfileInstallError.new("Failed to install cookbooks from lockfile", error)
-      end
-
-      def installing_from_lock?
-        !@overwrite && File.exist?(policyfile_lock_expanded_path)
-      end
-
     end
   end
 end
+

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -73,6 +73,9 @@ module ChefDK
   class PolicyfileInstallError < PolicyfileNestedException
   end
 
+  class PolicyfileUpdateError < PolicyfileNestedException
+  end
+
   class PolicyfilePushError < PolicyfileNestedException
   end
 

--- a/spec/unit/policyfile_services/update_attributes_spec.rb
+++ b/spec/unit/policyfile_services/update_attributes_spec.rb
@@ -92,7 +92,8 @@ E
   context "when no Policyfile is present or specified" do
 
     it "errors out" do
-      expect { update_attrs_service.run }.to raise_error(ChefDK::PolicyfileNotFound, "Policyfile not found at path #{policyfile_rb_path}")
+      expect { update_attrs_service.assert_policy_and_lock_present! }.to raise_error(ChefDK::PolicyfileNotFound, "Policyfile not found at path #{policyfile_rb_path}")
+      expect { update_attrs_service.run }.to raise_error(ChefDK::PolicyfileUpdateError)
     end
 
   end
@@ -101,7 +102,8 @@ E
 
     it "errors out" do
       with_file(policyfile_rb_path) { |f| f.print(policyfile_content) }
-      expect { update_attrs_service.run }.to raise_error(ChefDK::LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_path}")
+      expect { update_attrs_service.assert_policy_and_lock_present! }.to raise_error(ChefDK::LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_path}")
+      expect { update_attrs_service.run }.to raise_error(ChefDK::PolicyfileUpdateError)
     end
 
   end

--- a/spec/unit/policyfile_services/update_attributes_spec.rb
+++ b/spec/unit/policyfile_services/update_attributes_spec.rb
@@ -1,0 +1,215 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/helpers'
+require 'chef-dk/policyfile_services/update_attributes'
+
+describe ChefDK::PolicyfileServices::UpdateAttributes do
+
+  include ChefDK::Helpers
+
+  let(:working_dir) do
+    path = File.join(tempdir, "policyfile_services_test_working_dir")
+    Dir.mkdir(path)
+    path
+  end
+
+  let(:policyfile_rb_explicit_name) { nil }
+
+  let(:policyfile_rb_name) { policyfile_rb_explicit_name || "Policyfile.rb" }
+
+  let(:policyfile_lock_name) { "Policyfile.lock.json" }
+
+  let(:policyfile_rb_path) { File.join(working_dir, policyfile_rb_name) }
+
+  let(:policyfile_lock_path) { File.join(working_dir, policyfile_lock_name) }
+
+  let(:local_cookbooks_root) do
+    File.join(fixtures_path, "local_path_cookbooks")
+  end
+
+  let(:local_cookbook_path) { File.join(local_cookbooks_root, "local-cookbook") }
+
+  let(:local_cookbook_copy_path) { File.join(working_dir, "cookbooks/local-cookbook") }
+
+  let(:policyfile_content) do
+    <<-E
+name 'install-example'
+
+run_list 'local-cookbook'
+
+cookbook 'local-cookbook', path: 'cookbooks/local-cookbook'
+
+default["default_attr"] = "new_value_default"
+
+override["override_attr"] = "new_value_override"
+E
+  end
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  let(:storage_config) do
+    ChefDK::Policyfile::StorageConfig.new( cache_path: nil, relative_paths_root: working_dir )
+  end
+
+  subject(:update_attrs_service) { described_class.new(policyfile: policyfile_rb_name, ui: ui, root_dir: working_dir) }
+
+  before do
+    FileUtils.mkdir_p(File.dirname(local_cookbook_copy_path))
+    FileUtils.cp_r(local_cookbook_path, local_cookbook_copy_path)
+  end
+
+  context "when first created" do
+
+    it "has the UI object it was created with" do
+      expect(update_attrs_service.ui).to eq(ui)
+    end
+
+    it "creates a storage config from the given policyfile path and root dir" do
+      new_storage_config = instance_double("ChefDK::Policyfile::StorageConfig")
+      expect(ChefDK::Policyfile::StorageConfig).to receive(:new).with(no_args).and_return(new_storage_config)
+      expect(new_storage_config).to receive(:use_policyfile).with(policyfile_rb_path).and_return(new_storage_config)
+      expect(update_attrs_service.storage_config).to eq(new_storage_config)
+    end
+
+  end
+
+  context "when no Policyfile is present or specified" do
+
+    it "errors out" do
+      expect { update_attrs_service.run }.to raise_error(ChefDK::PolicyfileNotFound, "Policyfile not found at path #{policyfile_rb_path}")
+    end
+
+  end
+
+  context "when no lockfile exists" do
+
+    it "errors out" do
+      with_file(policyfile_rb_path) { |f| f.print(policyfile_content) }
+      expect { update_attrs_service.run }.to raise_error(ChefDK::LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_path}")
+    end
+
+  end
+
+  context "when both the policyfile and lockfile exist" do
+
+    let(:lock_data_with_new_values) do
+      {
+        "revision_id" => "522d740beba4c4e5857bd8bccdb2d7ffd0bbd45ac4350f92b26e4e3b8f68d530",
+        "name" => "install-example",
+        "run_list" => ["recipe[local-cookbook::default]"],
+        "cookbook_locks"=> {
+          "local-cookbook"=> {
+            "version"=>"2.3.4",
+            "identifier"=>"fab501cfaf747901bd82c1bc706beae7dc3a350c",
+            "dotted_decimal_identifier"=> "70567763561641081.489844270461035.258281553147148",
+            "source"=>"cookbooks/local-cookbook",
+            "cache_key"=>nil,
+            "scm_info" => nil,
+            "source_options"=> {
+              "path"=>"cookbooks/local-cookbook"
+            }
+          }
+        },
+        "default_attributes" => {"default_attr"=>"new_value_default"},
+        "override_attributes" => {"override_attr"=>"new_value_override"},
+        "solution_dependencies" => {
+          "Policyfile"=>[["local-cookbook", ">= 0.0.0"]],
+          "dependencies"=>{"local-cookbook (2.3.4)"=>[]}
+        }
+      }
+    end
+
+    let(:previous_policyfile_lock_data) { lock_data_with_new_values }
+
+    let(:policyfile_lock_content) do
+      FFI_Yajl::Encoder.encode(previous_policyfile_lock_data, pretty: true )
+    end
+
+    before do
+      with_file(policyfile_rb_path) { |f| f.print(policyfile_content) }
+      with_file(policyfile_lock_path) { |f| f.print(policyfile_lock_content) }
+    end
+
+    def result_policyfile_lock_data
+      expect(File).to exist(policyfile_lock_path)
+      content = IO.read(policyfile_lock_path)
+      FFI_Yajl::Parser.parse(content)
+    end
+
+    context "when the current lock already has the desired attributes" do
+
+      it "makes no changes to the lockfile" do
+        update_attrs_service.run
+        expect(result_policyfile_lock_data).to eq(lock_data_with_new_values)
+      end
+
+      it "emits a message that no changes have been made to the lockfile" do
+        update_attrs_service.run
+
+        message = "Attributes already up to date"
+        expect(ui.output).to include(message)
+      end
+
+    end
+
+    context "when the Policyfile.rb has different attributes than the lockfile" do
+
+      let(:previous_policyfile_lock_data) do
+        {
+          "revision_id" => "522d740beba4c4e5857bd8bccdb2d7ffd0bbd45ac4350f92b26e4e3b8f68d530",
+          "name" => "install-example",
+          "run_list" => ["recipe[local-cookbook::default]"],
+          "cookbook_locks"=> {
+            "local-cookbook"=> {
+              "version"=>"2.3.4",
+              "identifier"=>"fab501cfaf747901bd82c1bc706beae7dc3a350c",
+              "dotted_decimal_identifier"=> "70567763561641081.489844270461035.258281553147148",
+              "source"=>"cookbooks/local-cookbook",
+              "cache_key" => nil,
+              "scm_info" => nil,
+              "source_options"=> {
+                "path"=>"cookbooks/local-cookbook"
+              }
+            }
+          },
+          "default_attributes" => {"default_attr"=>"old_value_default"},
+          "override_attributes" => {"override_attr"=>"old_value_override"},
+          "solution_dependencies" => {
+            "Policyfile"=>[["local-cookbook", ">= 0.0.0"]],
+            "dependencies"=>{"local-cookbook (2.3.4)"=>[]}
+          }
+        }
+      end
+
+      it "updates the lockfile with the new attributes" do
+        update_attrs_service.run
+        expect(result_policyfile_lock_data).to eq(lock_data_with_new_values)
+      end
+
+      it "emits a messsage stating the attributes have been updated" do
+        update_attrs_service.run
+        expect(ui.output).to include("Updated attributes in #{policyfile_lock_path}")
+      end
+
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
Enables users to update only the attributes of their policyfile.lock by running `chef update -a`.