### PR TITLE
Push Archive Command

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -36,6 +36,8 @@ ChefDK.commands do |c|
 
   c.builtin "push", :Push, desc: "Push a local policy lock to a policy group on the server"
 
+  c.builtin "push-archive", :PushArchive, desc: "Push a policy archive to a policy group on the server"
+
   c.builtin "show-policy", :ShowPolicy, desc: "Show policyfile objects on you Chef Server"
 
   c.builtin "diff", :Diff, desc: "Generate an itemized diff of two Policyfile lock documents"

--- a/lib/chef-dk/command/push_archive.rb
+++ b/lib/chef-dk/command/push_archive.rb
@@ -1,0 +1,126 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/ui'
+require 'chef-dk/policyfile_services/push_archive'
+require 'chef-dk/configurable'
+
+module ChefDK
+  module Command
+
+    class PushArchive < Base
+
+      include Configurable
+
+      banner(<<-E)
+Usage: chef push-archive POLICY_GROUP ARCHIVE_FILE [options]
+
+`chef push-archive` publishes a policy archive to a Chef Server. Policy
+archives can be created with `chef export -a`. The policy will be applied to
+the given POLICY_GROUP, which is a set of nodes that share the same
+run_list and cookbooks.
+
+For more information about Policyfiles, see our detailed README:
+
+https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+
+Options:
+E
+
+      option :config_file,
+        short:       "-c CONFIG_FILE",
+        long:        "--config CONFIG_FILE",
+        description: "Path to configuration file"
+
+      option :debug,
+        short:       "-D",
+        long:        "--debug",
+        description: "Enable stacktraces and other debug output",
+        default:     false
+
+      attr_accessor :ui
+
+      attr_reader :policy_group
+
+      attr_reader :archive_path
+
+      def initialize(*args)
+        super
+        @policy_group = nil
+        @archive_path = nil
+        @chef_config = nil
+        @ui = UI.new
+      end
+
+      def run(params)
+        return 1 unless apply_params!(params)
+
+        push_archive_service.run
+
+        0
+      rescue PolicyfileServiceError => e
+        handle_error(e)
+        1
+      end
+
+      # @api private
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+
+      # @api private
+      def push_archive_service
+        @push_archive_service ||=
+          ChefDK::PolicyfileServices::PushArchive.new(
+            archive_file: archive_file,
+            policy_group: policy_group,
+            ui: ui,
+            config: chef_config
+        )
+      end
+
+      def archive_file
+        File.expand_path(archive_path)
+      end
+
+      # @api private
+      def debug?
+        !!config[:debug]
+      end
+
+      # @api private
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+        if remaining_args.size != 2
+          ui.err(opt_parser)
+          return false
+        end
+
+        @policy_group, @archive_path = remaining_args
+      end
+
+    end
+  end
+end
+

--- a/lib/chef-dk/policyfile/cookbook_locks.rb
+++ b/lib/chef-dk/policyfile/cookbook_locks.rb
@@ -286,6 +286,7 @@ module ChefDK
         @identifier_updated = false
         @version_updated = false
         @cookbook_in_git_repo = nil
+        @scm_info = nil
       end
 
       def cookbook_path
@@ -301,7 +302,12 @@ module ChefDK
       end
 
       def scm_info
-        scm_profiler.profile_data
+        @scm_info
+      end
+
+      def to_lock
+        refresh_scm_info
+        super
       end
 
       def lock_data
@@ -324,6 +330,7 @@ module ChefDK
         @dotted_decimal_identifier = lock_data["dotted_decimal_identifier"]
         @source = lock_data["source"]
         @source_options = symbolize_source_options_keys(lock_data["source_options"])
+        @scm_info = lock_data["scm_info"]
       end
 
       def validate!
@@ -365,6 +372,10 @@ module ChefDK
       end
 
       private
+
+      def refresh_scm_info
+        @scm_info = scm_profiler.profile_data
+      end
 
       def assert_required_keys_valid!(lock_data)
         super

