### PR TITLE
CLI front-end for diff

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -33,6 +33,8 @@ ChefDK.commands do |c|
 
   c.builtin "push", :Push, desc: "Push a local policy lock to a policy group on the server"
 
+  c.builtin "diff", :Diff, desc: "Generate an itemized diff of two Policyfile lock documents"
+
   c.builtin "export", :Export, desc: "Export a policy lock as a Chef Zero code repo"
 
   c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications"

--- a/lib/chef-dk/command/diff.rb
+++ b/lib/chef-dk/command/diff.rb
@@ -1,0 +1,280 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/ui'
+require 'chef-dk/policyfile/differ'
+require 'chef-dk/policyfile/comparison_base'
+require 'chef-dk/policyfile/storage_config'
+require 'chef-dk/configurable'
+require 'chef-dk/authenticated_http'
+
+module ChefDK
+  module Command
+
+    class Diff < Base
+
+      include Configurable
+      include Policyfile::StorageConfigDelegation
+
+      banner(<<-BANNER)
+Usage: chef diff [POLICYFILE] [--head | --git GIT_REF | POLICY_GROUP | POLICY_GROUP...POLICY_GROUP ]
+
+`chef diff` displays an itemized diff comparing two revisions of a
+Policyfile lock.
+
+When the `--git` option is given, `chef diff` either compares a given
+git reference against the current lockfile revision on disk or compares
+between two git references. Examples:
+
+* `chef diff --git HEAD`: compares the current lock with the latest
+  commit on the current branch.
+* `chef diff --git master` compares the current lock with the latest
+  commit to master.
+* `chef diff --git v1.0.0`: compares the current lock with the revision
+  as of the `v1.0.0` tag.
+* `chef diff --git master...dev-branch` compares the Policyfile lock on
+  master with the revision on the `dev-branch` branch.
+* `chef diff --git v1.0.0...master` compares the Policyfile lock at the
+  `v1.0.0` tag with the lastest revision on the master branch.
+
+`chef diff --head` is a shortcut for `chef diff --git HEAD`.
+
+When no git-specific flag is given, `chef diff` either compares the
+current lockfile revision on disk to one on the server or compares two
+lockfiles on the server. Lockfiles on the Chef Server are specified by
+Policy Group. Examples:
+
+* `chef diff staging`: compares the current lock with the one currently
+  assigned to the `staging` Policy Group.
+* `chef diff production...staging` compares the lock currently assigned
+  to the `production` Policy Group to the lock currently assigned to the
+  `staging` Policy Group.
+
+Options:
+BANNER
+
+      option :git,
+        short:       "-g GIT_REF",
+        long:        "--git GIT_REF",
+        description: "Compare local lock against GIT_REF, or between two git commits"
+
+      option :head,
+        long:        "--head",
+        description: "Compare local lock against last git commit",
+        boolean:     true
+
+      option :config_file,
+        short:       "-c CONFIG_FILE",
+        long:        "--config CONFIG_FILE",
+        description: "Path to configuration file"
+
+      option :debug,
+        short:       "-D",
+        long:        "--debug",
+        description: "Enable stacktraces and other debug output",
+        default:     false
+
+      attr_accessor :ui
+
+      attr_reader :old_base
+      attr_reader :new_base
+
+      attr_reader :storage_config
+
+      def initialize(*args)
+        super
+
+        @ui = UI.new
+
+        @old_base = nil
+        @new_base = nil
+        @policyfile_relative_path = nil
+        @storage_config = nil
+        @http_client = nil
+      end
+
+      def run(params = [])
+        return 1 unless apply_params!(params)
+        print_diff
+        0
+      rescue PolicyfileServiceError => e
+        handle_error(e)
+        1
+      end
+
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+
+      def print_diff
+        differ.run_report
+      end
+
+      def differ
+        Policyfile::Differ.new(old_name: old_base.name,
+                               old_lock: old_base.lock,
+                               new_name: new_base.name,
+                               new_lock: new_base.lock,
+                               ui: ui)
+      end
+
+      def http_client
+        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
+                                                       signing_key_filename: chef_config.client_key,
+                                                       client_name: chef_config.node_name)
+      end
+
+      def policy_name
+        local_lock["name"]
+      end
+
+      def local_lock
+        @local_lock ||= local_lock_comparison_base.lock
+      end
+
+      # ComparisonBase for the local lockfile. This is used to get the
+      # policy_name which is needed to query the server for the lockfile of a
+      # particular policy_group.
+      def local_lock_comparison_base
+        Policyfile::ComparisonBase::Local.new(policyfile_lock_relpath)
+      end
+
+      def policyfile_lock_relpath
+        storage_config.policyfile_lock_filename
+      end
+
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+
+        if no_comparison_specified?(remaining_args)
+          ui.err("No comparison specified")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif conflicting_args_and_opts_given?(remaining_args)
+          ui.err("Conflicting arguments and options: git and Policy Group comparisons cannot be mixed")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif conflicting_git_options_given?
+          ui.err("Conflicting git options: --head and --git are exclusive")
+          ui.err("")
+          ui.err(opt_parser)
+
+          false
+        elsif config[:head]
+          set_policyfile_path_from_args(remaining_args)
+          @old_base = Policyfile::ComparisonBase::Git.new("HEAD", policyfile_lock_relpath)
+          @new_base = Policyfile::ComparisonBase::Local.new(policyfile_lock_relpath)
+          true
+        elsif config[:git]
+          set_policyfile_path_from_args(remaining_args)
+          parse_git_comparison(config[:git])
+        else
+          set_policyfile_path_from_args(remaining_args)
+          parse_server_comparison(remaining_args)
+        end
+      end
+
+      def parse_server_comparison(args)
+        comparison_string = args.last
+        if comparison_string.include?("...")
+          old_pgroup, new_pgroup, *extra = comparison_string.split("...")
+          @old_base, @new_base = [old_pgroup, new_pgroup].map do |g|
+            Policyfile::ComparisonBase::PolicyGroup.new(g, policy_name, http_client)
+          end
+
+          unless extra.empty?
+            ui.err("Unable to parse policy group comparison `#{comparison_string}`. Only 2 references can be specified.")
+            return false
+          end
+        else
+          @old_base = Policyfile::ComparisonBase::PolicyGroup.new(comparison_string, policy_name, http_client)
+          @new_base = Policyfile::ComparisonBase::Local.new(policyfile_lock_relpath)
+        end
+        true
+      end
+
+      def parse_git_comparison(git_ref)
+        if git_ref.include?("...")
+          old_ref, new_ref, *extra = git_ref.split("...")
+          @old_base, @new_base = [old_ref, new_ref].map do |r|
+            Policyfile::ComparisonBase::Git.new(r, policyfile_lock_relpath)
+          end
+
+          unless extra.empty?
+            ui.err("Unable to parse git comparison `#{git_ref}`. Only 2 references can be specified.")
+            return false
+          end
+        else
+          @old_base = Policyfile::ComparisonBase::Git.new(git_ref, policyfile_lock_relpath)
+          @new_base = Policyfile::ComparisonBase::Local.new(policyfile_lock_relpath)
+        end
+        true
+      end
+
+      def no_comparison_specified?(args)
+        !policy_group_comparison?(args) && !config[:head] && !config[:git]
+      end
+
+      def conflicting_args_and_opts_given?(args)
+        (config[:git] || config[:head]) && policy_group_comparison?(args)
+      end
+
+      def conflicting_git_options_given?
+        config[:git] && config[:head]
+      end
+
+      def comparing_policy_groups?
+        !(config[:git] || config[:head])
+      end
+
+      # Try to detect if the only argument given is a policyfile path. This is
+      # necessary because we support an optional argument with the path to the
+      # ruby policyfile. It would be easier if we used an option like `-f`, but
+      # that would be inconsistent with other commands (`chef install`, `chef
+      # push`, etc.).
+      def policy_group_comparison?(args)
+        return false if args.empty?
+        return true if args.size > 1
+        !(args.first =~ /\.rb\Z/)
+      end
+
+      def set_policyfile_path_from_args(args)
+        policyfile_relative_path =
+          if !comparing_policy_groups?
+            args.first || "Policyfile.rb"
+          elsif args.size == 1
+            "Policyfile.rb"
+          else
+            args.first
+          end
+        @storage_config = Policyfile::StorageConfig.new.use_policyfile(policyfile_relative_path)
+      end
+
+    end
+
+  end
+end
+

