### PR TITLE
Adding verification for openssl issue, fixes https://github.com/chef/chef-dk/issues/420

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -215,6 +215,31 @@ end
         end
       end
 
+      add_component "openssl" do |c|
+        # https://github.com/chef/chef-dk/issues/420
+        c.base_dir = "chef"
+
+        test = <<-EOF.gsub(/^\s+/, "")
+        require "net/http"
+
+        uris = %w{https://www.google.com https://chef.io/ https://ec2.amazonaws.com}
+        uris.each do |uri|
+          uri = URI(uri)
+          puts "Fetching \#{uri} for SSL check"
+          Net::HTTP.get uri
+        end
+        EOF
+
+        c.unit_test do
+          tmpdir do |cwd|
+            with_file(File.join(cwd, "openssl.rb")) do |f|
+              f.write test
+            end
+            sh!("#{Gem.ruby} openssl.rb", cwd: cwd)
+          end
+        end
+      end
+
       attr_reader :verification_threads
       attr_reader :verification_results
       attr_reader :verification_status


### PR DESCRIPTION
/cc @jdmundrawala @fnichol @danielsdeleo 

This may be the wrong way to do this.  Basically, I'm trying to perform an SSL check _only_ if we can actually connect to the host.  This is to prevent failing `chef verify` on a location where everything is locked down by firewall.

The other option is to add some kind of flag like `--build-verify` that we only pass to our CI stage.

What do yall think?