### PR TITLE
Add basic smoke tests for the Delivery CLI

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -96,13 +96,16 @@ module ChefDK
         c.smoke_test { run_in_tmpdir("kitchen init") }
       end
 
-      add_component "delivery-cli" do |c|
-        # There is no base_dir as delivery-cli is a single binary in
-        # `/opt/chefdk/bin`.
-        c.base_dir = "chef-dk"
-        c.smoke_test do
-          tmpdir do |cwd|
-            sh!("delivery setup --user=shipit --server=delivery.shipit.io --ent=chef --org=squirrels", cwd: cwd)
+      # We only ship delivery-cli on *nix only ATM
+      unless Chef::Platform.windows?
+        add_component "delivery-cli" do |c|
+          # There is no base_dir as delivery-cli is a single binary in
+          # `/opt/chefdk/bin`.
+          c.base_dir = "chef-dk"
+          c.smoke_test do
+            tmpdir do |cwd|
+              sh!("delivery setup --user=shipit --server=delivery.shipit.io --ent=chef --org=squirrels", cwd: cwd)
+            end
           end
         end
       end
@@ -199,6 +202,9 @@ end
 
             sh!("/usr/bin/chef-client -v")
             sh!("/usr/bin/chef-solo -v")
+
+            # The Delivery CLI does not have a `--version` flag yet!
+            sh!("/usr/bin/delivery --help") unless Chef::Platform.windows?
 
             # In `knife`, `knife -v` follows a different code path that skips
             # command/plugin loading; `knife -h` loads commands and plugins, but

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -96,6 +96,17 @@ module ChefDK
         c.smoke_test { run_in_tmpdir("kitchen init") }
       end
 
+      add_component "delivery-cli" do |c|
+        # There is no base_dir as delivery-cli is a single binary in
+        # `/opt/chefdk/bin`.
+        c.base_dir = "chef-dk"
+        c.smoke_test do
+          tmpdir do |cwd|
+            sh!("delivery setup --user=shipit --server=delivery.shipit.io --ent=chef --org=squirrels", cwd: cwd)
+          end
+        end
+      end
+
       add_component "chef-client" do |c|
         c.base_dir = "chef"
         c.unit_test { sh("bundle exec rspec -fp -t '~volatile_from_verify' spec/unit") }

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -28,6 +28,20 @@ module Gem
 end
 
 describe ChefDK::Command::Verify do
+  DEFAULT_COMPONENTS = %w(
+    berkshelf
+    test-kitchen
+    delivery-cli
+    chef-client
+    chef-dk
+    chefspec
+    rubocop
+    fauxhai
+    knife-spork
+    kitchen-vagrant
+    package\ installation
+  )
+
   let(:command_instance) { ChefDK::Command::Verify.new() }
 
   let(:command_options) { [] }
@@ -35,25 +49,14 @@ describe ChefDK::Command::Verify do
   let(:components) { {} }
 
   let(:default_components) do
-    [
-      "berkshelf",
-      "test-kitchen",
-      "chef-client",
-      "chef-dk",
-      "chefspec",
-      "rubocop",
-      "fauxhai",
-      "knife-spork",
-      "kitchen-vagrant",
-      "package installation"
-    ]
+    DEFAULT_COMPONENTS
   end
 
   def run_command(expected_exit_code)
     expect(command_instance.run(command_options)).to eq(expected_exit_code)
   end
 
-  it "defines berks, tk, chef and chef-dk components by default" do
+  it "defines #{DEFAULT_COMPONENTS.join(', ')} components by default" do
     expect(command_instance.components).not_to be_empty
     expect(command_instance.components.map(&:name)).to match_array(default_components)
   end

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -31,7 +31,6 @@ describe ChefDK::Command::Verify do
   DEFAULT_COMPONENTS = %w(
     berkshelf
     test-kitchen
-    delivery-cli
     chef-client
     chef-dk
     chefspec
@@ -41,6 +40,9 @@ describe ChefDK::Command::Verify do
     kitchen-vagrant
     package\ installation
   )
+
+  # We only ship delivery-cli on *nix only ATM
+  DEFAULT_COMPONENTS << "delivery-cli" unless Chef::Platform.windows?
 
   let(:command_instance) { ChefDK::Command::Verify.new() }
 


### PR DESCRIPTION
These changes are in service of https://github.com/chef/omnibus-chef/pull/394.

/cc @chef/ociv @chef/delivery @chef/client-core @fnichol @tyler-ball @cwebberOps @adamhjk