### PR TITLE
Provision target host option and arbitrary options

### DIFF
--- a/PROVISION_README.md
+++ b/PROVISION_README.md
@@ -97,6 +97,19 @@ The provisioning context provides the following data:
 * `action`: `:converge`, or `:destroy` if you pass `-d` to the
   CLI.
 * `node_name`: the argument to the `-n` option.
+* `target`: the argument to the `-t` option. This is probably most
+  useful when using provisioning's SSH driver to converge existing
+  hosts.
+* `opts`: contains arbitrary user-defined options set via the `-o`
+  option. For example, given a command line including `-o foo=bar` you
+  would access the command line option via:
+
+```ruby
+context = ChefDK::ProvisioningData.context
+context.opts.foo
+# => "bar"
+```
+
 * `policy_group`: is set to the relevant CLI argument when operating in
   one of the Policyfile modes.
 * `policy_name`: set to either the value of `--policy-name` or the

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -40,6 +40,8 @@ module ChefDK
 
       attr_accessor :node_name
 
+      attr_accessor :target
+
       attr_accessor :enable_policyfile
 
       attr_accessor :policy_group
@@ -173,6 +175,11 @@ E
         long:         "--node-name NODE_NAME",
         description:  "Set default node name (may be overriden by provisioning cookbook)"
 
+      option :target,
+        short:        "-t REMOTE_HOST",
+        long:         "--target REMOTE_HOST",
+        description:  "Set hostname or IP of the host to converge (may be overriden by provisioning cookbook)"
+
       option :debug,
         short:       "-D",
         long:        "--debug",
@@ -238,6 +245,7 @@ E
 
           c.action = default_action
           c.node_name = node_name
+          c.target = target
 
           c.enable_policyfile = enable_policyfile?
 
@@ -267,6 +275,10 @@ E
 
       def node_name
         config[:node_name]
+      end
+
+      def target
+        config[:target]
       end
 
       def recipe

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -205,6 +205,34 @@ describe ChefDK::Command::Provision do
 
         end
 
+        context "with --opt" do
+          context "with one user-specified option" do
+            let(:extra_params) { %w[ --opt color=ebfg ] }
+
+            it "sets the given option name to the given value" do
+              expect(context.opts.color).to eq("ebfg")
+            end
+          end
+
+          context "with an option given as a quoted arg with spaces" do
+
+            let(:extra_params) { [ '--opt', 'color = ebfg' ] }
+
+            it "sets the given option name to the given value" do
+              expect(context.opts.color).to eq("ebfg")
+            end
+          end
+
+          context "with multiple options given" do
+            let(:extra_params) { %w[ --opt color=ebfg --opt nope=seppb ] }
+
+            it "sets the given option name to the given value" do
+              expect(context.opts.color).to eq("ebfg")
+              expect(context.opts.nope).to eq("seppb")
+            end
+          end
+        end
+
         context "with -d" do
 
           let(:extra_params) { %w[ -d ] }

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -195,6 +195,16 @@ describe ChefDK::Command::Provision do
 
         end
 
+        context "with --target" do
+
+          let(:extra_params) { %w[ -t 192.168.255.123 ] }
+
+          it "sets the target host to the given value" do
+            expect(context.target).to eq("192.168.255.123")
+          end
+
+        end
+
         context "with -d" do
 
           let(:extra_params) { %w[ -d ] }

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -223,6 +223,24 @@ describe ChefDK::Command::Provision do
             end
           end
 
+          context "with an option with an '=' in it" do
+
+            let(:extra_params) { [ '--opt', 'api_key=abcdef==' ] }
+
+            it "sets the given option name to the given value" do
+              expect(context.opts.api_key).to eq("abcdef==")
+            end
+          end
+
+          context "with an option with a space in it" do
+
+            let(:extra_params) { [ '--opt', 'full_name=Bobo T. Clown' ] }
+
+            it "sets the given option name to the given value" do
+              expect(context.opts.full_name).to eq("Bobo T. Clown")
+            end
+          end
+
           context "with multiple options given" do
             let(:extra_params) { %w[ --opt color=ebfg --opt nope=seppb ] }
 


### PR DESCRIPTION
* Add a `-t TARGET` option. This is intended to be used when bootstrapping/converging existing machines via the SSH driver
* Add a `--opt OPT=VALUE` option. This lets users set any arbitrary option they want that we haven't anticipated (or is specific to their org, use case, etc.).