### PR TITLE
Fix RSpec warnings for "potential false positives"

### DIFF
--- a/spec/unit/command/exec_spec.rb
+++ b/spec/unit/command/exec_spec.rb
@@ -94,7 +94,7 @@ describe ChefDK::Command::Exec do
         expect(ENV).to receive(:[]=).with("GEM_PATH", expected_GEM_PATH)
 
         expect(command_instance).to receive(:exec).with(*command_options)
-        expect{ run_command }.to raise_error # XXX: this isn't a test we just need to swallow the exception
+        expect{ run_command }.to raise_error(RuntimeError) # XXX: this isn't a test we just need to swallow the exception
       end
 
       ['-v', '--version', '-h', '--help'].each do |switch|
@@ -108,7 +108,7 @@ describe ChefDK::Command::Exec do
             expect(ENV).to receive(:[]=).with("GEM_PATH", expected_GEM_PATH)
 
             expect(command_instance).to receive(:exec).with(*command_options)
-            expect{ run_command }.to raise_error # XXX: this isn't a test we just need to swallow the exception
+            expect{ run_command }.to raise_error(RuntimeError) # XXX: this isn't a test we just need to swallow the exception
           end
         end
       end


### PR DESCRIPTION
RSpec now emits these warnings: 

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`.
```

Fixed in this commit.