### PR TITLE
Show specific policy

### DIFF
--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -92,7 +92,6 @@ BANNER
       def show_policy_service
         @policy_list_service ||=
           PolicyfileServices::ShowPolicy.new(config: chef_config,
-                                             show_all: show_all_policies?,
                                              ui: ui,
                                              policy_name: policy_name,
                                              policy_group: policy_group,
@@ -102,10 +101,6 @@ BANNER
 
       def debug?
         !!config[:debug]
-      end
-
-      def show_all_policies?
-        @show_all_policies
       end
 
       def show_summary_diff?

--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -28,11 +28,15 @@ module ChefDK
     class ShowPolicy < Base
 
       banner(<<-BANNER)
-Usage: chef show-policy [POLICY_NAME] [options]
+Usage: chef show-policy [POLICY_NAME [POLICY_GROUP]] [options]
 
 `chef show-policy` Displays the revisions of policyfiles on the server. By
 default, only active policy revisions are shown. Use the `--orphans` options to
 show policy revisions that are not assigned to any policy group.
+
+When both POLICY_NAME and POLICY_GROUP are given, the command shows the content
+of a the active policyfile lock for the given POLICY_GROUP. See also the `diff`
+command.
 
 The Policyfile feature is incomplete and beta quality. See our detailed README
 for more information.
@@ -66,10 +70,13 @@ BANNER
 
       attr_reader :policy_name
 
+      attr_reader :policy_group
+
       def initialize(*args)
         super
         @show_all_policies = nil
         @policy_name = nil
+        @policy_group = nil
         @ui = UI.new
       end
 
@@ -88,6 +95,7 @@ BANNER
                                              show_all: show_all_policies?,
                                              ui: ui,
                                              policy_name: policy_name,
+                                             policy_group: policy_group,
                                              show_orphans: show_orphans?,
                                              summary_diff: show_summary_diff?)
       end
@@ -127,11 +135,15 @@ BANNER
           ui.err(opt_parser)
           false
         elsif remaining_args.empty?
-          @policy_name = nil
           @show_all_policies = true
           true
         elsif remaining_args.size == 1
           @policy_name = remaining_args.first
+          @show_all_policies = false
+          true
+        elsif remaining_args.size == 2
+          @policy_name = remaining_args[0]
+          @policy_group = remaining_args[1]
           @show_all_policies = false
           true
         else

--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -53,6 +53,12 @@ BANNER
         description:  "Show policy revisions that are unassigned",
         default:      false
 
+      option :pager,
+        long:        "--[no-]pager",
+        description: "Enable/disable paged policyfile lock ouput (default: enabled)",
+        default:     true,
+        boolean:     true
+
       option :config_file,
         short:        "-c CONFIG_FILE",
         long:         "--config CONFIG_FILE",
@@ -96,7 +102,8 @@ BANNER
                                              policy_name: policy_name,
                                              policy_group: policy_group,
                                              show_orphans: show_orphans?,
-                                             summary_diff: show_summary_diff?)
+                                             summary_diff: show_summary_diff?,
+                                             pager: enable_pager?)
       end
 
       def debug?
@@ -109,6 +116,10 @@ BANNER
 
       def show_orphans?
         config[:show_orphans]
+      end
+
+      def enable_pager?
+        config[:pager]
       end
 
       def handle_error(error)

--- a/lib/chef-dk/policyfile_services/show_policy.rb
+++ b/lib/chef-dk/policyfile_services/show_policy.rb
@@ -67,9 +67,8 @@ module ChefDK
 
       attr_reader :policy_group
 
-      def initialize(config: nil, show_all: true, ui: nil, policy_name: nil, policy_group: nil, show_orphans: false, summary_diff: false)
+      def initialize(config: nil, ui: nil, policy_name: nil, policy_group: nil, show_orphans: false, summary_diff: false)
         @chef_config = config
-        @show_all = show_all
         @ui = ui
         @policy_name = policy_name
         @policy_group = policy_group
@@ -97,7 +96,7 @@ module ChefDK
       end
 
       def show_all_policies?
-        @show_all
+        !policy_name
       end
 
       def show_orphans?

