### PR TITLE
Fixes ambiguous term 'policy'

### DIFF
--- a/lib/chef-dk/command/generate.rb
+++ b/lib/chef-dk/command/generate.rb
@@ -50,7 +50,7 @@ module ChefDK
       generator(:template, :Template, "Generate a file template")
       generator(:file, :CookbookFile, "Generate a cookbook file")
       generator(:lwrp, :LWRP, "Generate a lightweight resource/provider")
-      generator(:repo, :Repo, "Generate a Chef policy repository")
+      generator(:repo, :Repo, "Generate a Chef code repository")
       generator(:policyfile, :Policyfile, "Generate a Policyfile for use with the install/push commands (experimental)")
 
       def self.banner_headline


### PR DESCRIPTION
A repo may be created with "-p" for "policy only" (i.e. everything but cookbooks).  However, chefdk also generates repos containing cookbooks without the "-p" option.  The term 'policy' is misleading in this context.

Cookbooks are sometimes referred to as "policy" is some versions of Chef Training.  This semantic fix also pulls the functional description of the 'chef generate repo' command in-line with where Chef Training terminology is headed.  Students find the description of "policy" confusing and too similar to "Policyfile".  Chef Training is now using the term "desired state" or "Chef code" rather than "policy".

So, really, what this command does (without the -p flag) is create a repo for your Chef code.