--- a/lib/chef-dk/command/push.rb
+++ b/lib/chef-dk/command/push.rb
@@ -104,7 +104,7 @@ E
       def apply_params!(params)
         remaining_args = parse_options(params)
         if remaining_args.size < 1 or remaining_args.size > 2
-          ui.err(banner)
+          ui.err(opt_parser)
           return false
         else
           @policy_group = remaining_args[0]

--- a/lib/chef-dk/pager.rb
+++ b/lib/chef-dk/pager.rb
@@ -1,0 +1,106 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/ui'
+
+module ChefDK
+  class Pager
+
+    attr_reader :pager_pid
+
+    def initialize(enable_pager: true)
+      @enable_pager = enable_pager
+      @pipe = nil
+      @pager_pid
+    end
+
+    def pager_enabled?
+      !!(@enable_pager && have_tty? && env["PAGER"])
+    end
+
+    def ui
+      @ui ||=
+        if pager_enabled?
+          UI.new(out: parent_stdout)
+        else
+          UI.new
+        end
+    end
+
+    def with_pager
+      start
+      begin
+        yield self
+      ensure
+        wait
+      end
+    end
+
+    def start
+      return false unless pager_enabled?
+
+      # Ignore CTRL-C because it can cause the parent to die before the
+      # pager which causes wonky behavior in the terminal
+      Kernel.trap(:INT, "IGNORE")
+
+      @pager_pid = Process.spawn(pager_env, env["PAGER"], in: child_stdin)
+
+      child_stdin.close
+    end
+
+    def wait
+      return false unless pager_enabled?
+
+      # Sends EOF to the PAGER
+      parent_stdout.close
+      # wait or else we'd kill the pager when we exit
+      Process.waitpid(pager_pid)
+    end
+
+    # @api private
+    # This is just public so we can stub it for testing
+    def env
+      ENV
+    end
+
+    # @api private
+    # This is just public so we can stub it for testing
+    def have_tty?
+      $stdout.tty?
+    end
+
+    private
+
+    def child_stdin
+      pipe[0]
+    end
+
+    def parent_stdout
+      pipe[1]
+    end
+
+    def pipe
+      @pipe ||= IO.pipe
+    end
+
+    def pager_env
+      {"LESS" => "-FRX", "LV" => "-c"}
+    end
+
+  end
+end
+

