### PR TITLE
Add `chef show-policy` command

### DIFF
--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -1,0 +1,414 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/ui'
+require 'chef-dk/configurable'
+require 'set'
+
+module ChefDK
+  module Command
+
+    class RevIDLockDataMap
+
+      attr_reader :policy_name
+      attr_reader :lock_info_by_rev_id
+
+      def initialize(policy_name, lock_info_by_rev_id)
+        @policy_name = policy_name
+        @lock_info_by_rev_id = lock_info_by_rev_id
+      end
+
+
+      def cb_info_for(rev_id, cookbook_name)
+        lock = lock_info_by_rev_id[rev_id]
+        cookbook_lock = lock["cookbook_locks"][cookbook_name]
+
+        if cookbook_lock
+          [cookbook_lock["version"], cookbook_lock["identifier"] ]
+        else
+          nil
+        end
+      end
+
+      def cbs_with_differing_ids
+        cbs_with_differing_ids = Set.new
+        all_cookbook_names.each do |cookbook_name|
+          all_identifiers = lock_info_by_rev_id.inject(Set.new) do |id_set, (_rev_id, rev_info)|
+            cookbook_lock = rev_info["cookbook_locks"][cookbook_name]
+            identifier = cookbook_lock && cookbook_lock["identifier"]
+            id_set << identifier
+          end
+          cbs_with_differing_ids << cookbook_name if all_identifiers.size > 1
+        end
+        cbs_with_differing_ids
+      end
+
+      def all_cookbook_names
+        lock_info_by_rev_id.inject(Set.new) do |cb_set, (_rev_id, rev_info)|
+          cb_set.merge(rev_info["cookbook_locks"].keys)
+        end
+      end
+    end
+
+    class PolicyGroupRevIDMap
+
+      attr_reader :policy_name
+      attr_reader :revision_ids_by_group
+
+      def initialize(policy_name, revision_ids_by_group)
+        @policy_name = policy_name
+        @revision_ids_by_group = revision_ids_by_group
+      end
+
+      def unique_revision_ids
+        revision_ids_by_group.values.uniq
+      end
+
+      def policy_group_names
+        revision_ids_by_group.keys
+      end
+
+      def max_group_name_length
+        policy_group_names.map(&:size).max
+      end
+
+      def format_revision_ids
+        revision_ids_by_group.inject({}) do |map, (group_name, rev_id)|
+          map[group_name] = yield rev_id
+          map
+        end
+      end
+
+      def empty?
+        policy_group_names.empty?
+      end
+
+      def each
+        revision_ids_by_group.each do |group_name, rev_id|
+          yield group_name, rev_id
+        end
+      end
+    end
+
+    class PolicyInfoFetcher
+
+      attr_accessor :policies_by_name
+
+      # A Hash with the following format:
+      #   "dev" => {
+      #     "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+      #     "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+      #     "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+      #   }
+      attr_accessor :policies_by_group
+
+      attr_accessor :policy_lock_content
+
+      def initialize
+        @policies_by_name = {}
+        @policies_by_group = {}
+        @policy_lock_content = {}
+        @active_revisions = nil
+      end
+
+      def set!(policies_by_name, policies_by_group)
+        @policies_by_name = policies_by_name
+        @policies_by_group = policies_by_group
+        @active_revisions = nil
+      end
+
+      def revision_info_for(policy_name, _revision_id_list)
+        RevIDLockDataMap.new(policy_name, policy_lock_content[policy_name])
+      end
+
+      def revision_ids_by_group_for_each_policy
+        policies_by_name.each do |policy_name, _policies|
+          rev_id_by_group = revision_ids_by_group_for(policy_name)
+          yield policy_name, rev_id_by_group
+        end
+      end
+
+      def revision_ids_by_group_for(policy_name)
+        map = policies_by_group.inject({}) do |rev_id_map, (group_name, rev_id_map_for_group)|
+          rev_id_map[group_name] = rev_id_map_for_group[policy_name]
+          rev_id_map
+        end
+        PolicyGroupRevIDMap.new(policy_name, map)
+      end
+
+      def orphaned_revisions(policy_name)
+        orphans = []
+        policies_by_name[policy_name].each do |rev_id, _data|
+          orphans << rev_id unless active_revisions.include?(rev_id)
+        end
+        orphans
+      end
+
+      def active_revisions
+        @active_revisions ||= policies_by_group.inject(Set.new) do |set, (_group, policy_name_rev_id_map)|
+          policy_name_rev_id_map.each do |policy_name, rev_id|
+            set << rev_id
+          end
+          set
+        end
+      end
+
+      def empty?
+        policies_by_name.empty? && policies_by_group.empty?
+      end
+
+    end
+
+    class ReportPrinter
+
+      attr_reader :ui
+
+      def initialize(ui)
+        @ui = ui
+      end
+
+      def h1(heading)
+        ui.msg(heading)
+        ui.msg("=" * heading.size)
+        ui.msg("")
+      end
+
+      def h2(heading)
+        ui.msg(heading)
+        ui.msg("-" * heading.size)
+        ui.msg("")
+      end
+
+      def table_list(items)
+        left_justify_size = items.keys.map(&:size).max.to_i + 2
+        items.each do |name, value|
+          justified_name = "#{name}:".ljust(left_justify_size)
+          ui.msg("* #{justified_name} #{value}")
+        end
+
+        ui.msg("")
+      end
+
+      def list(items)
+        items.each { |item| ui.msg("* #{item}") }
+        ui.msg("")
+      end
+    end
+
+    class ShowPolicy < Base
+
+      # TODO: banner
+
+      option :summary_diff,
+        short:        "-s",
+        long:         "--summary-diff",
+        description:  "Summarize differences in policy revisions",
+        default:      false
+
+      option :show_orphans,
+        short:        "-o",
+        long:         "--orphans",
+        description:  "Show policy revisions that are unassigned",
+        default:      false
+
+      option :config_file,
+        short:        "-c CONFIG_FILE",
+        long:         "--config CONFIG_FILE",
+        description:  "Path to configuration file"
+
+      option :debug,
+        short:        "-D",
+        long:         "--debug",
+        description:  "Enable stacktraces and other debug output",
+        default:      false
+
+      include Configurable
+
+      attr_accessor :ui
+
+      attr_reader :policy_name
+
+      def initialize(*args)
+        super
+        @show_all_policies = nil
+        @policy_name = nil
+        @ui = UI.new
+      end
+
+      def report
+        @report ||= ReportPrinter.new(ui)
+      end
+
+      def run(params)
+        return 1 unless apply_params!(params)
+
+        if show_all_policies?
+          display_all_policies
+        else
+          display_single_policy
+        end
+
+        0
+      end
+
+      def display_all_policies
+        if policy_info_fetcher.empty?
+          ui.err("No policies or policy groups exist on the server")
+          return
+        end
+        if policy_info_fetcher.policies_by_name.empty?
+          ui.err("No policies exist on the server")
+          return
+        end
+        policy_info_fetcher.revision_ids_by_group_for_each_policy do |policy_name, rev_id_by_group|
+          report.h1(policy_name)
+
+          if rev_id_by_group.empty?
+            ui.err("Policy #{policy_name} is not assigned to any groups")
+            ui.err("")
+          else
+            rev_ids_for_report = format_rev_ids_for_report(rev_id_by_group)
+            report.table_list(rev_ids_for_report)
+          end
+
+          if show_orphans?
+            orphans = policy_info_fetcher.orphaned_revisions(policy_name)
+
+            unless orphans.empty?
+              report.h2("Orphaned:")
+              formatted_orphans = orphans.map { |id| shorten_rev_id(id) }
+              report.list(formatted_orphans)
+            end
+          end
+        end
+      end
+
+      def display_single_policy
+        report.h1(policy_name)
+        rev_id_by_group = policy_info_fetcher.revision_ids_by_group_for(policy_name)
+
+        if rev_id_by_group.empty?
+          ui.err("No policies named '#{policy_name}' are associated with a policy group")
+          ui.err("")
+        elsif show_summary_diff?
+          unique_rev_ids = rev_id_by_group.unique_revision_ids
+          revision_info = policy_info_fetcher.revision_info_for(policy_name, unique_rev_ids)
+
+          ljust_size = rev_id_by_group.max_group_name_length + 2
+
+          cbs_with_differing_ids = revision_info.cbs_with_differing_ids
+
+          rev_id_by_group.each do |group_name, rev_id|
+            heading = "#{group_name}:".ljust(ljust_size) + shorten_rev_id(rev_id)
+            report.h2(heading)
+
+            differing_cbs_version_info = cbs_with_differing_ids.inject({}) do |cb_version_info, cb_name|
+
+              version, identifier = revision_info.cb_info_for(rev_id, cb_name)
+
+              cb_info_for_report =
+                if !version.nil?
+                  "#{version} (#{shorten_rev_id(identifier)})"
+                else
+                  "*NONE*"
+                end
+
+              cb_version_info[cb_name] = cb_info_for_report
+
+              cb_version_info
+            end
+
+            report.table_list(differing_cbs_version_info)
+          end
+
+        else
+          rev_ids_for_report = format_rev_ids_for_report(rev_id_by_group)
+          report.table_list(rev_ids_for_report)
+        end
+
+        if show_orphans?
+          orphans = policy_info_fetcher.orphaned_revisions(policy_name)
+
+          unless orphans.empty?
+            report.h2("Orphaned:")
+            formatted_orphans = orphans.map { |id| shorten_rev_id(id) }
+            report.list(formatted_orphans)
+          end
+        end
+      end
+
+      def shorten_rev_id(revision_id)
+        revision_id[0,10]
+      end
+
+      def policy_info_fetcher
+        @policy_info_fetcher ||= PolicyInfoFetcher.new
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def show_all_policies?
+        @show_all_policies
+      end
+
+      def show_summary_diff?
+        !!config[:summary_diff]
+      end
+
+      def show_orphans?
+        config[:show_orphans]
+      end
+
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+
+        if remaining_args.empty? && show_summary_diff?
+          ui.err("The --summary-diff option can only be used when showing a single policy")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif remaining_args.empty?
+          @policy_name = nil
+          @show_all_policies = true
+          true
+        elsif remaining_args.size == 1
+          @policy_name = remaining_args.first
+          @show_all_policies = false
+          true
+        else
+          ui.err("Too many arguments")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        end
+      end
+
+      private
+
+      def format_rev_ids_for_report(rev_id_by_group)
+        rev_id_by_group.format_revision_ids do |rev_id|
+          rev_id ? rev_id[0,10] : "*NOT APPLIED*"
+        end
+      end
+
+    end
+  end
+end
+

