### PR TITLE
Remove extra whitespace from generated license headers

### DIFF
--- a/lib/chef-dk/generator.rb
+++ b/lib/chef-dk/generator.rb
@@ -151,7 +151,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 EOH
         end
         if comment
-          result.gsub(/^/m, "#{comment} ")
+          result.gsub!(/^/m, "#{comment} ")
+          result.gsub(/\n#{comment} \n/, "\n#{comment}\n")
         else
           result
         end


### PR DESCRIPTION
Should fix #377 

Would love some feedback on this because I am not really satisfied with the extra regex