### PR TITLE
Provision command

### DIFF
--- a/PROVISION_README.md
+++ b/PROVISION_README.md
@@ -1,0 +1,112 @@
+# `chef provision` Command README
+
+`chef provision` invokes an embedded chef-client run to provision machines
+using Chef Provisioning. If not otherwise specified, `chef provision` will
+expect to find a cookbook named 'provision' in the current working directory.
+It runs a recipe in this cookbook which should use Chef Provisioning to create
+one or more machines (or other infrastructure).
+
+The `chef provision` command aims to achieve these goals:
+
+* Provide provisioning mechanism that supports Policyfiles
+* Improve Chef Provisioning ease of use by creating naming conventions
+* Improve Chef Provisioning ease of use by integrating with ChefDK CLI
+* Improve Chef Provisioning ease of use by separating the way you
+  configure provisioned machines from the way you invoke Chef
+  Provisioning
+* Improve on the `knife bootstrap` experience by expressing more of your
+  provisioning requirements as code (instead of CLI options).
+
+## Basic CLI Use
+
+`chef provision` provides three forms of operation:
+
+### chef provision POLICY_GROUP --policy-name POLICY_NAME
+
+In the first form of the command, `chef provision` creates machines that will
+operate in policyfile mode. The chef configuration passed to the cookbook will
+set the policy group and policy name as given.
+
+### chef provision POLICY_GROUP --sync [POLICYFILE_PATH] [options]
+
+In the second form of the command, `chef provision` create machines that will
+operate in policyfile mode and syncronizes a local policyfile to the server
+before converging the machine(s) defined in the provision cookbook.
+
+### chef provision --no-policy [options]
+
+In the third form of the command, `chef provision` expects to create machines
+that will not operate in policyfile mode.
+
+Note that this command is considered beta. Behavior, the APIs that pass CLI
+data to chef-client, and argument names may change as more experience is gained
+from real-world usage.
+
+## Cookbook Integration
+
+Most of the options and arguments to `chef provision` only affect what
+default data is passed to your provisioning recipe. Your recipe must
+pull data from the provisioning data context in order for the command
+line values to have any effect on the provisioned machines.
+
+### Basic Example
+
+This is a machine recipe I created to demonstrate provisioning with
+Policyfiles:
+
+```ruby
+# Assign the context to a local variable for convenience
+context = ChefDK::ProvisioningData.context
+
+with_driver 'vagrant:~/.vagrant.d/boxes' do
+
+  # Set Machine Options
+  options = {
+    vagrant_options: { 'vm.box' => 'opscode-ubuntu-14.04' },
+    # Set all machine options to the defaults provided by `chef provision`
+    convergence_options: context.convergence_options
+  }
+
+
+  # Set node_name to user provided node name
+  machine context.node_name do
+    machine_options(options)
+
+    # This forces a chef run every time, which is sensible for some
+    # `chef provision` use cases, especially when using `--sync`
+    converge(true)
+    # Set action to what `chef provision` specifies
+    action(context.action)
+  end
+end
+```
+
+To provision the machine, I run:
+
+```sh
+chef provision test123 --sync -n aar-dev
+```
+
+This synchronizes my Policyfile lock to my Chef Server and converges the
+node.
+
+### Provisioning Context
+
+The provisioning context provides the following data:
+
+* `action`: `:converge`, or `:destroy` if you pass `-d` to the
+  CLI.
+* `node_name`: the argument to the `-n` option.
+* `policy_group`: is set to the relevant CLI argument when operating in
+  one of the Policyfile modes.
+* `policy_name`: set to either the value of `--policy-name` or the
+  policy name specified in the Policyfile lock for `--sync`
+* `extra_chef_config`: `chef provision` currently uses the `chef_config`
+  convergence option to set Policyfile config and duplicate your current
+  `ssl_verify_mode` setting. You can set further custom config by
+  assigning a value to this setting, e.g.:
+
+```ruby
+ChefDK::ProvisioningData.context.extra_chef_config = 'log_level :debug'
+```
+

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -50,6 +50,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", "~> 1.0"
 
+  gem.add_dependency "chef-provisioning"
+
   %w(rspec-core rspec-expectations rspec-mocks).each do |dev_gem|
     gem.add_development_dependency dev_gem, "~> 3.0"
   end

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -50,7 +50,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", "~> 1.0"
 
-  gem.add_dependency "chef-provisioning"
+  # Chef Provisioning, used by the `chef provision` command:
+  gem.add_dependency "chef-provisioning", "~> 1.1"
 
   %w(rspec-core rspec-expectations rspec-mocks).each do |dev_gem|
     gem.add_development_dependency dev_gem, "~> 3.0"

--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -35,6 +35,8 @@ ChefDK.commands do |c|
 
   c.builtin "diff", :Diff, desc: "Generate an itemized diff of two Policyfile lock documents"
 
