### PR TITLE
Fixes #380, resolve generated cookbook rubocops

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/Berksfile
+++ b/lib/chef-dk/skeletons/code_generator/files/default/Berksfile
@@ -1,3 +1,3 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata

--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -1,8 +1,7 @@
-name             '<%= cookbook_name %>'
-maintainer       '<%= copyright_holder %>'
+name '<%= cookbook_name %>'
+maintainer '<%= copyright_holder %>'
 maintainer_email '<%= email %>'
-license          '<%= license %>'
-description      'Installs/Configures <%= cookbook_name %>'
+license '<%= license %>'
+description 'Installs/Configures <%= cookbook_name %>'
 long_description 'Installs/Configures <%= cookbook_name %>'
-version          '0.1.0'
-
+version '0.1.0'

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -7,9 +7,7 @@
 require 'spec_helper'
 
 describe '<%= cookbook_name %>::<%= recipe_name %>' do
-
   context 'When all attributes are default, on an unspecified platform' do
-
     let(:chef_run) do
       runner = ChefSpec::ServerRunner.new
       runner.converge(described_recipe)
@@ -18,6 +16,5 @@ describe '<%= cookbook_name %>::<%= recipe_name %>' do
     it 'converges successfully' do
       chef_run # This should not raise an error
     end
-
   end
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
@@ -1,12 +1,9 @@
 require 'spec_helper'
 
 describe '<%= cookbook_name %>::default' do
-
   # Serverspec examples can be found at
   # http://serverspec.org/resource_types.html
-  
   it 'does something' do
     skip 'Replace this with meaningful tests'
   end
-
 end


### PR DESCRIPTION
Fixes https://github.com/chef/chef-dk/issues/380

- Adds a rubocop.yml that ignores the single space before arguments in
  metadata.rb
- Fix quoting in Berksfile
- Clean up horribly offensive additional newlines, and trailing
  whitespace in generated specs :)