### PR TITLE
Added kitchen files to chefignore in code generator

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -53,6 +53,8 @@ test/*
 features/*
 Guardfile
 Procfile
+.kitchen
+.kitchen.yml
 
 # SCM #
 #######


### PR DESCRIPTION
This fixes an issue where kitchen converge and rspec takes long time to execute, see https://github.com/berkshelf/berkshelf/issues/1403
