### PR TITLE
Update chef export's config example for Chef 12.4

### DIFF
--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -38,6 +38,7 @@ to the target machine, you can apply the policy to the machine with
     use_policyfile true
     deployment_group '$POLICY_NAME-local'
     versioned_cookbooks true
+    policy_document_native_api false
 
 The Policyfile feature is incomplete and beta quality. See our detailed README
 for more information.


### PR DESCRIPTION
`policy_document_native_api false` is no longer the default as of Chef
12.4, so users must add it manually.