--- a/lib/chef-dk/policyfile/comparison_base.rb
+++ b/lib/chef-dk/policyfile/comparison_base.rb
@@ -1,0 +1,124 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'ffi_yajl'
+require 'mixlib/shellout'
+require 'chef-dk/service_exceptions'
+
+module ChefDK
+  module Policyfile
+    module ComparisonBase
+
+      class Local
+
+        attr_reader :policyfile_lock_relpath
+
+        def initialize(policyfile_lock_relpath)
+          @policyfile_lock_relpath = policyfile_lock_relpath
+        end
+
+        def name
+          "local:#{policyfile_lock_relpath}"
+        end
+
+        def lock
+          raise LockfileNotFound, "Expected lockfile at #{policyfile_lock_relpath} does not exist" unless File.exist?(policyfile_lock_relpath)
+          raise LockfileNotFound, "Expected lockfile at #{policyfile_lock_relpath} cannot be read" unless File.readable?(policyfile_lock_relpath)
+          FFI_Yajl::Parser.parse(IO.read(policyfile_lock_relpath))
+        rescue FFI_Yajl::ParseError => e
+          raise MalformedLockfile, "Invalid JSON in lockfile at #{policyfile_lock_relpath}:\n  #{e.message}"
+        end
+
+      end
+
+      class Git
+
+        attr_reader :ref
+        attr_reader :policyfile_lock_relpath
+
+        def initialize(ref, policyfile_lock_relpath)
+          @ref = ref
+          @policyfile_lock_relpath = policyfile_lock_relpath
+        end
+
+        def name
+          "git:#{ref}"
+        end
+
+        def lock
+          git_cmd.run_command
+          git_cmd.error!
+          FFI_Yajl::Parser.parse(git_cmd.stdout)
+        rescue Mixlib::ShellOut::ShellCommandFailed
+          raise GitError, "Git command `#{git_cmd_string}` failed with message: #{git_cmd.stderr.chomp}"
+        rescue FFI_Yajl::ParseError => e
+          raise MalformedLockfile, "Invalid JSON in lockfile at git ref '#{ref}' at path '#{policyfile_lock_relpath}':\n  #{e.message}"
+        end
+
+        def git_cmd
+          @git_cmd ||= Mixlib::ShellOut.new(git_cmd_string)
+        end
+
+        def git_cmd_string
+          # Git is a little picky about how we specify the paths, but it looks
+          # like we don't need to worry about the relative path to the root of
+          # the repo if we give git a leading dot:
+          #
+          #    git show 6644e6cb2ade90b8aff2ebb44728958fbc939ebf:zero.rb
+          #    fatal: Path 'etc/zero.rb' exists, but not 'zero.rb'.
+          #    Did you mean '6644e6cb2ade90b8aff2ebb44728958fbc939ebf:etc/zero.rb' aka '6644e6cb2ade90b8aff2ebb44728958fbc939ebf:./zero.rb'?
+          #    git show 6644e6cb2ade90b8aff2ebb44728958fbc939ebf:./zero.rb
+          #    (works)
+          "git show #{ref}:./#{policyfile_lock_relpath}"
+        end
+
+      end
+
+      class PolicyGroup
+
+        attr_reader :group
+        attr_reader :policy_name
+        attr_reader :http_client
+
+        def initialize(group, policy_name, http_client)
+          @group = group
+          @policy_name = policy_name
+          @http_client = http_client
+        end
+
+        def name
+          "policy_group:#{group}"
+        end
+
+        def lock
+          http_client.get("policy_groups/#{group}/policies/#{policy_name}")
+        rescue Net::ProtocolError => e
+          if e.respond_to?(:response) && e.response.code.to_s == "404"
+            raise PolicyfileDownloadError.new("No policyfile lock named '#{policy_name}' found in policy_group '#{group}' at #{http_client.url}", e)
+          else
+            raise PolicyfileDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}", e)
+          end
+        rescue => e
+          raise PolicyfileDownloadError.new("Failed to fetch policyfile lock from #{http_client.url}", e)
+        end
+
+      end
+
+    end
+  end
+end
+

