### PR TITLE
Add `chef verify chef-provisioning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Last Release: 0.7.0
 
+* [#433](https://github.com/chef/chef-dk/pull/433): Add `chef verify chef-provisioning`
 * [Jian Weihang](https://github.com/tonytonyjan): Add post install
   warning when installing via rubygems
   [#402](https://github.com/chef/chef-dk/pull/402)

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -40,6 +40,7 @@ describe ChefDK::Command::Verify do
       "test-kitchen",
       "chef-client",
       "chef-dk",
+      "chef-provisioning",
       "chefspec",
       "rubocop",
       "fauxhai",


### PR DESCRIPTION
Check that every shipped version of `chef-provisioning` can load a version of all of the shipped drivers.