### PR TITLE
Update default platforms for generated kitchen.yml

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -6,8 +6,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: ubuntu-12.04
-  - name: centos-6.5
+  - name: ubuntu-14.04
+  - name: centos-7.1
 
 suites:
   - name: default


### PR DESCRIPTION
- Ubuntu 14.04 is now a year old
- CentOS 6.6 is the current 6.x release