### PR TITLE
Revert "Merge pull request #398 from chef/schisamo/delivery-cli"

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -96,20 +96,6 @@ module ChefDK
         c.smoke_test { run_in_tmpdir("kitchen init") }
       end
 
-      # We only ship delivery-cli on *nix only ATM
-      unless Chef::Platform.windows?
-        add_component "delivery-cli" do |c|
-          # There is no base_dir as delivery-cli is a single binary in
-          # `/opt/chefdk/bin`.
-          c.base_dir = "chef-dk"
-          c.smoke_test do
-            tmpdir do |cwd|
-              sh!("delivery setup --user=shipit --server=delivery.shipit.io --ent=chef --org=squirrels", cwd: cwd)
-            end
-          end
-        end
-      end
-
       add_component "chef-client" do |c|
         c.base_dir = "chef"
         c.unit_test { sh("bundle exec rspec -fp -t '~volatile_from_verify' spec/unit") }
@@ -202,9 +188,6 @@ end
 
             sh!("/usr/bin/chef-client -v")
             sh!("/usr/bin/chef-solo -v")
-
-            # The Delivery CLI does not have a `--version` flag yet!
-            sh!("/usr/bin/delivery --help") unless Chef::Platform.windows?
 
             # In `knife`, `knife -v` follows a different code path that skips
             # command/plugin loading; `knife -h` loads commands and plugins, but

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -28,22 +28,6 @@ module Gem
 end
 
 describe ChefDK::Command::Verify do
-  DEFAULT_COMPONENTS = %w(
-    berkshelf
-    test-kitchen
-    chef-client
-    chef-dk
-    chefspec
-    rubocop
-    fauxhai
-    knife-spork
-    kitchen-vagrant
-    package\ installation
-  )
-
-  # We only ship delivery-cli on *nix only ATM
-  DEFAULT_COMPONENTS << "delivery-cli" unless Chef::Platform.windows?
-
   let(:command_instance) { ChefDK::Command::Verify.new() }
 
   let(:command_options) { [] }
@@ -51,14 +35,25 @@ describe ChefDK::Command::Verify do
   let(:components) { {} }
 
   let(:default_components) do
-    DEFAULT_COMPONENTS
+    [
+      "berkshelf",
+      "test-kitchen",
+      "chef-client",
+      "chef-dk",
+      "chefspec",
+      "rubocop",
+      "fauxhai",
+      "knife-spork",
+      "kitchen-vagrant",
+      "package installation"
+    ]
   end
 
   def run_command(expected_exit_code)
     expect(command_instance.run(command_options)).to eq(expected_exit_code)
   end
 
-  it "defines #{DEFAULT_COMPONENTS.join(', ')} components by default" do
+  it "defines berks, tk, chef and chef-dk components by default" do
     expect(command_instance.components).not_to be_empty
     expect(command_instance.components.map(&:name)).to match_array(default_components)
   end


### PR DESCRIPTION
This reverts commit a1342cb7a7f15b6ec292655897de28857ee00ccc, reversing
changes made to b32613a8a2bdd49e33abbab6e4a236afba217238.

Not quite ready to ship the delivery CLI in ChefDK... soon, but not right now.

See also: https://github.com/chef/omnibus-chef/pull/404