### PR TITLE
Multiple policyfile sources

### DIFF
--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -71,4 +71,31 @@ module ChefDK
   class BUG < RuntimeError
   end
 
+  class CookbookSourceConflict < StandardError
+
+    attr_reader :conflicting_cookbooks
+
+    attr_reader :cookbook_sources
+
+    def initialize(conflicting_cookbooks, cookbook_sources)
+      @conflicting_cookbooks = conflicting_cookbooks
+      @cookbook_sources = cookbook_sources
+      super(compute_message)
+    end
+
+    private
+
+    def compute_message
+      conflicting_cookbook_sets = cookbook_sources.combination(2).map do |source_a, source_b|
+        overlapping_cookbooks = conflicting_cookbooks.select do |cookbook_name|
+          source_a.universe_graph.key?(cookbook_name) && source_b.universe_graph.key?(cookbook_name)
+        end
+        "Source #{source_a.desc} and #{source_b.desc} contain conflicting cookbooks:\n" +
+          overlapping_cookbooks.sort.map {|c| "- #{c}"}.join("\n")
+      end
+      conflicting_cookbook_sets.join("\n") + "\n"
+    end
+
+  end
+
 end

--- a/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
@@ -61,6 +61,10 @@ module ChefDK
         false
       end
 
+      def desc
+        "chef_repo(#{path})"
+      end
+
       private
 
       # Setter for setting the path.  It may either be a full chef-repo with

--- a/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
@@ -57,6 +57,10 @@ module ChefDK
         { path: cookbook_version_paths[cookbook_name][cookbook_version], version: cookbook_version }
       end
 
+      def null?
+        false
+      end
+
       private
 
       # Setter for setting the path.  It may either be a full chef-repo with

--- a/lib/chef-dk/policyfile/chef_server_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_server_cookbook_source.rb
@@ -43,6 +43,10 @@ module ChefDK
         false
       end
 
+      def desc
+        "chef_server(#{uri})"
+      end
+
     end
   end
 end

--- a/lib/chef-dk/policyfile/chef_server_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_server_cookbook_source.rb
@@ -39,6 +39,10 @@ module ChefDK
         raise UnsupportedFeature, 'ChefDK does not support chef-server cookbook default sources at this time'
       end
 
+      def null?
+        false
+      end
+
     end
   end
 end

--- a/lib/chef-dk/policyfile/community_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/community_cookbook_source.rb
@@ -60,6 +60,10 @@ module ChefDK
         false
       end
 
+      def desc
+        "supermarket(#{uri})"
+      end
+
       private
 
       def http_connection_for(base_url)

--- a/lib/chef-dk/policyfile/community_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/community_cookbook_source.rb
@@ -56,6 +56,10 @@ module ChefDK
         { artifactserver: base_uri, version: cookbook_version }
       end
 
+      def null?
+        false
+      end
+
       private
 
       def http_connection_for(base_url)

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -44,7 +44,7 @@ module ChefDK
         @errors = []
         @run_list = []
         @named_run_lists = {}
-        @default_source = NullCookbookSource.new
+        @default_source = [ NullCookbookSource.new ]
         @cookbook_location_specs = {}
         @storage_config = storage_config
 
@@ -140,14 +140,14 @@ module ChefDK
       private
 
       def set_default_community_source(source_uri)
-        @default_source = CommunityCookbookSource.new(source_uri)
+        set_default_source(CommunityCookbookSource.new(source_uri))
       end
 
       def set_default_chef_server_source(source_uri)
         if source_uri.nil?
           @errors << "You must specify the server's URI when using a default_source :chef_server"
         else
-          @default_source = ChefServerCookbookSource.new(source_uri)
+          set_default_source(ChefServerCookbookSource.new(source_uri))
         end
       end
 
@@ -155,8 +155,13 @@ module ChefDK
         if path.nil?
           @errors << "You must specify the path to the chef-repo when using a default_source :chef_repo"
         else
-          @default_source = ChefRepoCookbookSource.new(path)
+          set_default_source(ChefRepoCookbookSource.new(path))
         end
+      end
+
+      def set_default_source(source)
+        @default_source.delete_at(0) if @default_source[0].null?
+        @default_source << source
       end
 
       def validate!

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -71,7 +71,7 @@ module ChefDK
       def default_source(source_type = nil, source_argument = nil)
         return @default_source if source_type.nil?
         case source_type
-        when :community
+        when :community, :supermarket
           set_default_community_source(source_argument)
         when :chef_server
           set_default_chef_server_source(source_argument)

--- a/lib/chef-dk/policyfile/null_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/null_cookbook_source.rb
@@ -32,6 +32,10 @@ module ChefDK
         raise UnsupportedFeature, 'You must set a default_source in your Policyfile to download cookbooks without explicit sources'
       end
 
+      def null?
+        true
+      end
+
     end
   end
 end

--- a/lib/chef-dk/policyfile/null_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/null_cookbook_source.rb
@@ -36,6 +36,10 @@ module ChefDK
         true
       end
 
+      def desc
+        "null_cookbook_source"
+      end
+
     end
   end
 end

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -675,10 +675,4 @@ describe ChefDK::PolicyfileCompiler, "when expressing the Policyfile graph deman
 
   end
 