--- a/spec/unit/command/show_policy_spec.rb
+++ b/spec/unit/command/show_policy_spec.rb
@@ -1,0 +1,839 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/show_policy'
+
+describe ChefDK::Command::ShowPolicy do
+
+  it_behaves_like "a command with a UI object"
+
+  let(:command) do
+    described_class.new
+  end
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:chef_config) { double("Chef::Config") }
+
+  # nil means the config loader will do the default path lookup
+  let(:config_arg) { nil }
+
+  before do
+    stub_const("Chef::Config", chef_config)
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "parsing args and options" do
+    let(:params) { [] }
+
+    before do
+      command.apply_params!(params)
+    end
+
+    context "with no params" do
+
+      it "disables debug by default" do
+        expect(command.debug?).to be(false)
+      end
+
+      it "is configured to show all policies across all groups" do
+        expect(command.show_all_policies?).to be(true)
+      end
+
+      it "disables displaying orphans" do
+        expect(command.show_orphans?).to be(false)
+      end
+
+    end
+
+    context "when debug mode is set" do
+
+      let(:params) { [ "-D" ] }
+
+      it "enables debug" do
+        expect(command.debug?).to be(true)
+      end
+
+    end
+
+    context "when --show-orphans is given" do
+
+      let(:params) { %w[ -o ] }
+
+      it "enables displaying orphans" do
+        expect(command.show_orphans?).to be(true)
+      end
+
+    end
+
+    context "when given a path to the config" do
+
+      let(:params) { %w[ -c ~/otherstuff/config.rb ] }
+
+      let(:config_arg) { "~/otherstuff/config.rb" }
+
+      before do
+        expect(chef_config_loader).to receive(:load)
+      end
+
+      it "reads the chef/knife config" do
+        expect(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+        expect(command.chef_config).to eq(chef_config)
+      end
+
+    end
+
+    context "when given a policy name" do
+
+      let(:params) { %w[ appserver ] }
+
+      it "is not configured to show all policies" do
+        expect(command.show_all_policies?).to be(false)
+      end
+
+      it "is configured to show the given policy" do
+        expect(command.policy_name).to eq("appserver")
+      end
+
+      context "and the summary diff option `-s`" do
+
+        let(:params) { %w[ appserver -s ] }
+
+        it "enables summary diff output" do
+          expect(command.show_summary_diff?).to be(true)
+        end
+
+      end
+
+    end
+
+  end
+
+  describe "running the command" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    let(:policy_info) { command.policy_info_fetcher }
+
+    before do
+      command.ui = ui
+    end
+
+    context "when given too many arguments" do
+
+      let(:params) { %w[ appserver chatserver ] }
+
+      it "shows usage and exits" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+
+    context "when the summary diff option is given but no policy name is specified" do
+
+      let(:params) { %w[ -s ] }
+
+      it "prints a message explaining that -s only applies to single policy" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+
+
+    describe "show all" do
+
+      let(:params) { [] }
+
+      let(:policies_by_name) { {} }
+      let(:policies_by_group) { {} }
+
+      before do
+        policy_info.set!(policies_by_name, policies_by_group)
+      end
+
+      context "when an error occurs contacting the server" do
+
+        it "displays the error and exits"
+
+      end
+
+      context "when there are no policies or groups on the server" do
+
+        it "prints a message to stderr that there aren't any policies or groups" do
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq("No policies or policy groups exist on the server\n")
+        end
+
+      end
+
+      context "when there are policies but no groups" do
+
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {}
+            },
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {},
+            },
+            "db" => {
+              "9999999999999999999999999999999999999999999999999999999999999999" => {},
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" => {}
+            }
+          }
+        end
+
+        it "prints a message to stderr that there are no active policies" do
+          expect(command.run(params)).to eq(0)
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+Policy appserver is not assigned to any groups
+
+load-balancer
+=============
+
+Policy load-balancer is not assigned to any groups
+
+db
+==
+
+Policy db is not assigned to any groups
+
+OUTPUT
+          expect(ui.output).to eq(expected_output)
+        end
+
+        context "with orphans shown" do
+
+          let(:params) { %w[ -o ] }
+
+          it "shows all policies as orphaned" do
+            expect(command.run(params)).to eq(0)
+            expected_output = <<-OUTPUT
+appserver
+=========
+
+Policy appserver is not assigned to any groups
+
+Orphaned:
+---------
+
+* 1111111111
+* 2222222222
+
+load-balancer
+=============
+
+Policy load-balancer is not assigned to any groups
+
+Orphaned:
+---------
+
+* 5555555555
+* 6666666666
+
+db
+==
+
+Policy db is not assigned to any groups
+
+Orphaned:
+---------
+
+* 9999999999
+* aaaaaaaaaa
+
+OUTPUT
+            expect(ui.output).to eq(expected_output)
+          end
+        end
+
+      end
+
+      context "when there are groups but no policies" do
+
+        let(:policies_by_group) do
+          {
+            "dev" => {},
+            "staging" => {},
+            "prod" => {}
+          }
+        end
+
+        it "prints a message to stderr and exits" do
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq("No policies exist on the server\n")
+        end
+
+      end
+
+      context "when there is a revision of each kind of policy assigned to every policy group" do
+
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {}
+            },
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {},
+            },
+            "db" => {
+              "9999999999999999999999999999999999999999999999999999999999999999" => {},
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" => {}
+            }
+          }
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+            },
+            "prod" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "6666666666666666666666666666666666666666666666666666666666666666",
+              "db" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        end
+
+        it "shows each policy name, followed by a list of group_name -> revision" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      1111111111
+* staging:  2222222222
+* prod:     2222222222
+
+load-balancer
+=============
+
+* dev:      5555555555
+* staging:  5555555555
+* prod:     6666666666
+
+db
+==
+
+* dev:      9999999999
+* staging:  9999999999
+* prod:     aaaaaaaaaa
+
+OUTPUT
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+
+      context "when there is a revision of each kind of policy assigned to every policy group, plus orphaned policies" do
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {},
+              "3333333333333333333333333333333333333333333333333333333333333333" => {}
+            },
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {},
+              "7777777777777777777777777777777777777777777777777777777777777777" => {}
+            },
+            "db" => {
+              "9999999999999999999999999999999999999999999999999999999999999999" => {},
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" => {},
+              "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" => {}
+            }
+          }
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+            },
+            "prod" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "6666666666666666666666666666666666666666666666666666666666666666",
+              "db" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        end
+
+        it "shows each policy name, followed by a list of group_name -> revision, followed by a list of orphaned policies" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      1111111111
+* staging:  2222222222
+* prod:     2222222222
+
+load-balancer
+=============
+
+* dev:      5555555555
+* staging:  5555555555
+* prod:     6666666666
+
+db
+==
+
+* dev:      9999999999
+* staging:  9999999999
+* prod:     aaaaaaaaaa
+
+OUTPUT
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+
+        context "with orphans shown" do
+
+          let(:params) { %w[ -o ] }
+
+          it "shows each policy name, followed by a list of group_name -> revision, followed by a list of orphaned policies" do
+            expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      1111111111
+* staging:  2222222222
+* prod:     2222222222
+
+Orphaned:
+---------
+
+* 3333333333
+
+load-balancer
+=============
+
+* dev:      5555555555
+* staging:  5555555555
+* prod:     6666666666
+
+Orphaned:
+---------
+
+* 7777777777
+
+db
+==
+
+* dev:      9999999999
+* staging:  9999999999
+* prod:     aaaaaaaaaa
+
+Orphaned:
+---------
+
+* bbbbbbbbbb
+
+OUTPUT
+            expect(command.run(params)).to eq(0)
+            expect(ui.output).to eq(expected_output)
+          end
+
+        end
+      end
+
+      context "when some groups do not have a revision of every policy" do
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {}
+            },
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {},
+            },
+            "db" => {
+              "9999999999999999999999999999999999999999999999999999999999999999" => {},
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" => {}
+            },
+            "memcache" => {
+              "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" => {}
+            }
+          }
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999",
+              "memcache" => "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999",
+              "memcache" => "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            },
+            "prod" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "6666666666666666666666666666666666666666666666666666666666666666",
+              "db" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        end
+
+
+        it "shows each policy name, followed by a list of group_name -> revision, omitting groups that don't have that policy" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      1111111111
+* staging:  2222222222
+* prod:     2222222222
+
+load-balancer
+=============
+
+* dev:      5555555555
+* staging:  5555555555
+* prod:     6666666666
+
+db
+==
+
+* dev:      9999999999
+* staging:  9999999999
+* prod:     aaaaaaaaaa
+
+memcache
+========
+
+* dev:      dddddddddd
+* staging:  dddddddddd
+* prod:     *NOT APPLIED*
+
+OUTPUT
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+    end
+
+    describe "showing a single policy" do
+
+      let(:params) { %w[ appserver ] }
+
+      let(:policies_by_name) { {} }
+      let(:policies_by_group) { {} }
+
+      before do
+        policy_info.set!(policies_by_name, policies_by_group)
+      end
+
+      context "when an error occurs contacting the server" do
+
+        it "displays the error and exits"
+
+      end
+
+      context "when there are no revisions of the policy on the server" do
+
+        let(:policies_by_name) do
+          {}
+        end
+
+        let(:policies_by_group) do
+          {}
+        end
+
+        it "prints a message to stderr that there are no copies of the policy on the server" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+No policies named 'appserver' are associated with a policy group
+
+OUTPUT
+
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+
+      context "when all policies are orphaned and orphans are not shown" do
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {},
+              "3333333333333333333333333333333333333333333333333333333333333333" => {}
+            }
+          }
+
+        end
+
+        let(:policies_by_group) do
+          {}
+        end
+
+        it "explains that no policies are assigned to a group" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+No policies named 'appserver' are associated with a policy group
+
+OUTPUT
+
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+      end
+
+      context "when all policy groups have the same revision of the policy" do
+
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {},
+              "3333333333333333333333333333333333333333333333333333333333333333" => {}
+            }
+          }
+
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222"
+            },
+            "prod" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222"
+            }
+          }
+        end
+        it "lists each of the groups with the associated revision" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      2222222222
+* staging:  2222222222
+* prod:     2222222222
+
+OUTPUT
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+
+      context "when policy groups have revisions with differing cookbooks" do
+
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {},
+              "3333333333333333333333333333333333333333333333333333333333333333" => {}
+            }
+          }
+
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222"
+            },
+            "prod" => {
+              "appserver" => "1111111111111111111111111111111111111111111111111111111111111111"
+            }
+          }
+        end
+
+        it "lists each of the groups with the associated revision" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      2222222222
+* staging:  2222222222
+* prod:     1111111111
+
+OUTPUT
+          expect(command.run(params)).to eq(0)
+          expect(ui.output).to eq(expected_output)
+        end
+
+        context "when the diff summary option is given" do
+
+          let(:appserver_lock_contents_111) do
+            {
+              "cookbook_locks" => {
+                "apache2" => {
+                  "version" => "2.1.3",
+                  "identifier" => "abcdef" + ("0" * 34)
+                },
+                "yum" => {
+                  "version" => "4.5.6",
+                  "identifier" => "123abc" + ("0" * 34)
+                },
+                "apt" => {
+                  "version" => "10.0.0",
+                  "identifier" => "ffffff" + ("0" * 34)
+                }
+
+              }
+            }
+          end
+
+          let(:appserver_lock_contents_222) do
+            {
+              "cookbook_locks" => {
+                "apache2" => {
+                  "version" => "2.0.5",
+                  "identifier" => "aaa123" + ("0" * 34)
+                },
+                "yum" => {
+                  "version" => "4.5.2",
+                  "identifier" => "867530" + ("9" * 34)
+                },
+                "apt" => {
+                  "version" => "10.0.0",
+                  "identifier" => "ffffff" + ("0" * 34)
+                },
+                "other_cookbook" => {
+                  "version" => "9.8.7",
+                  "identifier" => "113113" + ("0" * 34)
+                }
+              }
+            }
+          end
+
+          let(:appserver_lock_content) do
+            {
+              "appserver" => {
+                "1111111111111111111111111111111111111111111111111111111111111111" => appserver_lock_contents_111,
+                "2222222222222222222222222222222222222222222222222222222222222222" => appserver_lock_contents_222,
+              }
+            }
+          end
+
+          let(:params) { %w[ appserver -s ] }
+
+          before do
+            policy_info.policy_lock_content = appserver_lock_content
+          end
+
+          it "lists each of the groups and displays the version and identifier of the differing cookbooks" do
+            expected_output = <<-OUTPUT
+appserver
+=========
+
+dev:     2222222222
+-------------------
+
+* apache2:         2.0.5 (aaa1230000)
+* yum:             4.5.2 (8675309999)
+* other_cookbook:  9.8.7 (1131130000)
+
+staging: 2222222222
+-------------------
+
+* apache2:         2.0.5 (aaa1230000)
+* yum:             4.5.2 (8675309999)
+* other_cookbook:  9.8.7 (1131130000)
+
+prod:    1111111111
+-------------------
+
+* apache2:         2.1.3 (abcdef0000)
+* yum:             4.5.6 (123abc0000)
+* other_cookbook:  *NONE*
+
+OUTPUT
+            expect(command.run(params)).to eq(0)
+            expect(ui.output).to eq(expected_output)
+          end
+        end
+
+        context "when orphans are displayed" do
+
+          let(:params) { %w[ appserver -o ] }
+
+          it "lists each of the groups, then lists the orphaned revisions" do
+            expected_output = <<-OUTPUT
+appserver
+=========
+
+* dev:      2222222222
+* staging:  2222222222
+* prod:     1111111111
+
+Orphaned:
+---------
+
+* 3333333333
+
+OUTPUT
+
+            expect(command.run(params)).to eq(0)
+            expect(ui.output).to eq(expected_output)
+          end
+
+        end
+      end
+
+
+
+    end
+  end
+end
+


### PR DESCRIPTION
The requisite APIs for this don't exist yet so it is not yet usable (and
therefore not added to the command lookup). The work done so far
provides a UI so we know what kind of data the API must provide when
implemented.

Because of the above, I've avoided adding too much unit testing for some of the "lower level" functionality, because it may change when it uses the API for real. The functionality is generally pretty well exercised by the tests for the command though.