+  c.builtin "provision", :Provision, desc: "Provision VMs and clusters via cookbook"
+
   c.builtin "export", :Export, desc: "Export a policy lock as a Chef Zero code repo"
 
   c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications"

--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -58,7 +58,10 @@ module ChefDK
     end
 
     def formatter
-      @formatter ||= Chef::Formatters.new(:doc, stdout, stderr)
+      @formatter ||=
+        Chef::EventDispatch::Dispatcher.new.tap do |d|
+          d.register(Chef::Formatters.new(:doc, stdout, stderr))
+        end
     end
 
     def configure

--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -16,6 +16,7 @@
 #
 
 require 'chef-dk/exceptions'
+require 'chef-dk/service_exceptions'
 require 'chef'
 
 module ChefDK

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -118,6 +118,8 @@ Note that this command is considered beta. Behavior, the APIs that pass CLI
 data to chef-client, and argument names may change as more experience is gained
 from real-world usage.
 
+Chef Provisioning is documented at https://docs.chef.io/provisioning.html
+
 Options:
 
 E

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -202,7 +202,7 @@ E
 
         chef_runner.converge
         0
-      rescue PolicyfileServiceError => e
+      rescue ChefRunnerError, PolicyfileServiceError => e
         handle_error(e)
         1
         # TODO: need error handling here in general. In particular,

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -1,0 +1,393 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/configurable'
+require 'chef-dk/chef_runner'
+require 'chef-dk/policyfile_services/push'
+
+require 'chef/provisioning'
+
+module ChefDK
+
+  module ProvisioningData
+
+    def self.reset
+      @context = nil
+    end
+
+    def self.context
+      @context ||= Context.new
+    end
+
+    class Context
+
+      attr_accessor :action
+
+      attr_accessor :node_name
+
+      attr_accessor :policy_group
+
+      attr_accessor :policy_name
+
+      attr_accessor :extra_chef_config
+
+      def initialize
+        @extra_chef_config = ""
+      end
+
+      # TODO: generate slug id
+
+      def convergence_options
+        {
+          chef_server: Chef::Config.chef_server_url,
+          chef_config: chef_config
+        }
+      end
+
+      # TODO: this must respect the no-policy flag.
+      def chef_config
+        <<-CONFIG
+# SSL Settings:
+ssl_verify_mode #{Chef::Config[:ssl_verify_mode].inspect}
+
+# Policyfile Settings:
+use_policyfile true
+policy_document_native_api true
+
+policy_group "#{policy_group}"
+policy_name "#{policy_name}"
+
+#{extra_chef_config}
+CONFIG
+      end
+
+    end
+  end
+
+  module Command
+
+    class Provision < Base
+
+      # TODO: update with opts and args when we figure those out
+      banner(<<-E)
+Usage: chef provision POLICY_GROUP --policy-name POLICY_NAME [options]
+       chef provision POLICY_GROUP --sync [POLICYFILE_PATH] [options]
+       chef provision --no-policy [options]
+
+`chef provision` invokes an embedded chef-client run to provision machines
+using Chef Provisioning. If not otherwise specified, `chef provision` will
+expect to find a cookbook named 'provision' in the current working directory.
+It runs a recipe in this cookbook which should use Chef Provisioning to create
+one or more machines (or other infrastructure).
+
+`chef provision` provides three forms of operation:
+
+### chef provision POLICY_GROUP --policy-name POLICY_NAME
+
+In the first form of the command, `chef provision` creates machines that will
+operate in policyfile mode. The chef configuration passed to the cookbook will
+set the policy group and policy name as given.
+
+### chef provision POLICY_GROUP --sync [POLICYFILE_PATH] [options]
+
+In the second form of the command, `chef provision` create machines that will
+operate in policyfile mode and syncronizes a local policyfile to the server
+before converging the machine(s) defined in the provision cookbook.
+
+### chef provision --no-policy [options]
+
+In the third form of the command, `chef provision` expects to create machines
+that will not operate in policyfile mode.
+
+Note that this command is considered beta. Behavior, the APIs that pass CLI
+data to chef-client, and argument names may change as more experience is gained
+from real-world usage.
+
+Options:
+
+E
+      include Configurable
+
+      option :config_file,
+        short:        "-c CONFIG_FILE",
+        long:         "--config CONFIG_FILE",
+        description:  "Path to configuration file"
+
+      option :policy_name,
+        short:        "-p POLICY_NAME",
+        long:         "--policy-name POLICY_NAME",
+        description:  "Set the default policy name for provisioned machines"
+
+      option :sync,
+        short:        "-s [POLICYFILE_PATH]",
+        long:         "--sync [POLICYFILE_PATH]",
+        description:  "Push policyfile to the server before converging node(s)"
+
+      option :enable_policyfile,
+        long:         "--[no-]policy",
+        description:  "Enable/disable policyfile integration (defaults to enabled, use --no-policy to disable)",
+        default:      true
+
+      option :destroy,
+        short:        "-d",
+        long:         "--destroy",
+        description:  "Set default machine action to :destroy",
+        default:      false,
+        boolean:      true
+
+      option :machine_recipe,
+        short:        "-r RECIPE",
+        long:         "--recipe RECIPE",
+        description:  "Machine recipe to use",
+        default:      "default"
+
+      option :cookbook,
+        long:         "--cookbook COOKBOOK_PATH",
+        description:  "Path to your provisioning cookbook",
+        default:      "./provision"
+
+      option :node_name,
+        short:        "-n NODE_NAME",
+        long:         "--node-name NODE_NAME",
+        description:  "Set default node name (may be overriden by provisioning cookbook)"
+
+      option :debug,
+        short:       "-D",
+        long:        "--debug",
+        description: "Enable stacktraces and other debug output",
+        default:     false
+
+
+      attr_reader :params
+      attr_reader :policyfile_relative_path
+      attr_reader :policy_group
+
+      attr_accessor :ui
+
+      def initialize(*args)
+        super
+
+        @ui = UI.new
+
+        @policyfile_relative_path = nil
+        @policy_group = nil
+
+        @provisioning_cookbook_path = nil
+        @provisioning_cookbook_name = nil
+      end
+
+      def run(params = [])
+        return 1 unless apply_params!(params)
+        chef_config # force chef config to load
+        return 1 unless check_cookbook_and_recipe_path
+
+        push.run if sync_policy?
+
+        setup_context
+
+        chef_runner.converge
+        0
+      rescue PolicyfileServiceError => e
+        handle_error(e)
+        1
+        # TODO: need error handling here in general. In particular,
+        # chef-provisioning will choke with a load error if the desired
+        # provisioner isn't available (should fix that upstream though :( ).
+      rescue StandardError, LoadError => error
+        ui.err("Error: #{error.message}")
+        1
+      end
+
+      # An instance of ChefRunner. Calling ChefRunner#converge will trigger
+      # convergence and generate the desired code.
+      def chef_runner
+        @chef_runner ||= ChefRunner.new(provisioning_cookbook_path, ["recipe[#{provisioning_cookbook_name}::#{recipe}]"])
+      end
+
+      def push
+        @push ||= PolicyfileServices::Push.new(policyfile: policyfile_relative_path,
+                                               ui: ui,
+                                               policy_group: policy_group,
+                                               config: chef_config,
+                                               root_dir: Dir.pwd)
+      end
+
+      def setup_context
+        ProvisioningData.context.tap do |c|
+
+          c.action = default_action
+          c.node_name = node_name
+
+          if enable_policyfile?
+            c.policy_group = policy_group
+            c.policy_name = policy_name
+          end
+
+        end
+      end
+
+      def policy_name
+        if sync_policy?
+          push.policy_data["name"]
+        else
+          config[:policy_name]
+        end
+      end
+
+      def default_action
+        if config[:destroy]
+          :destroy
+        else
+          :converge
+        end
+      end
+
+      def node_name
+        config[:node_name]
+      end
+
+      # TODO: Must add a check to verify this exists
+      def recipe
+        config[:machine_recipe]
+      end
+
+      # Gives the `cookbook_path` in the chef-client sense, which is the
+      # directory that contains the provisioning cookbook.
+      def provisioning_cookbook_path
+        detect_provisioning_cookbook_name_and_path! unless @provisioning_cookbook_path
+        @provisioning_cookbook_path
+      end
+
+      # The name of the provisioning cookbook
+      def provisioning_cookbook_name
+        detect_provisioning_cookbook_name_and_path! unless @provisioning_cookbook_name
+        @provisioning_cookbook_name
+      end
+
+      def cookbook_path
+        config[:cookbook]
+      end
+
+      def enable_policyfile?
+        config[:enable_policyfile]
+      end
+
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+        if enable_policyfile?
+          handle_policy_argv(remaining_args)
+        else
+          handle_no_policy_argv(remaining_args)
+        end
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def sync_policy?
+        config.key?(:sync)
+      end
+
+      private
+
+      # TODO: this should default to CWD or CWD/provision, configure by ARGV.
+      def detect_provisioning_cookbook_name_and_path!
+        given_path = File.expand_path(cookbook_path, Dir.pwd)
+        @provisioning_cookbook_name = File.basename(given_path)
+        @provisioning_cookbook_path = File.dirname(given_path)
+      end
+
+      def check_cookbook_and_recipe_path
+        if !File.exist?(cookbook_expanded_path)
+          ui.err("ERROR: Provisioning cookbook not found at path #{cookbook_expanded_path}")
+          false
+        elsif !File.exist?(provisioning_recipe_path)
+          ui.err("ERROR: Provisioning recipe not found at path #{provisioning_recipe_path}")
+          false
+        else
+          true
+        end
+      end
+
+      def provisioning_recipe_path
+        File.join(cookbook_expanded_path, 'recipes', "#{recipe}.rb")
+      end
+
+      def cookbook_expanded_path
+        File.join(chef_runner.cookbook_path, provisioning_cookbook_name)
+      end
+
+      def handle_no_policy_argv(remaining_args)
+        if remaining_args.empty?
+          true
+        else
+          ui.err("The --no-policy flag cannot be combined with policyfile arguments")
+          ui.err("")
+          ui.err(opt_parser)
+          return false
+        end
+      end
+
+      def handle_policy_argv(remaining_args)
+        if remaining_args.size > 1
+          ui.err("Too many arguments")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif remaining_args.size < 1
+          ui.err("You must specify a POLICY_GROUP or disable policyfiles with --no-policy")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif !sync_policy? && config[:policy_name].nil?
+          ui.err("You must pass either --sync or --policy-name to provision machines in policyfile mode")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif sync_policy? && config[:policy_name]
+          ui.err("The --policy-name and --sync arguments cannot be combined")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif sync_policy?
+          @policy_group = remaining_args[0]
+          @policyfile_relative_path = config[:sync]
+          true
+        elsif config[:policy_name]
+          @policy_group = remaining_args[0]
+          true
+        else
+          raise BUG, "Cannot properly parse input argv '#{ARGV.inspect}'"
+        end
+      end
+
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+
+    end
+  end
+end
+

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -40,6 +40,8 @@ module ChefDK
 
       attr_accessor :node_name
 
