### PR TITLE
Preparing the ChefDK 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Chef Development Kit Changelog
 
+# 0.5.1:
+* [#368](https://github.com/chef/chef-dk/pull/368): Fixing undefined_method
+  error when performing `chef diff`
+* Updating Chef dependency to version 12.3.0
+
 # 0.5.0:
 * [#345](https://github.com/chef/chef-dk/pull/345): Support fish
   shell in `chef shell-init`

--- a/lib/chef-dk/version.rb
+++ b/lib/chef-dk/version.rb
@@ -16,5 +16,5 @@
 #
 
 module ChefDK
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
This contains the following fixes (so far):

* #368 - undefiend_method error when using `chef diff`
* Updates chef client to 12.3.0, which fixes OSX converges (uses homebrew instead of macports)