-  context "Given a run_list with roles" do
-    it "expands the roles from the given role source" do
-      skip
-    end
-  end
-
 end

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -632,12 +632,6 @@ describe ChefDK::PolicyfileCompiler, "when expressing the Policyfile graph deman
       expect(policyfile.graph_solution).to eq({"local-cookbook" => "2.3.4", "remote-cb" => "0.1.0"})
     end
 
-    it "builds a policyfile lock from the constraints" do
-      skip
-      expect(policyfile).to receive(:cache_path).and_return(Pathname.new("~/.nopenope/cache"))
-      expect(policyfile.lock).to eq(:wat)
-    end
-
     it "includes the policyfile constraint in the solution dependencies" do
       expected_solution_deps = {
         "Policyfile" => [ [ "remote-cb", "~> 0.1" ], [ "local-cookbook", ">= 0.0.0"] ],

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -212,6 +212,26 @@ describe ChefDK::PolicyfileCompiler, "when expressing the Policyfile graph deman
 
     let(:run_list) { ["remote-cb"] }
 
+    context "with no default source" do
+
+      it "fails to locate the cookbook" do
+        expect { policyfile.graph_solution }.to raise_error(Solve::Errors::NoSolutionError)
+      end
+
+      context "when the policyfile also has a `cookbook` entry for the run list item" do
+
+        before do
+          policyfile.dsl.cookbook "remote-cb"
+        end
+
+        it "fails to locate the cookbook" do
+          expect { policyfile.graph_solution }.to raise_error(Solve::Errors::NoSolutionError)
+        end
+
+      end
+
+    end
+
     context "And the default source is the community site" do
 
       include_context "community default source"

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -171,7 +171,9 @@ E
       end
 
       it "has no default cookbook source" do
-        expect(policyfile.default_source).to be_a(ChefDK::Policyfile::NullCookbookSource)
+        expect(policyfile.default_source).to be_an(Array)
+        expect(policyfile.default_source.size).to eq(1)
+        expect(policyfile.default_source.first).to be_a(ChefDK::Policyfile::NullCookbookSource)
       end
 
       context "with the default source set to the community site" do
@@ -185,7 +187,7 @@ E
 
         it "has a default source" do
           expect(policyfile.errors).to eq([])
-          expected = ChefDK::Policyfile::CommunityCookbookSource.new("https://supermarket.chef.io")
+          expected = [ ChefDK::Policyfile::CommunityCookbookSource.new("https://supermarket.chef.io") ]
           expect(policyfile.default_source).to eq(expected)
         end
 
@@ -200,7 +202,7 @@ E
 
           it "has a default source" do
             expect(policyfile.errors).to eq([])
-            expected = ChefDK::Policyfile::CommunityCookbookSource.new("https://cookbook-api.example.com")
+            expected = [ ChefDK::Policyfile::CommunityCookbookSource.new("https://cookbook-api.example.com") ]
             expect(policyfile.default_source).to eq(expected)
           end
 
@@ -256,7 +258,31 @@ E
 
         it "has a default source" do
           expect(policyfile.errors).to eq([])
-          expected = ChefDK::Policyfile::ChefRepoCookbookSource.new(chef_repo)
+          expected = [ ChefDK::Policyfile::ChefRepoCookbookSource.new(chef_repo) ]
+          expect(policyfile.default_source).to eq(expected)
+        end
+
+      end
+
+      context "with multiple default sources" do
+        let(:chef_repo) { File.expand_path("spec/unit/fixtures/local_path_cookbooks", project_root) }
+
+        let(:policyfile_rb) do
+          <<-EOH
+            run_list "foo", "bar"
+
+            default_source :community
+            default_source :chef_repo, "#{chef_repo}"
+          EOH
+        end
+
+        it "has an array of sources" do
+          expect(policyfile.errors).to eq([])
+
+          community_source = ChefDK::Policyfile::CommunityCookbookSource.new("https://supermarket.chef.io")
+          repo_source = ChefDK::Policyfile::ChefRepoCookbookSource.new(chef_repo)
+          expected = [ community_source, repo_source ]
+
           expect(policyfile.default_source).to eq(expected)
         end
 


### PR DESCRIPTION
Addresses https://github.com/chef/chef-dk/issues/430

This allows you to have multiple `default_source` lines in your policyfile.rb, so you can have a `chef_repo` with all your org-specific stuff, but pull cookbooks from the public supermarket easily. The way it's designed right now, the cookbook sets need to be disjoint (i.e., there cannot be cookbooks with the same name in both locations). If you manually specify a cookbook's source with a `cookbook "foo", source_option: "place"` line, though it will be respected. One downside of that is, if there is a conflict between your two sources, and the cookbook is totally irrelevant (wouldn't be in the dependency solution), it'll end up in your policy anyway, because adding the `cookbook` line tells chef-dk you want that cookbook around. That said, the 80% case we're targeting here is where there shouldn't be any overlap between, say, supermarket and your chef repo (or internal supermarket), and if there is a conflicting cookbook, it's a mistake.