+      attr_accessor :enable_policyfile
+
       attr_accessor :policy_group
 
       attr_accessor :policy_name
@@ -57,12 +59,14 @@ module ChefDK
         }
       end
 
-      # TODO: this must respect the no-policy flag.
       def chef_config
-        <<-CONFIG
+        config=<<-CONFIG
 # SSL Settings:
-ssl_verify_mode #{Chef::Config[:ssl_verify_mode].inspect}
+ssl_verify_mode #{Chef::Config.ssl_verify_mode.inspect}
 
+CONFIG
+        if enable_policyfile
+          policyfile_config=<<-CONFIG
 # Policyfile Settings:
 use_policyfile true
 policy_document_native_api true
@@ -70,8 +74,12 @@ policy_document_native_api true
 policy_group "#{policy_group}"
 policy_name "#{policy_name}"
 
-#{extra_chef_config}
 CONFIG
+          config << policyfile_config
+        end
+
+        config << extra_chef_config.to_s
+        config
       end
 
     end
@@ -230,6 +238,8 @@ E
 
           c.action = default_action
           c.node_name = node_name
+
+          c.enable_policyfile = enable_policyfile?
 
           if enable_policyfile?
             c.policy_group = policy_group

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -50,8 +50,6 @@ module ChefDK
         @extra_chef_config = ""
       end
 