--- a/lib/chef-dk/policyfile/differ.rb
+++ b/lib/chef-dk/policyfile/differ.rb
@@ -17,6 +17,7 @@
 
 require 'diff/lcs'
 require 'paint'
+require 'ffi_yajl'
 
 module ChefDK
   module Policyfile

--- a/lib/chef-dk/policyfile/differ.rb
+++ b/lib/chef-dk/policyfile/differ.rb
@@ -16,6 +16,7 @@
 #
 
 require 'diff/lcs'
+require 'diff/lcs/hunk'
 require 'paint'
 require 'ffi_yajl'
 

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -36,6 +36,12 @@ module ChefDK
   class LockfileNotFound < PolicyfileServiceError
   end
 
+  class MalformedLockfile < PolicyfileServiceError
+  end
+
+  class GitError < PolicyfileServiceError
+  end
+
   class ExportDirNotEmpty < PolicyfileServiceError
   end
 
@@ -68,6 +74,9 @@ module ChefDK
       end
     end
 
+  end
+
+  class PolicyfileDownloadError < PolicyfileNestedException
   end
 
   class PolicyfileInstallError < PolicyfileNestedException

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,8 @@ require 'test_helpers'
 require 'chef/workstation_config_loader'
 
 RSpec.configure do |c|
+  running_on_windows = (RUBY_PLATFORM =~ /mswin|mingw|windows/)
+
   c.include ChefDK
   c.include TestHelpers
 
@@ -37,8 +39,10 @@ RSpec.configure do |c|
   c.run_all_when_everything_filtered = true
   # Tests that randomly fail, but may have value.
   c.filter_run_excluding :volatile => true
+  c.filter_run_excluding :skip_on_windows => true if running_on_windows
 
   c.mock_with(:rspec) do |mocks|
     mocks.verify_partial_doubles = true
   end
+
 end

