### PR TITLE
Mockup policyfile revision cleanup

### DIFF
--- a/lib/chef-dk/policyfile_services/clean_policies.rb
+++ b/lib/chef-dk/policyfile_services/clean_policies.rb
@@ -1,0 +1,94 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/service_exceptions'
+require 'chef-dk/policyfile/lister'
+
+module ChefDK
+  module PolicyfileServices
+    class CleanPolicies
+
+      Orphan = Struct.new(:policy_name, :revision_id)
+
+      attr_reader :chef_config
+      attr_reader :ui
+
+      def initialize(config: nil, ui: nil)
+        @chef_config = config
+        @ui = ui
+      end
+
+      def run
+        revisions_to_remove = orphaned_policies
+
+        if revisions_to_remove.empty?
+          ui.err("No policy revisions deleted")
+          return true
+        end
+
+        results = revisions_to_remove.map do |policy|
+          [ remove_policy(policy), policy ]
+        end
+
+        failures = results.select { |result, _policy| result.kind_of?(Exception) }
+
+        unless failures.empty?
+          details = failures.map do |result, policy|
+            "- #{policy.policy_name} (#{policy.revision_id}): #{result.class} #{result}"
+          end
+
+          message = "Failed to delete some policy revisions:\n" + details.join("\n") + "\n"
+
+          raise PolicyfileCleanError.new(message, nil)
+        end
+
+        true
+      end
+
+      def orphaned_policies
+        policy_lister.policies_by_name.keys.inject([]) do |orphans, policy_name|
+          orphans + policy_lister.orphaned_revisions(policy_name).map do |revision_id|
+            Orphan.new(policy_name, revision_id)
+          end
+        end
+      rescue => e
+        raise PolicyfileCleanError.new("Failed to list policies for cleaning.", e)
+      end
+
+      def policy_lister
+        @policy_lister ||= Policyfile::Lister.new(config: chef_config)
+      end
+
+      def http_client
+        @http_client ||= ChefDK::AuthenticatedHTTP.new(config.chef_server_url,
+                                                       signing_key_filename: config.client_key,
+                                                       client_name: config.node_name)
+      end
+
+      private
+
+      def remove_policy(policy)
+        ui.msg("DELETE #{policy.policy_name} #{policy.revision_id}")
+        http_client.delete("/policies/#{policy.policy_name}/revisions/#{policy.revision_id}")
+        :ok
+      rescue => e
+        e
+      end
+
+    end
+  end
+end

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -31,6 +31,7 @@ module ChefDK
 
     def initialize(message, cause)
       super(message)
+      @message = message
       @inspector = inspector_for(cause)
       @cause = cause
     end
@@ -41,6 +42,14 @@ module ChefDK
 
     def extended_error_info
       inspector.extended_error_info
+    end
+
+    def message
+      @message
+    end
+
+    def to_s
+      "#{message}\nCaused by: #{reason}"
     end
 
     private

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -115,6 +115,9 @@ module ChefDK
   class PolicyfileListError < PolicyfileNestedException
   end
 
+  class PolicyfileCleanError < PolicyfileNestedException
+  end
+
   class ChefRunnerError < StandardError
 
     include NestedExceptionWithInspector