--- a/lib/chef-dk/policyfile_services/push_archive.rb
+++ b/lib/chef-dk/policyfile_services/push_archive.rb
@@ -1,0 +1,173 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'zlib'
+require 'archive/tar/minitar'
+
+require 'chef-dk/service_exceptions'
+require 'chef-dk/policyfile_lock'
+require 'chef-dk/authenticated_http'
+require 'chef-dk/policyfile/uploader'
+
+module ChefDK
+  module PolicyfileServices
+    class PushArchive
+
+      USTAR_INDICATOR = "ustar\0".force_encoding(Encoding::ASCII_8BIT).freeze
+
+      attr_reader :archive_file
+      attr_reader :policy_group
+      attr_reader :root_dir
+      attr_reader :ui
+      attr_reader :config
+
+      attr_reader :policyfile_lock
+
+
+      def initialize(archive_file: nil, policy_group: nil, root_dir: nil, ui: nil, config: nil)
+        @archive_file = archive_file
+        @policy_group = policy_group
+        @root_dir = root_dir || Dir.pwd
+        @ui = ui
+        @config = config
+
+        @policyfile_lock = nil
+      end
+
+      def archive_file_path
+        File.join(root_dir, archive_file)
+      end
+
+      def run
+        unless File.exist?(archive_file_path)
+          raise InvalidPolicyArchive, "Archive file #{archive_file_path} not found"
+        end
+        stage_unpacked_archive do |staging_dir|
+          read_policyfile_lock(staging_dir)
+
+          uploader.upload
+        end
+
+      rescue => e
+        raise PolicyfilePushArchiveError.new("Failed to publish archived policy", e)
+      end
+
+      # @api private
+      def uploader
+        ChefDK::Policyfile::Uploader.new(policyfile_lock, policy_group,
+                                         ui: ui,
+                                         http_client: http_client,
+                                         policy_document_native_api: config.policy_document_native_api)
+      end
+
+      # @api private
+      def http_client
+        @http_client ||= ChefDK::AuthenticatedHTTP.new(config.chef_server_url,
+                                                       signing_key_filename: config.client_key,
+                                                       client_name: config.node_name)
+      end
+
+      private
+
+      def read_policyfile_lock(staging_dir)
+        policyfile_lock_path = File.join(staging_dir, "Policyfile.lock.json")
+
+        unless File.exist?(policyfile_lock_path)
+          raise InvalidPolicyArchive, "Archive does not contain a Policyfile.lock.json"
+        end
+
+        unless File.directory?(File.join(staging_dir, "cookbooks"))
+          raise InvalidPolicyArchive, "Archive does not contain a cookbooks directory"
+        end
+
+
+        policy_data = load_policy_data(policyfile_lock_path)
+        storage_config = Policyfile::StorageConfig.new.use_policyfile_lock(policyfile_lock_path)
+        @policyfile_lock = ChefDK::PolicyfileLock.new(storage_config).build_from_archive(policy_data)
+
+        missing_cookbooks = policyfile_lock.cookbook_locks.select do |name, lock|
+          !lock.installed?
+        end
+
+        unless missing_cookbooks.empty?
+          message = "Archive does not have all cookbooks required by the Policyfile.lock. " +
+            "Missing cookbooks: '#{missing_cookbooks.keys.join('", "')}'."
+          raise InvalidPolicyArchive, message
+        end
+
+      end
+
+      def load_policy_data(policyfile_lock_path)
+        FFI_Yajl::Parser.parse(IO.read(policyfile_lock_path))
+      end
+
+      def stage_unpacked_archive
+        p = Process.pid
+        t = Time.new.utc.strftime("%Y%m%d%H%M%S")
+        Dir.mktmpdir("chefdk-push-archive-#{p}-#{t}") do |staging_dir|
+          unpack_to(staging_dir)
+          yield staging_dir
+        end
+
+      end
+
+      def unpack_to(staging_dir)
+        Zlib::GzipReader.open(archive_file_path) do |gz_file|
+          untar_to(gz_file, staging_dir)
+        end
+
+        # untar_to can raise InvalidPolicyArchive, let it through
+      rescue InvalidPolicyArchive
+        raise
+      rescue => e
+        raise InvalidPolicyArchive, "Archive file #{archive_file_path} could not be unpacked. #{e}"
+      end
+
+      def untar_to(tar_file, staging_dir)
+        # Minitar doesn't do much input checking, so if you feed it a
+        # garbage-enough file it will just do weird things and blow up. For
+        # example, if tar_file is just a bunch of nul characters, then tar will
+        # try to open a file named '.'; if you give it some random string that
+        # fits in the size of the filename header, it will create that file.
+        #
+        # Tar archives that we create via `chef export -a` and probably
+        # everything else we might encounter should be in ustar format. For
+        # such a tar file, bytes 257-263 should be "ustar\0", so we use this as
+        # a sanity check.
+        # https://en.wikipedia.org/wiki/Tar_(computing)
+
+        first_tar_header = tar_file.read(512)
+        ustar_indicator = first_tar_header[257, 6]
+
+        unless ustar_indicator == USTAR_INDICATOR
+          raise InvalidPolicyArchive, "Archive file #{archive_file_path} could not be unpacked. Tar archive looks corrupt."
+        end
+
+        # "undo" read of the first 512 bytes
+        tar_file.rewind
+
+        Archive::Tar::Minitar::Input.open(tar_file) do |stream|
+          stream.each do |entry|
+            stream.extract_entry(staging_dir, entry)
+          end
+        end
+      end
+
+
+    end
+  end
+end