--- a/spec/unit/command/diff_spec.rb
+++ b/spec/unit/command/diff_spec.rb
@@ -1,0 +1,278 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/diff'
+
+describe ChefDK::Command::Diff do
+
+  it_behaves_like "a command with a UI object"
+
+  let(:params) { [] }
+
+  let(:command) do
+    described_class.new
+  end
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:chef_config) { double("Chef::Config") }
+
+  let(:config_arg) { nil }
+
+  before do
+    stub_const("Chef::Config", chef_config)
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "selecting comparison bases" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP") }
+
+    let(:differ) { instance_double("ChefDK::Policyfile::Differ", run_report: nil) }
+
+    before do
+      allow(command).to receive(:differ).and_return(differ)
+      allow(command).to receive(:http_client).and_return(http_client)
+      command.ui = ui
+    end
+
+    context "when no base is given" do
+
+      it "prints an error message and exits" do
+        expect(command.run(params)).to eq(1)
+        expect(ui.output).to include("No comparison specified")
+      end
+
+    end
+
+    context "when server and git comparison bases are mixed" do
+
+      let(:params) { %w{ --git gitref policygroup } }
+
+      it "prints an error message and exits" do
+        expect(command.run(params)).to eq(1)
+        expect(ui.output).to include("Conflicting arguments and options: git and Policy Group comparisons cannot be mixed")
+      end
+
+    end
+
+    context "when specific git comparison bases are mixed with --head" do
+
+      let(:params) { %w{ --head --git gitref } }
+
+      it "prints an error message and exits" do
+        expect(command.run(params)).to eq(1)
+        expect(ui.output).to include("Conflicting git options: --head and --git are exclusive")
+      end
+
+    end
+
+    describe "selecting git comparison bases" do
+
+      context "when the Policyfile isn't named" do
+
+        let(:params) { %w{ --head } }
+
+        it "uses Policyfile.lock.json as the local lock" do
+          expect(command.run(params)).to eq(0)
+          expect(command.policyfile_lock_relpath).to eq("Policyfile.lock.json")
+        end
+
+      end
+
+      context "when the Policyfile is named" do
+
+        context "using the --head option" do
+
+          let(:params) { %w{ policies/OtherPolicy.rb --head } }
+
+          it "uses the corresponding lock as the local lock" do
+            expect(command.run(params)).to eq(0)
+            expect(command.policyfile_lock_relpath).to eq("policies/OtherPolicy.lock.json")
+          end
+
+        end
+
+        context "using the --git option" do
+
+          let(:params) { %w{ policies/OtherPolicy.rb --git master } }
+
+          it "uses the corresponding lock as the local lock" do
+            expect(command.run(params)).to eq(0)
+            expect(command.policyfile_lock_relpath).to eq("policies/OtherPolicy.lock.json")
+          end
+
+        end
+
+      end
+
+      context "when given a single commit-ish" do
+
+        let(:params) { %w{ --git master } }
+
+        it "compares the local lock to the commit" do
+          expect(command.run(params)).to eq(0)
+          expect(command.old_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Git)
+          expect(command.old_base.ref).to eq("master")
+          expect(command.new_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Local)
+          expect(command.new_base.policyfile_lock_relpath).to eq("Policyfile.lock.json")
+        end
+
+      end
+
+      context "when given two commit-ish names" do
+
+        let(:params) { %w{ --git master...dev-branch } }
+
+        it "compares the two commits" do
+          expect(command.run(params)).to eq(0)
+          expect(command.old_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Git)
+          expect(command.old_base.ref).to eq("master")
+          expect(command.new_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Git)
+          expect(command.new_base.ref).to eq("dev-branch")
+        end
+
+      end
+
+      context "when given too many commit-ish names" do
+
+        let(:params) { %w{ --git too...many...things } }
+
+        it "prints an error and exits" do
+          expect(command.run(params)).to eq(1)
+          expect(ui.output).to include("Unable to parse git comparison `too...many...things`. Only 2 references can be specified.")
+        end
+
+      end
+
+      context "when --head is used" do
+
+        let(:params) { %w{ --head } }
+
+        it "compares the local lock to git HEAD" do
+          expect(command.run(params)).to eq(0)
+          expect(command.old_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Git)
+          expect(command.old_base.ref).to eq("HEAD")
+          expect(command.new_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Local)
+          expect(command.new_base.policyfile_lock_relpath).to eq("Policyfile.lock.json")
+        end
+
+      end
+
+    end
+
+    describe "selecting policy group comparison bases" do
+
+      let(:local_lock_comparison_base) do
+        instance_double("ChefDK::Policyfile::ComparisonBase::Local")
+      end
+
+      before do
+        allow(command).to receive(:local_lock_comparison_base).and_return(local_lock_comparison_base)
+      end
+
+      context "when the local lockfile cannot be read and parsed" do
+
+        let(:params) { %w{ dev-group } }
+
+        before do
+          allow(local_lock_comparison_base).to receive(:lock).and_raise(ChefDK::LockfileNotFound)
+        end
+
+        it "prints an error and exits" do
+          expect(command.run(params)).to eq(1)
+        end
+
+      end
+
+      context "when the local lockfile can be read and parsed" do
+        before do
+          allow(local_lock_comparison_base).to receive(:lock).and_return({"name" => "example-policy"})
+          allow(command).to receive(:differ).and_return(differ)
+          command.ui = ui
+        end
+
+        context "when the Policyfile isn't named" do
+
+          let(:params) { %w{ dev-group } }
+
+          it "uses Policyfile.lock.json as the local lock" do
+            expect(command.run(params)).to eq(0)
+            expect(command.policyfile_lock_relpath).to eq("Policyfile.lock.json")
+          end
+
+        end
+
+        context "when the Policyfile is named" do
+
+          let(:params) { %w{ policies/SomePolicy.rb dev-group } }
+
+          it "uses the corresponding lock as the local lock" do
+            expect(command.run(params)).to eq(0)
+            expect(command.policyfile_lock_relpath).to eq("policies/SomePolicy.lock.json")
+          end
+
+        end
+
+        context "when given a single policy group name" do
+
+          let(:params) { %w{ dev-group } }
+
+          it "compares the policy group's lock to the local lock" do
+            expect(command.run(params)).to eq(0)
+            expect(command.old_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::PolicyGroup)
+            expect(command.old_base.group).to eq("dev-group")
+            expect(command.new_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::Local)
+            expect(command.new_base.policyfile_lock_relpath).to eq("Policyfile.lock.json")
+          end
+
+        end
+
+        context "when given two policy group names" do
+
+          let(:params) { %w{ prod-group...stage-group } }
+
+          it "compares the two locks" do
+            expect(command.run(params)).to eq(0)
+            expect(command.old_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::PolicyGroup)
+            expect(command.old_base.group).to eq("prod-group")
+            expect(command.new_base).to be_a_kind_of(ChefDK::Policyfile::ComparisonBase::PolicyGroup)
+            expect(command.new_base.group).to eq("stage-group")
+          end
+
+        end
+
+        context "when given too many policy group names" do
+
+          let(:params) { %w{ prod...stage...dev } }
+
+          it "prints an error and exits" do
+            expect(command.run(params)).to eq(1)
+            expect(ui.output).to include("Unable to parse policy group comparison `prod...stage...dev`. Only 2 references can be specified.")
+          end
+
+        end
+
+      end
+    end
+  end
+end
+