--- a/spec/unit/command/show_policy_spec.rb
+++ b/spec/unit/command/show_policy_spec.rb
@@ -127,6 +127,27 @@ describe ChefDK::Command::ShowPolicy do
 
       end
 
+      context "when given a policy name and a policy group name" do
+
+        let(:params) { %w[ appserver production ] }
+
+        it "is not configured to show all policies" do
+          expect(command.show_all_policies?).to be(false)
+          expect(show_policy_service.show_all_policies?).to be(false)
+        end
+
+        it "is configured to show the given policy" do
+          expect(command.policy_name).to eq("appserver")
+          expect(show_policy_service.policy_name).to eq("appserver")
+        end
+
+        it "is configured to display the exact revision for the given policy+group" do
+          expect(command.policy_group).to eq("production")
+          expect(show_policy_service.policy_group).to eq("production")
+        end
+
+      end
+
     end
   end
 
@@ -141,7 +162,7 @@ describe ChefDK::Command::ShowPolicy do
 
     context "when given too many arguments" do
 
-      let(:params) { %w[ appserver chatserver ] }
+      let(:params) { %w[ appserver policygroup wut-is-this ] }
 
       it "shows usage and exits" do
         expect(command.run(params)).to eq(1)

--- a/spec/unit/command/show_policy_spec.rb
+++ b/spec/unit/command/show_policy_spec.rb
@@ -79,7 +79,6 @@ describe ChefDK::Command::ShowPolicy do
         end
 
         it "is configured to show all policies across all groups" do
-          expect(command.show_all_policies?).to be(true)
           expect(show_policy_service.show_all_policies?).to be(true)
         end
 
@@ -116,7 +115,6 @@ describe ChefDK::Command::ShowPolicy do
         let(:params) { %w[ appserver ] }
 
         it "is not configured to show all policies" do
-          expect(command.show_all_policies?).to be(false)
           expect(show_policy_service.show_all_policies?).to be(false)
         end
 
@@ -132,7 +130,6 @@ describe ChefDK::Command::ShowPolicy do
         let(:params) { %w[ appserver production ] }
 
         it "is not configured to show all policies" do
-          expect(command.show_all_policies?).to be(false)
           expect(show_policy_service.show_all_policies?).to be(false)
         end
 

--- a/spec/unit/policyfile_services/show_policy_spec.rb
+++ b/spec/unit/policyfile_services/show_policy_spec.rb
@@ -22,8 +22,6 @@ describe ChefDK::PolicyfileServices::ShowPolicy do
 
   let(:chef_config) { double("Chef::Config") }
 
-  let(:show_all) { true }
-
   let(:ui) { TestHelpers::TestUI.new }
 
   let(:policy_name) { nil }
@@ -36,7 +34,6 @@ describe ChefDK::PolicyfileServices::ShowPolicy do
 
   subject(:show_policy_service) do
     described_class.new(config: chef_config,
-                        show_all: show_all,
                         ui: ui,
                         policy_name: policy_name,
                         policy_group: policy_group,
@@ -487,8 +484,6 @@ OUTPUT
 
     let(:policy_name) { "appserver" }
 
-    let(:show_all) { false }
-
     let(:policies_by_name) { {} }
     let(:policies_by_group) { {} }
 
@@ -760,8 +755,6 @@ OUTPUT
     let(:policy_name) { "appserver" }
 
     let(:policy_group) { "dev" }
-
-    let(:show_all) { false }
 
     let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP", url: "https://chef.example/organizations/monkeynews") }
 

--- a/spec/unit/policyfile_services/show_policy_spec.rb
+++ b/spec/unit/policyfile_services/show_policy_spec.rb
@@ -819,7 +819,11 @@ OUTPUT
 
       let(:policyfile_lock_json) { FFI_Yajl::Encoder.encode(policyfile_lock_data, pretty: true) }
 
+      let(:pager) { instance_double("ChefDK::Pager", ui: ui) }
+
       before do
+        allow(ChefDK::Pager).to receive(:new).and_return(pager)
+        allow(pager).to receive(:with_pager).and_yield(pager)
         allow(http_client).to receive(:get).with("policy_groups/dev/policies/appserver").and_return(policyfile_lock_data)
       end
 


### PR DESCRIPTION
Adds the ability to display a specific policyfile lock revision by giving the policy name and group. This is displayed via the pager by default.