--- a/lib/chef-dk/policyfile_services/push_archive.rb
+++ b/lib/chef-dk/policyfile_services/push_archive.rb
@@ -49,7 +49,7 @@ module ChefDK
       end
 
       def archive_file_path
-        File.join(root_dir, archive_file)
+        File.expand_path(archive_file, root_dir)
       end
 
       def run

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -76,6 +76,9 @@ module ChefDK
   class ExportDirNotEmpty < PolicyfileServiceError
   end
 
+  class InvalidPolicyArchive < PolicyfileServiceError
+  end
+
   class PolicyfileNestedException < PolicyfileServiceError
 
     include NestedExceptionWithInspector
@@ -89,6 +92,9 @@ module ChefDK
   end
 
   class PolicyfileUpdateError < PolicyfileNestedException
+  end
+
+  class PolicyfilePushArchiveError < PolicyfileNestedException
   end
 
   class PolicyfilePushError < PolicyfileNestedException

--- a/spec/unit/command/push_archive_spec.rb
+++ b/spec/unit/command/push_archive_spec.rb
@@ -1,0 +1,153 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/push_archive'
+
+describe ChefDK::Command::PushArchive do
+
+  subject(:command) { described_class.new }
+
+  let(:policy_group) { "staging" }
+
+  let(:archive_path) { "mypolicy-abc123.tgz" }
+
+  it_behaves_like "a command with a UI object"
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:config_arg) { nil }
+
+  before do
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "evaluating params" do
+
+    before do
+      command.ui = ui
+    end
+
+    context "when given no arguments" do
+
+      it "prints the banner message and exits non-zero" do
+        expect(command.run([])).to eq(1)
+        expect(ui.output).to include(described_class.banner)
+      end
+
+    end
+
+    context "when the archive path is omitted" do
+
+      it "prints the banner message and exits non-zero" do
+        expect(command.run([policy_group])).to eq(1)
+        expect(ui.output).to include(described_class.banner)
+      end
+
+    end
+
+    context "when all required arguments are given" do
+
+      let(:params) { [ policy_group, archive_path ] }
+
+      before do
+        command.apply_params!(params)
+      end
+
+      it "disables debug by default" do
+        expect(command.debug?).to be(false)
+      end
+
+      context "and debug mode is set" do
+
+        let(:params) { [ policy_group, archive_path, "-D" ] }
+
+        it "enables debug messages" do
+          expect(command.debug?).to be(true)
+        end
+
+      end
+
+      describe "configuring settings that depend on the chef config file" do
+
+        before do
+          expect(chef_config_loader).to receive(:load)
+        end
+
+        it "sets the policy group" do
+          expect(command.policy_group).to eq(policy_group)
+          expect(command.push_archive_service.policy_group).to eq(policy_group)
+        end
+
+        it "sets the path to the archive file" do
+          expect(command.archive_path).to eq(archive_path)
+          expect(command.push_archive_service.archive_file).to eq(File.expand_path(archive_path))
+        end
+      end
+
+    end
+
+  end
+
+  describe "running the push operation" do
+
+    let(:push_archive_service) { instance_double("ChefDK::PolicyfileServices::PushArchive") }
+
+    let(:params) { [ policy_group, archive_path ] }
+
+    before do
+      allow(command).to receive(:push_archive_service).and_return(push_archive_service)
+      command.ui = ui
+    end
+
+    context "when the push is successful" do
+
+      it "exits 0" do
+        expect(push_archive_service).to receive(:run)
+        expect(command.run(params)).to eq(0)
+      end
+
+    end
+
+    context "when the push in not successful" do
+
+      let(:backtrace) { caller[0...3] }
+
+      let(:cause) do
+        e = StandardError.new("some operation failed")
+        e.set_backtrace(backtrace)
+        e
+      end
+
+      let(:exception) do
+        ChefDK::PolicyfilePushArchiveError.new("push failed", cause)
+      end
+
+      before do
+        expect(push_archive_service).to receive(:run).and_raise(exception)
+      end
+
+      it "exits non-zero" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+  end
+end

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -1,0 +1,345 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile_services/push_archive'
+
+describe ChefDK::PolicyfileServices::PushArchive do
+
+  FileToTar = Struct.new(:name, :content)
+
+  def create_archive
+    Zlib::GzipWriter.open(archive_file_path) do |gz_file|
+      Archive::Tar::Minitar::Writer.open(gz_file) do |tar|
+
+
+        archive_dirs.each do |dir|
+          tar.mkdir(dir, mode: 0755)
+        end
+
+        archive_files.each do |file|
+          name = file.name
+          content = file.content
+          size = content.bytesize
+          tar.add_file_simple(name, mode: 0644, size: size) { |f| f.write(content) }
+        end
+
+      end
+    end
+  end
+
+  let(:valid_lockfile) do
+    <<-E
+{
+  "name": "install-example",
+  "run_list": [
+    "recipe[local-cookbook::default]"
+  ],
+  "cookbook_locks": {
+    "local-cookbook": {
+      "version": "2.3.4",
+      "identifier": "fab501cfaf747901bd82c1bc706beae7dc3a350c",
+      "dotted_decimal_identifier": "70567763561641081.489844270461035.258281553147148",
+      "source": "project-cookbooks/local-cookbook",
+      "cache_key": null,
+      "scm_info": null,
+      "source_options": {
+        "path": "project-cookbooks/local-cookbook"
+      }
+    }
+  },
+  "default_attributes": {},
+  "override_attributes": {},
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "local-cookbook",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "local-cookbook (2.3.4)": [
+
+      ]
+    }
+  }
+}
+E
+  end
+
+  let(:archive_files) { [] }
+
+  let(:archive_dirs) { [] }
+
+  let(:working_dir) do
+    path = File.join(tempdir, "policyfile_services_test_working_dir")
+    Dir.mkdir(path)
+    path
+  end
+
+  let(:archive_file_name) { "example-policy-abc123.tgz" }
+
+  let(:archive_file_path) { File.join(working_dir, archive_file_name) }
+
+  let(:policy_group) { "dev-cluster-1" }
+
+  let(:config) do
+    double("Chef::Config",
+           chef_server_url: "https://localhost:10443",
+           client_key: "/path/to/client/key.pem",
+           node_name: "deuce",
+           policy_document_native_api: true)
+  end
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  subject(:push_archive_service) do
+    described_class.new(archive_file: archive_file_name,
+                        policy_group: policy_group,
+                        root_dir: working_dir,
+                        ui: ui,
+                        config: config)
+  end
+
+  it "has an archive file" do
+    expect(push_archive_service.archive_file).to eq(archive_file_name)
+    expect(push_archive_service.archive_file_path).to eq(archive_file_path)
+  end
+
+  it "configures an HTTP client" do
+    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+                                                       signing_key_filename: "/path/to/client/key.pem",
+                                                       client_name: "deuce")
+    push_archive_service.http_client
+  end
+
+  context "with an invalid archive" do
+
+    let(:exception) do
+      begin
+        push_archive_service.run
+      rescue ChefDK::PolicyfilePushArchiveError => e
+        e
+      else
+        nil
+      end
+    end
+
+    let(:exception_cause) { exception.cause }
+
+    context "when the archive is malformed/corrupted/etc" do
+
+      context "when the archive file doesn't exist" do
+
+        it "errors out" do
+          expect(exception).to_not be_nil
+          expect(exception.message).to eq("Failed to publish archived policy")
+          expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+          expect(exception_cause.message).to eq("Archive file #{archive_file_path} not found")
+        end
+      end
+
+      context "when the archive is not a gzip file" do
+
+        before do
+          FileUtils.touch(archive_file_path)
+        end
+
+        it "errors out" do
+          expect(exception).to_not be_nil
+          expect(exception.message).to eq("Failed to publish archived policy")
+          expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+          expect(exception_cause.message).to eq("Archive file #{archive_file_path} could not be unpacked. not in gzip format")
+        end
+
+      end
+
+      context "when the archive is a gzip file of a garbage file" do
+
+        before do
+          Zlib::GzipWriter.open(archive_file_path) do |gz_file|
+            gz_file << "lol this isn't a tar file"
+          end
+        end
+
+        it "errors out" do
+          expect(exception).to_not be_nil
+          expect(exception.message).to eq("Failed to publish archived policy")
+          expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+          expect(exception_cause.message).to eq("Archive file #{archive_file_path} could not be unpacked. Tar archive looks corrupt.")
+        end
+      end
+
+
+      context "when the archive is a gzip file of a very malformed tar archive" do
+
+        before do
+          Zlib::GzipWriter.open(archive_file_path) do |gz_file|
+            gz_file << "\0\0\0\0\0"
+          end
+        end
+
+        it "errors out" do
+          expect(exception).to_not be_nil
+          expect(exception.message).to eq("Failed to publish archived policy")
+          expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+          expect(exception_cause.message).to eq("Archive file #{archive_file_path} could not be unpacked. Tar archive looks corrupt.")
+        end
+      end
+    end
+
+    context "when the archive is well-formed but has invalid content" do
+
+      before do
+        create_archive
+      end
+
+      context "when the archive is missing Policyfile.lock.json" do
+
+        let(:archive_files) { [ FileToTar.new("empty.txt", "") ] }
+
+        it "errors out" do
+          expect(exception).to_not be_nil
+          expect(exception.message).to eq("Failed to publish archived policy")
+          expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+          expect(exception_cause.message).to eq("Archive does not contain a Policyfile.lock.json")
+        end
+
+      end
+
+      context "when the archive has no cookbooks/ directory" do
+
+        let(:archive_files) { [ FileToTar.new("Policyfile.lock.json", "") ] }
+
+        it "errors out" do
+          expect(exception).to_not be_nil
+          expect(exception.message).to eq("Failed to publish archived policy")
+          expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+          expect(exception_cause.message).to eq("Archive does not contain a cookbooks directory")
+        end
+
+      end
+
+      context "when the archive has the correct files but the lockfile is invalid" do
+
+        let(:archive_dirs) { ["cookbooks"] }
+
+        let(:archive_files) { [ FileToTar.new("Policyfile.lock.json", lockfile_content) ] }
+
+        context "when the lockfile has invalid JSON" do
+
+          let(:lockfile_content) { ":::" }
+
+          it "errors out" do
+            expect(exception).to_not be_nil
+            expect(exception.message).to eq("Failed to publish archived policy")
+            expect(exception_cause).to be_a(FFI_Yajl::ParseError)
+          end
+
+        end
+
+        context "when the lockfile is semantically invalid" do
+
+          let(:lockfile_content) { '{ }' }
+
+          it "errors out" do
+            expect(exception).to_not be_nil
+            expect(exception.message).to eq("Failed to publish archived policy")
+            expect(exception_cause).to be_a(ChefDK::InvalidLockfile)
+          end
+
+        end
+
+
+        context "when the archive does not have all the necessary cookbooks" do
+
+          let(:lockfile_content) { valid_lockfile }
+
+          it "errors out" do
+            expect(exception).to_not be_nil
+            expect(exception.message).to eq("Failed to publish archived policy")
+            expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+
+            msg = "Archive does not have all cookbooks required by the Policyfile.lock. Missing cookbooks: 'local-cookbook'."
+            expect(exception_cause.message).to eq(msg)
+          end
+
+        end
+      end
+    end
+
+  end
+
+  context "with a valid archive" do
+
+    let(:lockfile_content) { valid_lockfile }
+
+    let(:cookbook_name) { "local-cookbook" }
+
+    let(:dotted_decimal_identifier) { "70567763561641081.489844270461035.258281553147148" }
+
+    let(:cookbook_dir) { File.join("cookbooks", "#{cookbook_name}-#{dotted_decimal_identifier}") }
+
+    let(:recipes_dir) { File.join(cookbook_dir, "recipes") }
+
+    let(:archive_dirs) { ["cookbooks", cookbook_dir, recipes_dir] }
+
+    let(:archive_files) do
+      [
+        FileToTar.new("Policyfile.lock.json", lockfile_content),
+        FileToTar.new(File.join(cookbook_dir, "metadata.rb"), "name 'local-cookbook'"),
+        FileToTar.new(File.join(recipes_dir, "default.rb"), "puts 'hello'")
+      ]
+    end
+
+    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+
+    let(:uploader) { instance_double(ChefDK::Policyfile::Uploader) }
+
+    before do
+      expect(push_archive_service).to receive(:http_client).and_return(http_client)
+
+      expect(ChefDK::Policyfile::Uploader).to receive(:new).
+        # TODO: need more verification that the policyfile.lock is right (?)
+        with(an_instance_of(ChefDK::PolicyfileLock), policy_group, http_client: http_client, ui: ui, policy_document_native_api: true).
+        and_return(uploader)
+
+      create_archive
+    end
+
+    describe "when the upload is successful" do
+
+      it "uploads the cookbooks and lockfile" do
+        expect(uploader).to receive(:upload)
+        push_archive_service.run
+      end
+
+    end
+
+    describe "when the upload fails" do
+
+      it "raises a nested error" do
+        expect(uploader).to receive(:upload).and_raise("an error")
+        expect { push_archive_service.run }.to raise_error(ChefDK::PolicyfilePushArchiveError)
+      end
+
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
Add a `chef push-archive` command that can upload a policy archive (tarball) directly to the server. So you can do:

```bash
chef export -a .
# Exported policy 'aar' to /Users/ddeleo/oc/aar/aar-d81e80ae9bb9778e8c4b7652d29b11d2111e763a840d0cadb34b46a8b2ca4347.tgz
# move that tarball to some other machine
chef push-archive prodution aar-d81e80ae9bb9778e8c4b7652d29b11d2111e763a840d0cadb34b46a8b2ca4347.tgz
```