--- a/spec/unit/command/diff_spec.rb
+++ b/spec/unit/command/diff_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,12 @@ describe ChefDK::Command::Diff do
 
     let(:differ) { instance_double("ChefDK::Policyfile::Differ", run_report: nil) }
 
+    let(:pager) { instance_double("ChefDK::Pager", ui: ui) }
+
     before do
+      allow(ChefDK::Pager).to receive(:new).and_return(pager)
+      allow(pager).to receive(:with_pager).and_yield(pager)
+      allow(command).to receive(:materialize_locks).and_return(nil)
       allow(command).to receive(:differ).and_return(differ)
       allow(command).to receive(:http_client).and_return(http_client)
       command.ui = ui

--- a/spec/unit/pager_spec.rb
+++ b/spec/unit/pager_spec.rb
@@ -1,0 +1,119 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/pager'
+
+describe ChefDK::Pager do
+
+  context "with default options" do
+
+    subject(:pager) { ChefDK::Pager.new }
+
+    it "gives ENV for env" do
+      expect(pager.env).to eq(ENV)
+    end
+
+    it "checks stdout for TTY" do
+      expect($stdout).to receive(:tty?).twice.and_call_original
+      expect(pager.have_tty?).to eq($stdout.tty?)
+    end
+
+    it "enables paging" do
+      expect(pager).to receive(:env).and_return({"PAGER" => "less"})
+      expect(pager).to receive(:have_tty?).and_return(true)
+      expect(pager.pager_enabled?).to be(true)
+    end
+  end
+
+  context "with paging enabled" do
+
+    subject(:pager) do
+      ChefDK::Pager.new(enable_pager: true).tap do |p|
+        allow(p).to receive(:env).and_return({"PAGER" => "less"})
+        allow(p).to receive(:have_tty?).and_return(true)
+      end
+    end
+
+    let(:pipe_read) { instance_double("IO") }
+    let(:pipe_write) { instance_double("IO") }
+
+    let(:pager_env) { { "LESS" => "-FRX", "LV" => "-c" } }
+
+    before do
+      allow(IO).to receive(:pipe).and_return([pipe_read, pipe_write])
+    end
+
+    it "provides a UI object with stdout set to a pipe" do
+      expect(pager.ui.out_stream).to eq(pipe_write)
+    end
+
+    it "starts the pager" do
+      expect(Kernel).to receive(:trap).with(:INT, "IGNORE")
+      expect(Process).to receive(:spawn).with(pager_env, "less", in: pipe_read).and_return(12345)
+      expect(pipe_read).to receive(:close)
+      pager.start
+    end
+
+    it "waits for the pager to exit" do
+      expect(Kernel).to receive(:trap).with(:INT, "IGNORE")
+      expect(Process).to receive(:spawn).with(pager_env, "less", in: pipe_read).and_return(12345)
+      expect(pipe_read).to receive(:close)
+      pager.start
+
+      expect(pipe_write).to receive(:close)
+      expect(Process).to receive(:waitpid).with(12345)
+      pager.wait
+    end
+  end
+
+  context "with paging disabled" do
+
+    subject(:pager) do
+      ChefDK::Pager.new(enable_pager: false).tap do |p|
+        allow(p).to receive(:env).and_return({"PAGER" => "less"})
+        allow(p).to receive(:have_tty?).and_return(true)
+      end
+    end
+
+    before do
+      expect(IO).to_not receive(:pipe)
+    end
+
+
+    it "provides a UI with stdout set to stdout" do
+      expect(pager.ui.out_stream).to eq($stdout)
+    end
+
+    it "no-ops on pager start" do
+      expect(Kernel).to_not receive(:trap)
+      expect(Process).to_not receive(:spawn)
+      pager.start
+    end
+
+    it "no-ops on pager wait" do
+      expect(Kernel).to_not receive(:trap)
+      expect(Process).to_not receive(:spawn)
+      pager.start
+
+      expect(Process).to_not receive(:waitpid)
+      pager.wait
+    end
+
+  end
+end
+

--- a/spec/unit/policyfile/comparison_base_spec.rb
+++ b/spec/unit/policyfile/comparison_base_spec.rb
@@ -68,6 +68,10 @@ E
 
     subject(:comparison_base) { described_class.new(policyfile_lock_relpath) }
 
+    before do
+      reset_tempdir
+    end
+
     after do
       reset_tempdir
     end
@@ -90,7 +94,7 @@ E
 
     end
 
-    context "when the local policyfile lock is not readable" do
+    context "when the local policyfile lock is not readable", :skip_on_windows do
 
       before do
         Dir.chdir(tempdir) do

