### PR TITLE
Pinning chef-provisioning to 1.1.1

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -51,7 +51,11 @@ Gem::Specification.new do |gem|
   gem.add_dependency "paint", "~> 1.0"
 
   # Chef Provisioning, used by the `chef provision` command:
-  gem.add_dependency "chef-provisioning", "~> 1.1"
+  # chef-provisioning 1.2 has a dependency on winrm 1.3, which
+  # conflicts with the current version of knife-windows.  We can
+  # pin to `~> 1.2` when we are packaging knife-windows 1.0 in
+  # the ChefDK.
+  gem.add_dependency "chef-provisioning", "~> 1.1.1"
 
   %w(rspec-core rspec-expectations rspec-mocks).each do |dev_gem|
     gem.add_development_dependency dev_gem, "~> 3.0"


### PR DESCRIPTION
Later versions of chef-provisioning will depend on winrm 1.3, which conflicts with knife-windows (0.8.4 depends on winrm 1.2) when bundled in the ChefDK.  We can include chef-provisioning 1.2 when knife-windows 1.0 is released because both of those will depend on winrm 1.3

\cc @chef/client-maintainers 