### PR TITLE
Don't error when profiling an unborn branch

### DIFF
--- a/spec/unit/cookbook_profiler/git_spec.rb
+++ b/spec/unit/cookbook_profiler/git_spec.rb
@@ -25,60 +25,22 @@ describe ChefDK::CookbookProfiler::Git do
 
   include ChefDK::Helpers
 
-  include_context "setup git cookbooks"
-
   let(:git_profiler) do
     ChefDK::CookbookProfiler::Git.new(cookbook_path)
   end
 
-  def edit_repo
-    with_file(File.join(cookbook_path, "README.md"), "ab+") { |f| f.puts "some unpublished changes" }
-  end
+  context "with cookbooks in a valid git repo" do
 
-  context "given a clean repo with no remotes" do
+    include_context "setup git cookbooks"
 
-    it "reports that the repo has no remotes" do
-      expect(git_profiler.remote).to be_nil
+    def edit_repo
+      with_file(File.join(cookbook_path, "README.md"), "ab+") { |f| f.puts "some unpublished changes" }
     end
 
-    it "determines the rev of the repo" do
-      expect(git_profiler.revision).to eq(current_rev)
-    end
+    context "given a clean repo with no remotes" do
 
-    it "reports that the repo is clean" do
-      expect(git_profiler.clean?).to be true
-    end
-
-    it "reports that the commits are unpublished" do
-      expect(git_profiler.unpublished_commits?).to be true
-    end
-
-    it "reports that no remotes have the commits" do
-      expect(git_profiler.synchronized_remotes).to eq([])
-    end
-
-  end
-
-  context "when the remote is a local branch" do
-
-    before do
-      allow(git_profiler).to receive(:remote_name).and_return(".")
-    end
-
-    it "reports that the repo doesn't have a remote" do
-      expect(git_profiler.have_remote?).to be(false)
-    end
-
-  end
-
-  context "with a remote configured" do
-
-    include_context "setup git cookbook remote"
-
-    context "given a clean repo with all commits published to the remote" do
-
-      it "determines the remote for the repo" do
-        expect(git_profiler.remote).to eq(remote_url)
+      it "reports that the repo has no remotes" do
+        expect(git_profiler.remote).to be_nil
       end
 
       it "determines the rev of the repo" do
@@ -89,30 +51,7 @@ describe ChefDK::CookbookProfiler::Git do
         expect(git_profiler.clean?).to be true
       end
 
-      it "reports that all commits are published to the upstream" do
-        expect(git_profiler.unpublished_commits?).to be false
-      end
-
-      it "lists the remotes that commits are published to" do
-        expect(git_profiler.synchronized_remotes).to eq(%w[origin/master])
-      end
-
-    end
-
-    context "given a clean repo with unpublished changes" do
-
-      before do
-        edit_repo
-        system_command('git config --local user.name "Alice"', cwd: cookbook_path).error!
-        system_command('git config --local user.email "alice@example.com"', cwd: cookbook_path).error!
-        system_command('git commit -a -m "update readme" --author "Alice <alice@example.com>"', cwd: cookbook_path).error!
-      end
-
-      it "reports that the repo is clean" do
-        expect(git_profiler.clean?).to be true
-      end
-
-      it "reports that there are unpublished changes" do
+      it "reports that the commits are unpublished" do
         expect(git_profiler.unpublished_commits?).to be true
       end
 
@@ -121,18 +60,116 @@ describe ChefDK::CookbookProfiler::Git do
       end
 
     end
+
+    context "when the remote is a local branch" do
+
+      before do
+        allow(git_profiler).to receive(:remote_name).and_return(".")
+      end
+
+      it "reports that the repo doesn't have a remote" do
+        expect(git_profiler.have_remote?).to be(false)
+      end
+
+    end
+
+    context "with a remote configured" do
+
+      include_context "setup git cookbook remote"
+
+      context "given a clean repo with all commits published to the remote" do
+
+        it "determines the remote for the repo" do
+          expect(git_profiler.remote).to eq(remote_url)
+        end
+
+        it "determines the rev of the repo" do
+          expect(git_profiler.revision).to eq(current_rev)
+        end
+
+        it "reports that the repo is clean" do
+          expect(git_profiler.clean?).to be true
+        end
+
+        it "reports that all commits are published to the upstream" do
+          expect(git_profiler.unpublished_commits?).to be false
+        end
+
+        it "lists the remotes that commits are published to" do
+          expect(git_profiler.synchronized_remotes).to eq(%w[origin/master])
+        end
+
+      end
+
+      context "given a clean repo with unpublished changes" do
+
+        before do
+          edit_repo
+          system_command('git config --local user.name "Alice"', cwd: cookbook_path).error!
+          system_command('git config --local user.email "alice@example.com"', cwd: cookbook_path).error!
+          system_command('git commit -a -m "update readme" --author "Alice <alice@example.com>"', cwd: cookbook_path).error!
+        end
+
+        it "reports that the repo is clean" do
+          expect(git_profiler.clean?).to be true
+        end
+
+        it "reports that there are unpublished changes" do
+          expect(git_profiler.unpublished_commits?).to be true
+        end
+
+        it "reports that no remotes have the commits" do
+          expect(git_profiler.synchronized_remotes).to eq([])
+        end
+
+      end
+    end
+
+    context "given a dirty repo" do
+
+      before do
+        edit_repo
+      end
+
+      it "reports that the repo is dirty" do
+        expect(git_profiler.clean?).to be false
+      end
+
+    end
+
   end
 
-  context "given a dirty repo" do
+  context "given a repo on an unborn master branch" do
+
+    let(:cookbook_path) { File.join(tempdir, "unborn") }
+
+    let(:profile_data) { git_profiler.profile_data }
 
     before do
-      edit_repo
+      reset_tempdir
+      FileUtils.mkdir_p(cookbook_path)
+      system_command("git init .", cwd: cookbook_path).error!
     end
 
-    it "reports that the repo is dirty" do
-      expect(git_profiler.clean?).to be false
+    it "does not error when profiling the cookbook" do
+      expect { git_profiler.profile_data }.to_not raise_error
     end
 
+    it "has a nil revision" do
+      expect(profile_data["revision"]).to be_nil
+    end
+
+    it "has no remote" do
+      expect(profile_data["remote"]).to be_nil
+    end
+
+    it "has no synchronized remote branches" do
+      expect(profile_data["synchronized_remote_branches"]).to eq([])
+    end
+
+    it "is not published" do
+      expect(profile_data["published"]).to be(false)
+    end
   end
 
 end


### PR DESCRIPTION
As described in #364 when you create a repo (`git init`) but don't have a commit, you're on an unborn master branch. Commands such as `git rev-parse HEAD` will fail in such a scenario, which causes most Policyfile commands to fail (when attempting to extract git information about the cookbook). There does not seem to be a canonical way to detect that you're on an unborn branch, git uses the same exit code for all failures, and the error messages printed to stderr do not seem to be stable across git versions. So I settled on feeding the output of `git symbolic-ref -q HEAD` to `show-ref --verify $SYMBOLIC_REF` (we expect the first command to succeed and the second command to fail on an unborn branch).

fixes #364 

@chef/client-core @tyler-ball 