### PR TITLE
Export archive

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 2.0.0.rc.0", "< 3.0.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
 
+  gem.add_dependency "minitar", "~> 0.5.4"
+
   gem.add_dependency "chef", "~> 12.0", ">= 12.2.1"
 
   gem.add_dependency "solve", "~> 2.0", ">= 2.0.1"

--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -48,6 +48,13 @@ Options:
 
 E
 
+      option :archive,
+        short:       "-a",
+        long:        "--archive",
+        description: "Export as a tarball archive rather than a directory",
+        default:     false,
+        boolean:     true
+
       option :force,
         short:       "-f",
         long:        "--force",
@@ -94,10 +101,15 @@ E
         !!config[:debug]
       end
 
+      def archive?
+        !!config[:archive]
+      end
+
       def export_service
         @export_service ||= PolicyfileServices::ExportRepo.new(policyfile: policyfile_relative_path,
                                                        export_dir: export_dir,
                                                        root_dir: Dir.pwd,
+                                                       archive: archive?,
                                                        force: config[:force])
       end
 

--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -86,7 +86,7 @@ E
       def run(params = [])
         return 1 unless apply_params!(params)
         export_service.run
-        ui.msg("Exported policy '#{export_service.policyfile_lock.name}' to #{export_dir}")
+        ui.msg("Exported policy '#{export_service.policyfile_lock.name}' to #{export_target}")
         0
       rescue ExportDirNotEmpty => e
         ui.err("ERROR: " + e.message)
@@ -95,6 +95,14 @@ E
       rescue PolicyfileServiceError => e
         handle_error(e)
         1
+      end
+
+      def export_target
+        if archive?
+          export_service.archive_file_location
+        else
+          export_dir
+        end
       end
 
       def debug?

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -38,9 +38,10 @@ module ChefDK
       attr_reader :root_dir
       attr_reader :export_dir
 
-      def initialize(policyfile: nil, export_dir: nil, root_dir: nil, force: false)
+      def initialize(policyfile: nil, export_dir: nil, root_dir: nil, archive: false, force: false)
         @root_dir = root_dir
         @export_dir = File.expand_path(export_dir)
+        @archive = archive
         @force_export = force
 
         @policy_data = nil
@@ -49,6 +50,10 @@ module ChefDK
         policyfile_rel_path = policyfile || "Policyfile.rb"
         policyfile_full_path = File.expand_path(policyfile_rel_path, root_dir)
         @storage_config = Policyfile::StorageConfig.new.use_policyfile(policyfile_full_path)
+      end
+
+      def archive?
+        @archive
       end
 
       def policy_name

--- a/spec/unit/command/export_spec.rb
+++ b/spec/unit/command/export_spec.rb
@@ -59,6 +59,19 @@ describe ChefDK::Command::Export do
       end
     end
 
+    context "when archive mode is set" do
+
+      let(:params) { [ "path/to/export", "-a" ] }
+
+      it "enables archiving the exported repo" do
+        expect(command.archive?).to be(true)
+      end
+
+      it "configures the export service to archive" do
+        expect(command.export_service.archive?).to be(true)
+      end
+    end
+
     context "when the path to the exported repo is given" do
 
       let(:params) { [ "path/to/export" ] }


### PR DESCRIPTION
Adds a flag to `chef export` so you can export a tarball instead of just the plain directory structure. This is to support a future `chef push-archive` command that can be used to transfer policyfiles and the relevant code to an environment with limited networking access.