--- a/spec/unit/policyfile_services/clean_policies_spec.rb
+++ b/spec/unit/policyfile_services/clean_policies_spec.rb
@@ -1,0 +1,236 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile_services/clean_policies'
+
+describe ChefDK::PolicyfileServices::CleanPolicies do
+
+  let(:chef_config) { double("Chef::Config") }
+
+  let(:policy_lister) do
+    clean_policies_service.policy_lister
+  end
+
+  let(:policies_by_name) { {} }
+  let(:policies_by_group) { {} }
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  subject(:clean_policies_service) do
+    described_class.new(config: chef_config, ui: ui)
+  end
+
+  describe "when there is an error listing data from the server" do
+
+    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+
+    let(:response) do
+      Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
+        r.instance_variable_set(:@body, "oops")
+      end
+    end
+
+    let(:http_exception) do
+      begin
+        response.error!
+      rescue => e
+        e
+      end
+    end
+
+    before do
+      expect(policy_lister).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:get).and_raise(http_exception)
+    end
+
+    it "raises an error" do
+      expect { clean_policies_service.run }.to raise_error(ChefDK::PolicyfileCleanError)
+    end
+
+  end
+
+  context "when existing policies are listed successfully" do
+
+    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+
+    before do
+      policy_lister.set!(policies_by_name, policies_by_group)
+    end
+
+    describe "cleaning unused policy revisions" do
+
+      before do
+        allow(clean_policies_service).to receive(:http_client).and_return(http_client)
+      end
+
+      context "when there are no policies" do
+
+        before do
+          expect(http_client).to_not receive(:delete)
+        end
+
+        it "doesn't delete anything" do
+          clean_policies_service.run
+          expect(ui.output).to eq("No policy revisions deleted\n")
+        end
+
+      end
+
+      context "when there are policies but none are orphans" do
+
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {}
+            },
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {}
+            }
+          }
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555"
+            },
+            "prod" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "6666666666666666666666666666666666666666666666666666666666666666"
+            }
+          }
+        end
+
+        before do
+          expect(http_client).to_not receive(:delete)
+        end
+
+        it "doesn't delete anything" do
+          clean_policies_service.run
+          expect(ui.output).to eq("No policy revisions deleted\n")
+        end
+
+      end
+
+      context "when there are policies and some are orphans" do
+
+        let(:policies_by_name) do
+          {
+            "appserver" => {
+              "1111111111111111111111111111111111111111111111111111111111111111" => {},
+              "2222222222222222222222222222222222222222222222222222222222222222" => {},
+              "4444444444444444444444444444444444444444444444444444444444444444" => {}
+            },
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {},
+              "7777777777777777777777777777777777777777777777777777777777777777" => {}
+            }
+          }
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555"
+            },
+            "staging" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555"
+            },
+            "prod" => {
+              "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+              "load-balancer" => "6666666666666666666666666666666666666666666666666666666666666666"
+            }
+          }
+        end
+
+        describe "and all deletes are successful" do
+
+          before do
+            expect(http_client).to receive(:delete).with("/policies/appserver/revisions/4444444444444444444444444444444444444444444444444444444444444444")
+            expect(http_client).to receive(:delete).with("/policies/load-balancer/revisions/7777777777777777777777777777777777777777777777777777777777777777")
+          end
+
+          it "deletes the orphaned policies" do
+            clean_policies_service.run
+            expected_message = <<-MESSAGE
+DELETE appserver 4444444444444444444444444444444444444444444444444444444444444444
+DELETE load-balancer 7777777777777777777777777777777777777777777777777777777777777777
+MESSAGE
+            expect(ui.output).to eq(expected_message)
+          end
+
+        end
+
+        # For example, a user doesn't have permission on all policy_names
+        describe "when some deletes fail" do
+
+          let(:response) do
+            Net::HTTPResponse.send(:response_class, "403").new("1.0", "403", "Unauthorized").tap do |r|
+              r.instance_variable_set(:@body, "I can't let you do that Dave")
+            end
+          end
+
+          let(:http_exception) do
+            begin
+              response.error!
+            rescue => e
+              e
+            end
+          end
+
+          before do
+            expect(http_client).to receive(:delete).
+              with("/policies/appserver/revisions/4444444444444444444444444444444444444444444444444444444444444444").
+              and_raise(http_exception)
+            expect(http_client).to receive(:delete).with("/policies/load-balancer/revisions/7777777777777777777777777777777777777777777777777777777777777777")
+          end
+
+          it "deletes what it can, then raises an error" do
+            expected_message = <<-ERROR
+Failed to delete some policy revisions:
+- appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPServerException 403 \"Unauthorized\"
+ERROR
+
+            expect { clean_policies_service.run }.to raise_error do |error|
+              expect(error.message).to eq(expected_message)
+            end
+            expected_message = <<-MESSAGE
+DELETE appserver 4444444444444444444444444444444444444444444444444444444444444444
+DELETE load-balancer 7777777777777777777777777777777777777777777777777777777777777777
+MESSAGE
+            expect(ui.output).to eq(expected_message)
+          end
+
+        end
+
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/policyfile_services/show_policy_spec.rb
+++ b/spec/unit/policyfile_services/show_policy_spec.rb
@@ -58,7 +58,6 @@ describe ChefDK::PolicyfileServices::ShowPolicy do
 
       let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
 
-      # TODO: make this reusable
       let(:response) do
         Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
           r.instance_variable_set(:@body, "oops")


### PR DESCRIPTION
Adds a service object that garbage collects unused policyfile revision objects on the server. This requires APIs that don't yet exist, so it only works with the HTTP code mocked out. Implementing the server API is the next step, then I'll come back and add a command to the CLI that exposes this to the end user.