### PR TITLE
Enable policyfile native mode by default, remove warning

### DIFF
--- a/lib/chef-dk/configurable.rb
+++ b/lib/chef-dk/configurable.rb
@@ -21,7 +21,7 @@ require 'chef/workstation_config_loader'
 # Define a config context for ChefDK
 class Chef::Config
 
-  default(:policy_document_native_api, false)
+  default(:policy_document_native_api, true)
 
   config_context(:chefdk) do
 

--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -51,13 +51,12 @@ module ChefDK
       def upload
         ui.msg("Uploading policy to policy group #{policy_group}")
 
-        if using_policy_document_native_api?
+        if !using_policy_document_native_api?
           ui.msg(<<-DRAGONS)
-WARN: Using native policy API preview mode. You may be required to delete and
-re-upload this data when upgrading to the final release version of the feature.
+WARN: Uploading policy to policy group #{policy_group} in compatibility mode.
+Cookbooks will be uploaded with very large version numbers, which may be picked
+up by existing nodes.
 DRAGONS
-        else
-          ui.msg("WARN: Uploading policy to policy group #{policy_group} in compatibility mode")
         end
 
         upload_cookbooks


### PR DESCRIPTION
Next Chef Server release (probably 12.0.9) will have policyfile APIs
enabled by default, and it's safer for users if we default to the native
APIs. Also, we don't plan on any compat-breaking data changes in the
foreseeable future, so the warning is no longer relevant.

@chef/lob 