### PR TITLE
Use a stub to ensure we always test file-not-readable behavior

### DIFF
--- a/spec/unit/policyfile/comparison_base_spec.rb
+++ b/spec/unit/policyfile/comparison_base_spec.rb
@@ -99,7 +99,7 @@ E
       before do
         Dir.chdir(tempdir) do
           FileUtils.touch(policyfile_lock_relpath)
-          FileUtils.chmod(0000, policyfile_lock_relpath)
+          allow(File).to receive(:readable?).with(policyfile_lock_relpath).and_return(false)
         end
       end
 


### PR DESCRIPTION
In Ci the file is still readable after setting 000 permissions, so we're
not testing with the proper context.

@tyler-ball 