--- a/spec/unit/policyfile/comparison_base_spec.rb
+++ b/spec/unit/policyfile/comparison_base_spec.rb
@@ -1,0 +1,339 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile/comparison_base'
+
+describe "Policyfile Comparison Bases" do
+
+  let(:minimal_lockfile_json) do
+        <<-E
+{
+  "revision_id": "6fe753184c8946052d3231bb4212116df28d89a3a5f7ae52832ad408419dd5eb",
+  "name": "install-example",
+  "run_list": [
+    "recipe[local-cookbook::default]"
+  ],
+  "cookbook_locks": {
+    "local-cookbook": {
+      "version": "2.3.4",
+      "identifier": "fab501cfaf747901bd82c1bc706beae7dc3a350c",
+      "dotted_decimal_identifier": "70567763561641081.489844270461035.258281553147148",
+      "source": "cookbooks/local-cookbook",
+      "cache_key": null,
+      "scm_info": null,
+      "source_options": {
+        "path": "cookbooks/local-cookbook"
+      }
+    }
+  },
+  "default_attributes": {},
+  "override_attributes": {},
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "local-cookbook",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "local-cookbook (2.3.4)": [
+
+      ]
+    }
+  }
+}
+E
+  end
+
+  let(:minimal_lockfile) { FFI_Yajl::Parser.parse(minimal_lockfile_json) }
+
+  describe ChefDK::Policyfile::ComparisonBase::Local do
+
+    let(:policyfile_lock_relpath) { "Policyfile.lock.json" }
+
+    subject(:comparison_base) { described_class.new(policyfile_lock_relpath) }
+
+    after do
+      reset_tempdir
+    end
+
+    it "has the lockfile relative path" do
+      expect(comparison_base.policyfile_lock_relpath).to eq(policyfile_lock_relpath)
+    end
+
+    it "is named local:RELATIVE_PATH" do
+      expect(comparison_base.name).to eq("local:#{policyfile_lock_relpath}")
+    end
+
+    context "when the local lock doesn't exist" do
+
+      it "raises an exception when reading the lockfile" do
+        Dir.chdir(tempdir) do
+          expect { comparison_base.lock }.to raise_error(ChefDK::LockfileNotFound)
+        end
+      end
+
+    end
+
+    context "when the local policyfile lock is not readable" do
+
+      before do
+        Dir.chdir(tempdir) do
+          FileUtils.touch(policyfile_lock_relpath)
+          FileUtils.chmod(0000, policyfile_lock_relpath)
+        end
+      end
+
+      it "raises an exception" do
+        Dir.chdir(tempdir) do
+          expect { comparison_base.lock }.to raise_error(ChefDK::LockfileNotFound)
+        end
+      end
+
+    end
+
+    context "when the local policyfile lock is malformed" do
+
+      before do
+        Dir.chdir(tempdir) do
+          File.open(policyfile_lock_relpath, "w+") { |f| f.print("}}}}}}") }
+        end
+      end
+
+      it "raises an exception" do
+        Dir.chdir(tempdir) do
+          expect { comparison_base.lock }.to raise_error(ChefDK::MalformedLockfile)
+        end
+      end
+
+    end
+
+    context "when the local lock exists and is valid JSON" do
+
+      before do
+        Dir.chdir(tempdir) do
+          File.open(policyfile_lock_relpath, "w+") { |f| f.print(minimal_lockfile_json) }
+        end
+      end
+
+      it "reads the local lock and parses the JSON" do
+        Dir.chdir(tempdir) do
+          expect(comparison_base.lock).to eq(minimal_lockfile)
+        end
+      end
+
+    end
+
+  end
+
+  describe ChefDK::Policyfile::ComparisonBase::Git do
+
+    let(:ref) { "master" }
+
+    let(:policyfile_lock_relpath) { "policies/MyPolicy.lock.json" }
+
+    subject(:comparison_base) { described_class.new(ref, policyfile_lock_relpath) }
+
+    it "has the policyfile lock relative path it was created with" do
+      expect(comparison_base.policyfile_lock_relpath).to eq(policyfile_lock_relpath)
+    end
+
+    it "has the ref it was created with" do
+      expect(comparison_base.ref).to eq(ref)
+    end
+
+    it "is named git:REF" do
+      expect(comparison_base.name).to eq("git:master")
+    end
+
+    it "creates a `git show` command for the policyfile lock and ref" do
+      expect(comparison_base.git_cmd_string).to eq("git show master:./policies/MyPolicy.lock.json")
+      expect(comparison_base.git_cmd.command).to eq("git show master:./policies/MyPolicy.lock.json")
+    end
+
+    context "when the git command fails" do
+
+      before do
+        allow(comparison_base.git_cmd).to receive(:run_command)
+        allow(comparison_base.git_cmd).to receive(:error!).and_raise(Mixlib::ShellOut::ShellCommandFailed)
+        allow(comparison_base.git_cmd).to receive(:stderr).and_return("fatal: Not a git repository (or any of the parent directories): .git\n")
+      end
+
+      it "raises an exception when reading the lockfile" do
+        expect { comparison_base.lock }.to raise_error(ChefDK::GitError)
+      end
+
+    end
+
+    context "when the git command succeeds" do
+
+      before do
+        allow(comparison_base.git_cmd).to receive(:run_command)
+        allow(comparison_base.git_cmd).to receive(:error!).and_return(nil)
+      end
+
+      context "and the JSON is malformed" do
+
+        before do
+          allow(comparison_base.git_cmd).to receive(:stdout).and_return("}}}}}")
+        end
+
+        it "raises an exception" do
+          expect { comparison_base.lock }.to raise_error(ChefDK::MalformedLockfile)
+        end
+
+      end
+
+      context "and the JSON is well-formed" do
+
+        before do
+          allow(comparison_base.git_cmd).to receive(:stdout).and_return(minimal_lockfile_json)
+        end
+
+        it "reads the lockfile and parses the JSON" do
+          expect(comparison_base.lock).to eq(minimal_lockfile)
+        end
+      end
+
+    end
+
+  end
+
+  describe ChefDK::Policyfile::ComparisonBase::PolicyGroup do
+
+    let(:group) { "acceptance" }
+    let(:policy_name) { "chatserver" }
+    let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP", url: "https://chef.example/organizations/monkeynews") }
+
+    subject(:comparison_base) { described_class.new(group, policy_name, http_client) }
+
+    it "has the group it was created with" do
+      expect(comparison_base.group).to eq(group)
+    end
+
+    it "has the policy_name it was created with" do
+      expect(comparison_base.policy_name).to eq(policy_name)
+    end
+
+    it "has the HTTP client it was created with" do
+      expect(comparison_base.http_client).to eq(http_client)
+    end
+
+    it "is named policy_group:GROUP" do
+      expect(comparison_base.name).to eq("policy_group:#{group}")
+    end
+
+    context "when there is a non-404 HTTP error fetching the policyfile lock" do
+
+      let(:response) do
+        Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
+          r.instance_variable_set(:@body, "oops")
+        end
+      end
+
+      let(:http_exception) do
+        begin
+          response.error!
+        rescue => e
+          e
+        end
+      end
+
+      before do
+        allow(http_client).to receive(:get).and_raise(http_exception)
+      end
+
+      it "raises an exception" do
+        exception = nil
+        begin
+          comparison_base.lock
+        rescue => exception
+          expect(exception).to be_a_kind_of(ChefDK::PolicyfileDownloadError)
+          expect(exception.message).to eq("HTTP error attempting to fetch policyfile lock from https://chef.example/organizations/monkeynews")
+          expect(exception.cause).to eq(http_exception)
+        end
+        expect(exception).to_not be_nil
+      end
+
+    end
+
+    context "when the server returns 404 fetching the policyfile lock" do
+
+      let(:response) do
+        Net::HTTPResponse.send(:response_class, "404").new("1.0", "404", "Not Found").tap do |r|
+          r.instance_variable_set(:@body, "nothin' here, chief")
+        end
+      end
+
+      let(:http_exception) do
+        begin
+          response.error!
+        rescue => e
+          e
+        end
+      end
+
+      before do
+        allow(http_client).to receive(:get).and_raise(http_exception)
+      end
+
+      it "raises an exception" do
+        exception = nil
+        begin
+          comparison_base.lock
+        rescue => exception
+          expect(exception).to be_a_kind_of(ChefDK::PolicyfileDownloadError)
+          expect(exception.message).to eq("No policyfile lock named 'chatserver' found in policy_group 'acceptance' at https://chef.example/organizations/monkeynews")
+          expect(exception.cause).to eq(http_exception)
+        end
+        expect(exception).to_not be_nil
+      end
+
+
+    end
+
+
+    context "when a non-HTTP error occurs fetching the policyfile lock" do
+
+      before do
+        allow(http_client).to receive(:get).and_raise(Errno::ECONNREFUSED)
+      end
+
+      it "raises an exception" do
+        expect { comparison_base.lock }.to raise_error(ChefDK::PolicyfileDownloadError)
+      end
+
+    end
+
+    context "when the policyfile lock is fetched from the server" do
+
+      before do
+        expect(http_client).to receive(:get).
+          with("policy_groups/acceptance/policies/chatserver").
+          and_return(minimal_lockfile)
+      end
+
+      it "returns the policyfile lock data" do
+        expect(comparison_base.lock).to eq(minimal_lockfile)
+      end
+
+    end
+
+  end
+end
+


### PR DESCRIPTION
Adds a `chef diff` command that can diff the current policyfile lock on disk with git commits or locks on the server, or diff two git commits or two revisions on the server. Output is sent to the PAGER by default, and if it's `less`, it's run with colors and such enabled, similar to how git does it.