-      # TODO: generate slug id
-
       def convergence_options
         {
           chef_server: Chef::Config.chef_server_url,
@@ -83,7 +81,6 @@ CONFIG
 
     class Provision < Base
 
-      # TODO: update with opts and args when we figure those out
       banner(<<-E)
 Usage: chef provision POLICY_GROUP --policy-name POLICY_NAME [options]
        chef provision POLICY_GROUP --sync [POLICYFILE_PATH] [options]
@@ -207,9 +204,8 @@ E
       rescue ChefRunnerError, PolicyfileServiceError => e
         handle_error(e)
         1
-        # TODO: need error handling here in general. In particular,
-        # chef-provisioning will choke with a load error if the desired
-        # provisioner isn't available (should fix that upstream though :( ).
+        # Chef Provisioning doesn't fail gracefully when a driver is missing:
+        # https://github.com/chef/chef-provisioning/issues/338
       rescue StandardError, LoadError => error
         ui.err("Error: #{error.message}")
         1
@@ -263,7 +259,6 @@ E
         config[:node_name]
       end
 
-      # TODO: Must add a check to verify this exists
       def recipe
         config[:machine_recipe]
       end
@@ -308,7 +303,6 @@ E
 
       private
 
-      # TODO: this should default to CWD or CWD/provision, configure by ARGV.
       def detect_provisioning_cookbook_name_and_path!
         given_path = File.expand_path(cookbook_path, Dir.pwd)
         @provisioning_cookbook_name = File.basename(given_path)

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -83,4 +83,7 @@ module ChefDK
 
   class ChefConvergeError < ChefRunnerError; end
 
+  class BUG < RuntimeError
+  end
+
 end

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -68,21 +68,6 @@ module ChefDK
   class InvalidPolicyfileFilename < StandardError
   end
 
-  class ChefRunnerError < StandardError
-
-    attr_reader :cause
-
-    def initialize(message, cause)
-      super(message)
-      @cause = cause
-    end
-
-  end
-
-  class CookbookNotFound < ChefRunnerError; end
-
-  class ChefConvergeError < ChefRunnerError; end
-
   class BUG < RuntimeError
   end
 

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -24,28 +24,7 @@ require 'chef-dk/service_exception_inspectors'
 
 module ChefDK
 
-  # Base class for errors raised by ChefDK::PolicyfileServices objects. Don't
-  # raise this directly, create a descriptively-named subclass. You can rescue
-  # this to catch all errors from PolicyfileServices objects though.
-  class PolicyfileServiceError < StandardError
-  end
-
-  class PolicyfileNotFound < PolicyfileServiceError
-  end
-
-  class LockfileNotFound < PolicyfileServiceError
-  end
-
-  class MalformedLockfile < PolicyfileServiceError
-  end
-
-  class GitError < PolicyfileServiceError
-  end
-
-  class ExportDirNotEmpty < PolicyfileServiceError
-  end
-
-  class PolicyfileNestedException < PolicyfileServiceError
+  module NestedExceptionWithInspector
 
     attr_reader :cause
     attr_reader :inspector
@@ -76,6 +55,33 @@ module ChefDK
 
   end
 
+  # Base class for errors raised by ChefDK::PolicyfileServices objects. Don't
+  # raise this directly, create a descriptively-named subclass. You can rescue
+  # this to catch all errors from PolicyfileServices objects though.
+  class PolicyfileServiceError < StandardError
+  end
+
+  class PolicyfileNotFound < PolicyfileServiceError
+  end
+
+  class LockfileNotFound < PolicyfileServiceError
+  end
+
+  class MalformedLockfile < PolicyfileServiceError
+  end
+
+  class GitError < PolicyfileServiceError
+  end
+
+  class ExportDirNotEmpty < PolicyfileServiceError
+  end
+
+  class PolicyfileNestedException < PolicyfileServiceError
+
+    include NestedExceptionWithInspector
+
+  end
+
   class PolicyfileDownloadError < PolicyfileNestedException
   end
 
@@ -90,6 +96,16 @@ module ChefDK
 
   class PolicyfileExportRepoError < PolicyfileNestedException
   end
+
+  class ChefRunnerError < StandardError
+
+    include NestedExceptionWithInspector
+
+  end
+
+  class CookbookNotFound < ChefRunnerError; end
+
+  class ChefConvergeError < ChefRunnerError; end
 
 end
 

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -54,7 +54,14 @@ describe ChefDK::ChefRunner do
   end
 
   it "configures a formatter for the chef run" do
-    expect(chef_runner.formatter).to be_a(Chef::Formatters::Doc)
+    expect(chef_runner.formatter).to be_a(Chef::EventDispatch::Dispatcher)
+
+    # TODO: Once https://github.com/chef/chef/pull/3340 is merged/released,
+    # just use `formatter.subscribers`
+    subscribers = chef_runner.formatter.instance_variable_get(:@subscribers)
+
+    expect(subscribers.size).to eq(1)
+    expect(subscribers.first).to be_a(Chef::Formatters::Doc)
   end
 
   it "detects the platform with ohai" do

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -416,14 +416,11 @@ E
 
         allow(command).to receive(:chef_runner).and_return(chef_runner)
         allow(chef_runner).to receive(:cookbook_path).and_return(Dir.pwd)
-        expect(chef_runner).to receive(:converge).and_raise(base_exception)
+        expect(chef_runner).to receive(:converge).and_raise(exception)
       end
 
-      it "prints an error and exits non-zero", pending: "Add #reason and inspection code to ChefConvergeError" do
+      it "prints an error and exits non-zero" do
         expect(command.run(params)).to eq(1)
-        # TODO: need to handle the nested exception that ChefConvergeError includes.
-        # it should be printed when given the -D debug argument.
-        # That arg might also need to set chef to debug?
         expect(ui.output).to include("Error: Chef failed to converge")
         expect(ui.output).to include("Reason: (StandardError) Something went wrong")
       end

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -1,0 +1,490 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/provision'
+
+describe ChefDK::Command::Provision do
+
+  it_behaves_like "a command with a UI object"
+
+  let(:command) do
+    described_class.new
+  end
+
+  let(:push_service) { instance_double(ChefDK::PolicyfileServices::Push) }
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:chef_config) { double("Chef::Config") }
+
+  let(:config_arg) { nil }
+
+  before do
+    ChefDK::ProvisioningData.reset
+
+    stub_const("Chef::Config", chef_config)
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "evaluating CLI options and arguments" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    before do
+      command.ui = ui
+    end
+
+    describe "when input is invalid" do
+
+      context "when not enough arguments are given" do
+
+        let(:params) { [] }
+
+        it "prints usage and exits non-zero" do
+          expect(command.run(params)).to eq(1)
+          expect(ui.output).to include("You must specify a POLICY_GROUP or disable policyfiles with --no-policy")
+        end
+
+      end
+
+      context "when --no-policy is combined with policy arguments" do
+
+        let(:params) { %w[ --no-policy some-policy-group ] }
+
+        it "prints usage and exits non-zero" do
+          expect(command.run(params)).to eq(1)
+          expect(ui.output).to include("The --no-policy flag cannot be combined with policyfile arguments")
+        end
+
+      end
+
+      context "when a POLICY_GROUP is given but neither of --sync or --policy-name are given" do
+
+        let(:params) { %w[ some-policy-group ] }
+
+        it "prints usage and exits non-zero" do
+          expect(command.run(params)).to eq(1)
+          expect(ui.output).to include("You must pass either --sync or --policy-name to provision machines in policyfile mode")
+        end
+
+      end
+
+      context "when both --sync and --policy-name are given" do
+
+        let(:params) { %w[ some-policy-group --policy-name foo --sync] }
+
+        it "prints usage and exits non-zero" do
+          expect(command.run(params)).to eq(1)
+          expect(ui.output).to include("The --policy-name and --sync arguments cannot be combined")
+        end
+
+      end
+
+      context "when too many arguments are given" do
+
+        let(:params) { %w[ policygroup extraneous-argument --sync ] }
+
+        it "prints usage and exits non-zero" do
+          expect(command.run(params)).to eq(1)
+          expect(ui.output).to include("Too many arguments")
+        end
+
+      end
+    end
+
+    describe "when input is valid" do
+
+      let(:context) { ChefDK::ProvisioningData.context }
+
+      shared_examples  "common_optional_options" do
+
+        context "with default option values" do
+
+          it "node name is not specified" do
+            expect(command.node_name).to eq(nil)
+            expect(context.node_name).to eq(nil)
+          end
+
+          it "sets the cookbook path to CWD" do
+            # this is cookbook_path in the chef sense, a directory with cookbooks in it.
+            expect(command.provisioning_cookbook_path).to eq(Dir.pwd)
+          end
+
+          it "sets the cookbook name to 'provision'" do
+            expect(command.provisioning_cookbook_name).to eq('provision')
+          end
+
+          it "sets the recipe to 'default'" do
+            expect(command.recipe).to eq("default")
+            expect(command.chef_runner.run_list).to eq(["recipe[provision::default]"])
+          end
+
+          it "sets the default action to converge" do
+            expect(command.default_action).to eq(:converge)
+            expect(context.action).to eq(:converge)
+          end
+
+        end
+
+        context "with -n NODE_NAME" do
+
+          let(:extra_params) { %w[ -n example-node ] }
+
+          it "sets the default requested node name" do
+            expect(command.node_name).to eq("example-node")
+            expect(context.node_name).to eq("example-node")
+          end
+
+        end
+
+        context "with --cookbook COOKBOOK_PATH" do
+
+          let(:extra_params) { %w[ --cookbook ~/mystuff/my-provision-cookbook ] }
+
+          let(:expected_cookbook_path) { File.expand_path("~/mystuff") }
+          let(:expected_cookbook_name) { "my-provision-cookbook" }
+
+          it "sets the cookbook path" do
+            # this is cookbook_path in the chef sense, a directory with cookbooks in it.
+            expect(command.provisioning_cookbook_path).to eq(expected_cookbook_path)
+          end
+
+          it "sets the cookbook name" do
+            expect(command.provisioning_cookbook_name).to eq(expected_cookbook_name)
+          end
+
+        end
+
+        context "with -c CONFIG_FILE" do
+
+          let(:config_arg) { "~/somewhere_else/knife.rb" }
+
+          let(:extra_params) { [ "-c", config_arg ] }
+
+          it "loads config from the specified location" do
+            # The configurable module uses config[:config_file]
+            expect(command.config[:config_file]).to eq("~/somewhere_else/knife.rb")
+          end
+
+        end
+
+        context "with -r MACHINE_RECIPE" do
+
+          let(:extra_params) { %w[ -r ec2cluster ] }
+
+          it "sets the recipe to run as specified" do
+            expect(command.recipe).to eq("ec2cluster")
+            expect(command.chef_runner.run_list).to eq(["recipe[provision::ec2cluster]"])
+          end
+
+        end
+
+        context "with -d" do
+
+          let(:extra_params) { %w[ -d ] }
+
+          it "sets the default action to destroy" do
+            expect(command.default_action).to eq(:destroy)
+            expect(context.action).to eq(:destroy)
+          end
+
+        end
+
+      end # shared examples
+
+      context "when --no-policy is given" do
+
+        before do
+          allow(chef_config_loader).to receive(:load)
+          allow(command).to receive(:push).and_return(push_service)
+
+          command.apply_params!(params)
+          command.setup_context
+        end
+
+        let(:extra_params) { [] }
+        let(:params) { %w[ --no-policy ] + extra_params }
+
+        it "disables policyfile integration" do
+          expect(command.enable_policyfile?).to be(false)
+        end
+
+        include_examples "common_optional_options"
+
+      end # when --no-policy is given
+
+      context "when --sync POLICYFILE argument is given" do
+
+        let(:policy_data) { { "name" => "myapp" } }
+
+        before do
+          allow(chef_config_loader).to receive(:load)
+
+          allow(ChefDK::PolicyfileServices::Push).to receive(:new).
+            with(policyfile: given_policyfile_path, ui: ui, policy_group: given_policy_group, config: chef_config, root_dir: Dir.pwd).
+            and_return(push_service)
+
+          allow(push_service).to receive(:policy_data).and_return(policy_data)
+
+          command.apply_params!(params)
+          command.setup_context
+        end
+
+        context "with explicit policyfile relative path" do
+
+          let(:given_policyfile_path) { "policies/OtherPolicy.rb" }
+
+          let(:given_policy_group) { "some-policy-group" }
+
+          let(:params) { [ given_policy_group, '--sync', given_policyfile_path ] }
+
+          it "sets policy group" do
+            expect(command.policy_group).to eq(given_policy_group)
+            expect(context.policy_group).to eq(given_policy_group)
+          end
+
+          it "sets policy name" do
+            expect(command.policy_name).to eq("myapp")
+            expect(context.policy_name).to eq("myapp")
+          end
+
+        end
+
+        context "with implicit policyfile relative path" do
+
+          let(:given_policyfile_path) { nil }
+
+          let(:given_policy_group) { "some-policy-group" }
+
+          let(:extra_params) { [] }
+
+          let(:params) { [ given_policy_group, '--sync' ] + extra_params }
+
+          it "sets policy group" do
+            expect(command.policy_group).to eq(given_policy_group)
+            expect(context.policy_group).to eq(given_policy_group)
+          end
+
+          it "sets policy name" do
+            expect(command.policy_name).to eq("myapp")
+            expect(context.policy_name).to eq("myapp")
+          end
+
+          include_examples "common_optional_options"
+
+        end
+
+      end # when --sync POLICYFILE argument is given
+
+      context "when a --policy-name is given" do
+
+        let(:given_policy_group) { "some-policy-group" }
+
+        let(:extra_params) { [] }
+
+        let(:params) { [ given_policy_group, '--policy-name', "myapp" ] + extra_params }
+
+        before do
+          command.apply_params!(params)
+          command.setup_context
+        end
+
+        it "sets policy group" do
+          expect(command.policy_group).to eq(given_policy_group)
+          expect(context.policy_group).to eq(given_policy_group)
+        end
+
+        it "sets policy name" do
+          expect(command.policy_name).to eq("myapp")
+          expect(context.policy_name).to eq("myapp")
+        end
+
+        include_examples "common_optional_options"
+
+      end
+    end
+
+  end
+
+  describe "running the provision cookbook" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    before do
+      allow(chef_config_loader).to receive(:load)
+      allow(command).to receive(:push).and_return(push_service)
+      command.ui = ui
+    end
+
+    let(:provision_cookbook_path) { File.expand_path("provision", Dir.pwd) }
+    let(:provision_recipe_path) { File.join(provision_cookbook_path, "recipes", "default.rb") }
+
+    let(:chef_runner) { instance_double("ChefDK::ChefRunner") }
+
+    let(:params) { %w[ policygroup --sync ] }
+
+    context "when the provision cookbook doesn't exist" do
+
+      before do
+        allow(File).to receive(:exist?).with(provision_cookbook_path).and_return(false)
+      end
+
+      it "prints an error and exits non-zero" do
+        expect(command.run(params)).to eq(1)
+        expect(ui.output).to include("Provisioning cookbook not found at path #{provision_cookbook_path}")
+      end
+
+    end
+
+    context "when the provision cookbook doesn't have the requested recipe" do
+
+      before do
+        allow(File).to receive(:exist?).with(provision_cookbook_path).and_return(true)
+        allow(File).to receive(:exist?).with(provision_recipe_path).and_return(false)
+      end
+
+      it "prints an error and exits non-zero" do
+        expect(command.run(params)).to eq(1)
+        expect(ui.output).to include("Provisioning recipe not found at path #{provision_recipe_path}")
+      end
+
+    end
+
+    context "when the policyfile upload fails" do
+
+      let(:backtrace) { caller[0...3] }
+
+      let(:cause) do
+        e = StandardError.new("some operation failed")
+        e.set_backtrace(backtrace)
+        e
+      end
+
+      let(:exception) do
+        ChefDK::PolicyfilePushError.new("push failed", cause)
+      end
+
+      before do
+        allow(File).to receive(:exist?).with(provision_cookbook_path).and_return(true)
+        allow(File).to receive(:exist?).with(provision_recipe_path).and_return(true)
+
+        expect(push_service).to receive(:run).and_raise(exception)
+      end
+
+      it "prints an error and exits non-zero" do
+          expected_output=<<-E
+Error: push failed
+Reason: (StandardError) some operation failed
+
+E
+        expect(command.run(params)).to eq(1)
+        expect(ui.output).to include(expected_output)
+      end
+
+    end
+
+    context "when the chef run fails" do
+
+      let(:base_exception) { StandardError.new("Something went wrong") }
+      let(:exception) { ChefDK::ChefConvergeError.new("Chef failed to converge: #{base_exception}", base_exception) }
+
+      let(:policy_data) { { "name" => "myapp" } }
+
+      before do
+        allow(File).to receive(:exist?).with(provision_cookbook_path).and_return(true)
+        allow(File).to receive(:exist?).with(provision_recipe_path).and_return(true)
+
+        allow(push_service).to receive(:policy_data).and_return(policy_data)
+
+        expect(push_service).to receive(:run)
+
+        allow(command).to receive(:chef_runner).and_return(chef_runner)
+        allow(chef_runner).to receive(:cookbook_path).and_return(Dir.pwd)
+        expect(chef_runner).to receive(:converge).and_raise(base_exception)
+      end
+
+      it "prints an error and exits non-zero", pending: "Add #reason and inspection code to ChefConvergeError" do
+        expect(command.run(params)).to eq(1)
+        # TODO: need to handle the nested exception that ChefConvergeError includes.
+        # it should be printed when given the -D debug argument.
+        # That arg might also need to set chef to debug?
+        expect(ui.output).to include("Error: Chef failed to converge")
+        expect(ui.output).to include("Reason: (StandardError) Something went wrong")
+      end
+
+    end
+
+    context "when the chef run is successful" do
+
+      before do
+        allow(File).to receive(:exist?).with(provision_cookbook_path).and_return(true)
+        allow(File).to receive(:exist?).with(provision_recipe_path).and_return(true)
+        allow(command).to receive(:chef_runner).and_return(chef_runner)
+        allow(chef_runner).to receive(:cookbook_path).and_return(Dir.pwd)
+
+        expect(chef_runner).to receive(:converge)
+      end
+
+      context "when using --no-policy" do
+
+        let(:params) { %w[ --no-policy ] }
+
+        it "exits 0" do
+          return_value = command.run(params)
+          expect(ui.output).to eq("")
+          expect(return_value).to eq(0)
+        end
+
+      end
+
+      context "with --policy-name" do
+
+        let(:params) { %w[ policygroup --policy-name otherapp ] }
+
+        it "exits 0" do
+          return_value = command.run(params)
+          expect(ui.output).to eq("")
+          expect(return_value).to eq(0)
+        end
+      end
+
+      context "with --sync" do
+
+        let(:policy_data) { { "name" => "myapp" } }
+
+        before do
+          allow(push_service).to receive(:policy_data).and_return(policy_data)
+          # TODO: having doubts about this, do we *always* want to push? What
+          # if you're adding a new thing to an existing cluster?
+          expect(push_service).to receive(:run)
+        end
+
+        it "exits 0" do
+          return_value = command.run(params)
+          expect(ui.output).to eq("")
+          expect(return_value).to eq(0)
+        end
+
+      end
+
+    end
+
+  end
+end
+

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -467,8 +467,6 @@ E
 
         before do
           allow(push_service).to receive(:policy_data).and_return(policy_data)
-          # TODO: having doubts about this, do we *always* want to push? What
-          # if you're adding a new thing to an existing cluster?
           expect(push_service).to receive(:run)
         end
 


### PR DESCRIPTION
Adds a `chef provision` command to ChefDK. I created this because, when I was working on a Policyfile "walkthrough" blog post, I had no good way to provision production-y machines (which I needed to properly demonstrate how cookbook "versioning" works in Policyfiles). I mostly like how Chef Provisioning works but I wanted some command line integration for convenience.

For now, I'm considering this an experimental feature. It covers my use cases but I'm only scratching the surface of what you can do with Chef Provisioning, so it's possible that some design decision I made will not produce a good user experience for many cases, therefore I want to explicitly reserve the right to make radically breaking changes for a little while. Once this is shipped I'll solicit feedback and we'll see how it goes. When everything seems stable, I'll take off the warning and add a complementary cookbook generator.

@chef/client-core 