### PR TITLE
Backend for policy group removal

### DIFF
--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -68,6 +68,9 @@ module ChefDK
   class InvalidPolicyfileFilename < StandardError
   end
 
+  class InvalidUndoRecord < StandardError
+  end
+
   class BUG < RuntimeError
   end
 

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -71,6 +71,9 @@ module ChefDK
   class InvalidUndoRecord < StandardError
   end
 
+  class CantUndo < StandardError
+  end
+
   class BUG < RuntimeError
   end
 

--- a/lib/chef-dk/policyfile/undo_record.rb
+++ b/lib/chef-dk/policyfile/undo_record.rb
@@ -49,6 +49,12 @@ module ChefDK
         reset!
       end
 
+      def ==(other)
+        other.kind_of?(UndoRecord) &&
+          other.policy_groups == policy_groups &&
+          other.policy_revisions == policy_revisions
+      end
+
       def add_policy_group(name)
         @policy_groups << name
       end
@@ -101,7 +107,7 @@ module ChefDK
           @policy_revisions << PolicyGroupRestoreData.new.load(revision)
         end
 
-        true
+        self
       end
 
       def for_serialization

--- a/lib/chef-dk/policyfile/undo_record.rb
+++ b/lib/chef-dk/policyfile/undo_record.rb
@@ -120,10 +120,6 @@ module ChefDK
         }
       end
 
-      def commit!
-        raise NotImplementedError, "TODO"
-      end
-
       private
 
       def reset!

--- a/lib/chef-dk/policyfile/undo_record.rb
+++ b/lib/chef-dk/policyfile/undo_record.rb
@@ -1,0 +1,133 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/exceptions'
+
+module ChefDK
+  module Policyfile
+
+    class UndoRecord
+
+      PolicyGroupRestoreData = Struct.new(:policy_name, :policy_group, :data) do
+
+        def load(data)
+          self.policy_name = data["policy_name"]
+          self.policy_group = data["policy_group"]
+          self.data = data["data"]
+          self
+        end
+
+        def for_serialization
+          {
+            "policy_name" => policy_name,
+            "policy_group" => policy_group,
+            "data" => data
+          }
+        end
+
+      end
+
+      attr_reader :policy_groups
+
+      attr_reader :policy_revisions
+
+      def initialize
+        reset!
+      end
+
+      def add_policy_group(name)
+        @policy_groups << name
+      end
+
+      def add_policy_revision(policy_name, policy_group, data)
+        @policy_revisions << PolicyGroupRestoreData.new(policy_name, policy_group, data)
+      end
+
+      def load(data)
+        reset!
+
+        unless data.kind_of?(Hash)
+          raise InvalidUndoRecord, "Undo data is incorrectly formatted. Must be a Hash, got '#{data}'."
+        end
+        missing_fields = %w[ format_version backup_data ].select { |key| !data.key?(key) }
+        unless missing_fields.empty?
+          raise InvalidUndoRecord, "Undo data is missing mandatory field(s) #{missing_fields.join(', ')}. Undo data: '#{data}'"
+        end
+        policy_data = data["backup_data"]
+        unless policy_data.kind_of?(Hash)
+          raise InvalidUndoRecord, "'backup_data' in the undo record is incorrectly formatted. Must be a Hash, got '#{policy_data}'"
+        end
+        missing_policy_data_fields = %w[ policy_groups policy_revisions ].select { |key| !policy_data.key?(key) }
+        unless missing_policy_data_fields.empty?
+          raise InvalidUndoRecord,
+            "'backup_data' in the undo record is missing mandatory field(s) #{missing_policy_data_fields.join(', ')}. Backup data: #{policy_data}"
+        end
+
+        policy_groups = policy_data["policy_groups"]
+
+        unless policy_groups.kind_of?(Array)
+          raise InvalidUndoRecord,
+            "'policy_groups' data in the undo record is incorrectly formatted. Must be an Array, got '#{policy_groups}'"
+        end
+
+        @policy_groups = policy_groups
+
+        policy_revisions = policy_data["policy_revisions"]
+        unless policy_revisions.kind_of?(Array)
+          raise InvalidUndoRecord,
+            "'policy_revisions' data in the undo record is incorrectly formatted. Must be an Array, got '#{policy_revisions}'"
+        end
+
+        policy_revisions.each do |revision|
+          unless revision.kind_of?(Hash)
+            raise InvalidUndoRecord,
+              "Invalid item in 'policy_revisions' in the undo record. Must be a Hash, got '#{revision}'"
+          end
+
+          @policy_revisions << PolicyGroupRestoreData.new.load(revision)
+        end
+
+        true
+      end
+
+      def for_serialization
+        {
+          "format_version" => 1,
+          "backup_data" => {
+            "policy_groups" => policy_groups,
+            "policy_revisions" => policy_revisions.map(&:for_serialization)
+          }
+        }
+      end
+
+      def commit!
+        raise NotImplementedError, "TODO"
+      end
+
+      private
+
+      def reset!
+        @policy_groups = []
+        @policy_revisions = []
+      end
+
+    end
+  end
+end
+
+
+

--- a/lib/chef-dk/policyfile/undo_stack.rb
+++ b/lib/chef-dk/policyfile/undo_stack.rb
@@ -1,0 +1,98 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'fileutils'
+
+require 'ffi_yajl'
+
+require 'chef-dk/helpers'
+require 'chef-dk/policyfile/undo_record'
+
+module ChefDK
+  module Policyfile
+
+    class UndoStack
+
+      MAX_SIZE = 10
+
+      include Helpers
+
+      def undo_dir
+        File.join(Helpers.chefdk_home, "undo")
+      end
+
+      def size
+        undo_record_files.size
+      end
+
+      def undo_records
+        undo_record_files.map { |f| load_undo_record(f) }
+      end
+
+      def push(undo_record)
+        ensure_undo_dir_exists
+
+        record_id = Time.new.utc.strftime("%Y%m%d%H%M%S")
+        path = File.join(undo_dir, record_id)
+
+        with_file(path) do |f|
+          f.print(FFI_Yajl::Encoder.encode(undo_record.for_serialization))
+        end
+
+        records_to_delete = undo_record_files.size - MAX_SIZE
+        if records_to_delete > 0
+          undo_record_files.take(records_to_delete).each do |file|
+            File.unlink(file)
+          end
+        end
+
+        self
+      end
+
+      def pop
+        file_to_pop = undo_record_files.last
+        if file_to_pop.nil?
+          raise CantUndo, "No undo records exist in #{undo_dir}"
+        end
+
+        record = load_undo_record(file_to_pop)
+        File.unlink(file_to_pop)
+        record
+      end
+
+      private
+
+      def load_undo_record(file)
+        data = FFI_Yajl::Parser.parse(IO.read(file))
+        UndoRecord.new.load(data)
+      end
+
+      def undo_record_files
+        Dir[File.join(undo_dir, '*')].sort
+      end
+
+      def ensure_undo_dir_exists
+        return false if File.directory?(undo_dir)
+
+
+        FileUtils.mkdir_p(undo_dir)
+      end
+    end
+
+  end
+end
+

--- a/lib/chef-dk/policyfile_services/rm_policy_group.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy_group.rb
@@ -1,0 +1,104 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/service_exceptions'
+require 'chef-dk/authenticated_http'
+
+module ChefDK
+  module PolicyfileServices
+
+    class UndoRecord
+
+      PolicyGroupRestoreData = Struct.new(:policy_name, :policy_group, :data)
+
+      attr_reader :policy_groups
+
+      attr_reader :policy_revisions
+
+      def initialize
+        @policy_groups = []
+        @policy_revisions = []
+      end
+
+      def add_policy_group(name)
+        @policy_groups << name
+      end
+
+      def add_policy_revision(policy_name, policy_group, data)
+        @policy_revisions << PolicyGroupRestoreData.new(policy_name, policy_group, data)
+      end
+
+      def commit!
+        raise NotImplementedError, "TODO"
+      end
+
+    end
+
+    class RmPolicyGroup
+
+      attr_reader :policy_group
+
+      # @api private
+      attr_reader :chef_config
+
+      # @api private
+      attr_reader :ui
+
+      # @api private
+      attr_reader :undo_record
+
+      def initialize(config: nil, ui: nil, policy_group: nil)
+        @chef_config = config
+        @ui = ui
+        @policy_group = policy_group
+
+        @undo_record = UndoRecord.new
+      end
+
+      def run
+
+        policy_group_list = http_client.get("/policy_groups")
+
+        unless policy_group_list.has_key?(policy_group)
+          ui.err("Policy group '#{policy_group}' does not exist on the server")
+          return false
+        end
+        policies_in_group = policy_group_list[policy_group]
+        policies_in_group.each do |name, rev_id|
+          policy_revision_data = http_client.get("/policies/#{name}/revisions/#{rev_id}")
+          undo_record.add_policy_revision(name, policy_group, policy_revision_data)
+        end
+        http_client.delete("/policy_groups/#{policy_group}")
+        undo_record.add_policy_group(policy_group)
+        ui.err("Removed policy group '#{policy_group}'.")
+        undo_record.commit!
+      rescue => e
+        raise DeletePolicyGroupError.new("Failed to delete policy group '#{policy_group}'", e)
+      end
+
+      # @api private
+      # An instance of ChefDK::AuthenticatedHTTP configured with the user's
+      # server URL and credentials.
+      def http_client
+        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
+                                                       signing_key_filename: chef_config.client_key,
+                                                       client_name: chef_config.node_name)
+      end
+    end
+  end
+end
+

--- a/lib/chef-dk/policyfile_services/rm_policy_group.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy_group.rb
@@ -17,36 +17,10 @@
 
 require 'chef-dk/service_exceptions'
 require 'chef-dk/authenticated_http'
+require 'chef-dk/policyfile/undo_record'
 
 module ChefDK
   module PolicyfileServices
-
-    class UndoRecord
-
-      PolicyGroupRestoreData = Struct.new(:policy_name, :policy_group, :data)
-
-      attr_reader :policy_groups
-
-      attr_reader :policy_revisions
-
-      def initialize
-        @policy_groups = []
-        @policy_revisions = []
-      end
-
-      def add_policy_group(name)
-        @policy_groups << name
-      end
-
-      def add_policy_revision(policy_name, policy_group, data)
-        @policy_revisions << PolicyGroupRestoreData.new(policy_name, policy_group, data)
-      end
-
-      def commit!
-        raise NotImplementedError, "TODO"
-      end
-
-    end
 
     class RmPolicyGroup
 
@@ -66,7 +40,7 @@ module ChefDK
         @ui = ui
         @policy_group = policy_group
 
-        @undo_record = UndoRecord.new
+        @undo_record = Policyfile::UndoRecord.new
       end
 
       def run

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -118,6 +118,9 @@ module ChefDK
   class PolicyfileCleanError < PolicyfileNestedException
   end
 
+  class DeletePolicyGroupError < PolicyfileNestedException
+  end
+
   class ChefRunnerError < StandardError
 
     include NestedExceptionWithInspector

--- a/spec/unit/policyfile/undo_record_spec.rb
+++ b/spec/unit/policyfile/undo_record_spec.rb
@@ -1,0 +1,243 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile/undo_record'
+
+describe ChefDK::Policyfile::UndoRecord do
+
+  subject(:undo_record) { described_class.new }
+
+  let(:policy_revision) do
+    {
+      "name" => "appserver",
+      "revision_id" => "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+  end
+
+  context "when empty" do
+
+    it "has an empty set of policy groups" do
+      expect(undo_record.policy_groups).to eq([])
+    end
+
+    it "has an empty set of policy revisions" do
+      expect(undo_record.policy_revisions).to eq([])
+    end
+
+    it "converts to a serializable data structure" do
+      expected = {
+        "format_version" => 1,
+        "backup_data" => {
+          "policy_groups" => [],
+          "policy_revisions" => []
+        }
+      }
+      expect(undo_record.for_serialization).to eq(expected)
+    end
+  end
+
+  context "with policy data" do
+
+    before do
+      undo_record.add_policy_group("preprod")
+      undo_record.add_policy_revision("appserver", "preprod", policy_revision)
+    end
+
+    it "has a policy group" do
+      expect(undo_record.policy_groups).to eq( [ "preprod" ] )
+    end
+
+    it "has a policy revision" do
+      expect(undo_record.policy_revisions.size).to eq(1)
+      revision_info = undo_record.policy_revisions.first
+      expect(revision_info.policy_name).to eq("appserver")
+      expect(revision_info.policy_group).to eq("preprod")
+      expect(revision_info.data).to eq(policy_revision)
+    end
+
+    it "converts to a serializable data structure" do
+      expected = {
+        "format_version" => 1,
+        "backup_data" => {
+          "policy_groups" => [ "preprod" ],
+          "policy_revisions" => [
+            {
+              "policy_name" => "appserver",
+              "policy_group" => "preprod",
+              "data" => policy_revision
+            }
+          ]
+        }
+      }
+      expect(undo_record.for_serialization).to eq(expected)
+    end
+
+  end
+
+  describe "loading from serialized data" do
+
+    context "with invalid data" do
+
+      context "with an invalid object type" do
+
+        let(:serialized_data) { [] }
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+
+      context "when required top-level keys aren't present" do
+
+        let(:serialized_data) { {} }
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+
+      context "when backup_data is an invalid type" do
+
+        let(:serialized_data) do
+          {
+            "format_version" => 1,
+            "backup_data" => []
+          }
+        end
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+
+      context "when backup_data is missing required fields" do
+
+        let(:serialized_data) do
+          {
+            "format_version" => 1,
+            "backup_data" => {}
+          }
+        end
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+
+      context "when backup_data has invalid policy_groups data" do
+
+        let(:serialized_data) do
+          {
+            "format_version" => 1,
+            "backup_data" => {
+              "policy_groups" => nil,
+              "policy_revisions" => []
+            }
+          }
+        end
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+
+      context "when backup_data has and invalid type for policy_revisions" do
+
+        let(:serialized_data) do
+          {
+            "format_version" => 1,
+            "backup_data" => {
+              "policy_groups" => [],
+              "policy_revisions" => nil
+            }
+          }
+        end
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+
+      context "when the backup_data has an invalid item in policy revisions" do
+
+        let(:serialized_data) do
+          {
+            "format_version" => 1,
+            "backup_data" => {
+              "policy_groups" => [],
+              "policy_revisions" => [ nil ]
+            }
+          }
+        end
+
+        it "raises an error" do
+          expect { undo_record.load(serialized_data) }.to raise_error(ChefDK::InvalidUndoRecord)
+        end
+
+      end
+    end
+
+    context "with valid data" do
+      let(:serialized_data) do
+        {
+          "format_version" => 1,
+          "backup_data" => {
+            "policy_groups" => [ "preprod" ],
+            "policy_revisions" => [
+              {
+                "policy_name" => "appserver",
+                "policy_group" => "preprod",
+                "data" => policy_revision
+              }
+            ]
+          }
+        }
+      end
+
+      before do
+        undo_record.load(serialized_data)
+      end
+
+      it "has a policy group" do
+        expect(undo_record.policy_groups).to eq( [ "preprod" ] )
+      end
+
+      it "has a policy revision" do
+        expect(undo_record.policy_revisions.size).to eq(1)
+        revision_info = undo_record.policy_revisions.first
+        expect(revision_info.policy_name).to eq("appserver")
+        expect(revision_info.policy_group).to eq("preprod")
+        expect(revision_info.data).to eq(policy_revision)
+      end
+
+      it "converts to a serializable data structure" do
+        expect(undo_record.for_serialization).to eq(serialized_data)
+      end
+
+
+    end
+  end
+
+end
+

--- a/spec/unit/policyfile/undo_stack_spec.rb
+++ b/spec/unit/policyfile/undo_stack_spec.rb
@@ -1,0 +1,219 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile/undo_stack'
+
+describe ChefDK::Policyfile::UndoStack do
+
+  let(:chefdk_home) { File.join(tempdir, "chefdk_home", ".chefdk") }
+
+  let(:policy_revision) do
+    {
+      "name" => "appserver",
+      "revision_id" => "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+  end
+
+  let(:undo_record) do
+    ChefDK::Policyfile::UndoRecord.new.tap do |undo_record|
+      undo_record.add_policy_group("preprod")
+      undo_record.add_policy_revision("appserver", "preprod", policy_revision)
+    end
+  end
+
+  # Probably takes a Chef::Config as an arg?
+  subject(:undo_stack) { described_class.new }
+
+  let(:expected_undo_dir) { File.join(chefdk_home, "undo") }
+
+  def undo_stack_files
+    Dir[File.join(expected_undo_dir, "*")]
+  end
+
+  before do
+    clear_tempdir
+    allow(ChefDK::Helpers).to receive(:chefdk_home).and_return(chefdk_home)
+  end
+
+  after(:all) do
+    clear_tempdir
+  end
+
+  it "uses chefdk_home to infer the location of the undo directory" do
+    expect(undo_stack.undo_dir).to eq(expected_undo_dir)
+  end
+
+  context "when there are no undo records" do
+
+    it "has zero items" do
+      expect(undo_stack.size).to eq(0)
+    end
+
+    it "has an empty list of undo records" do
+      expect(undo_stack.undo_records).to eq([])
+    end
+
+    it "raises an error when attempting to pop an item from the stack" do
+      expect { undo_stack.pop }.to raise_error(ChefDK::CantUndo)
+    end
+
+    describe "pushing an undo record" do
+
+      before do
+        expect(File.exist?(chefdk_home)).to be(false)
+        expect(File.exist?(expected_undo_dir)).to be(false)
+
+        undo_stack.push(undo_record)
+      end
+
+      it "creates the undo directory" do
+        expect(File.exist?(chefdk_home)).to be(true)
+        expect(File.exist?(expected_undo_dir)).to be(true)
+      end
+
+      it "creates the undo record" do
+        expect(undo_stack_files.size).to eq(1)
+
+        undo_record_json = IO.read(undo_stack_files.first)
+        undo_record_data = FFI_Yajl::Parser.parse(undo_record_json)
+        expect(undo_record_data).to eq(undo_record.for_serialization)
+      end
+
+    end
+
+  end
+
+  context "when there is one undo record" do
+
+    before do
+      undo_stack.push(undo_record)
+    end
+
+    it "creates the item on disk" do
+      expect(File).to be_directory(undo_stack.undo_dir)
+      expect(undo_stack_files.size).to eq(1)
+    end
+
+    it "has one item" do
+      expect(undo_stack.size).to eq(1)
+    end
+
+    it "has the undo record that was pushed" do
+      expect(undo_stack.undo_records.size).to eq(1)
+      expect(undo_stack.undo_records).to eq( [ undo_record ] )
+    end
+
+    describe "popping the last undo record" do
+
+      let!(:popped_record) { undo_stack.pop }
+
+      it "returns the popped item" do
+        expect(popped_record).to eq(undo_record)
+      end
+
+      it "removes the popped item" do
+        expect(undo_stack_files.size).to eq(0)
+      end
+
+    end
+
+  end
+
+
+  context "when the stack is at the maximum configured size" do
+    # `Time.new` is stubbed later on, need to force it to be evaluated before
+    # then.
+    let!(:start_time) { Time.new }
+
+    def next_time
+      @increment ||= 0
+      @increment += 1
+
+      start_time + @increment
+    end
+
+    def incremented_undo_record(i)
+      record = {
+        "name" => "appserver",
+        "revision_id" => i.to_s * 64
+      }
+
+      ChefDK::Policyfile::UndoRecord.new.tap do |undo_record|
+        undo_record.add_policy_group("preprod-#{i}")
+        undo_record.add_policy_revision("appserver", "preprod-#{i}", record)
+      end
+    end
+
+    before do
+      ##  # UndoStack assumes you're not creating more than 1 undo record/second,
+      ##  # which is reasonable in the real world but won't work here.
+      allow(Time).to receive(:new) { next_time }
+
+      10.times { |i| undo_stack.push(incremented_undo_record(i)) }
+
+      expect(undo_stack_files.size).to eq(10)
+    end
+
+    describe "pushing a new undo record" do
+      it "does not exceed the maximum size" do
+        undo_stack.push(incremented_undo_record(11))
+
+        expect(undo_stack_files.size).to eq(10)
+      end
+
+      it "removes the oldest record" do
+        oldest_record_file = undo_stack_files.sort.first
+
+        undo_stack.push(incremented_undo_record(11))
+
+        expect(File.exist?(oldest_record_file)).to be(false)
+      end
+    end
+
+    context "when the stack is above maximum configured size" do
+
+      let(:older_record_path) do
+        record_id = (Time.new - (3600 * 24)).utc.strftime("%Y%m%d%H%M%S")
+        File.join(expected_undo_dir, record_id)
+      end
+
+      before do
+        FileUtils.touch(older_record_path)
+      expect(undo_stack_files.size).to eq(11)
+      end
+
+      describe "pushing a new undo record" do
+        it "does not exceed the maximum size" do
+          undo_stack.push(incremented_undo_record(11))
+
+          expect(undo_stack_files.size).to eq(10)
+        end
+
+        it "removes the oldest record" do
+          oldest_record_file = undo_stack_files.sort.first
+
+          undo_stack.push(incremented_undo_record(11))
+
+          expect(File.exist?(oldest_record_file)).to be(false)
+        end
+      end
+
+    end
+  end
+
+end

--- a/spec/unit/policyfile_services/rm_policy_group_spec.rb
+++ b/spec/unit/policyfile_services/rm_policy_group_spec.rb
@@ -1,0 +1,226 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile_services/rm_policy_group'
+
+describe ChefDK::PolicyfileServices::RmPolicyGroup do
+
+  let(:policy_group) { "preprod" }
+
+  let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  let(:non_empty_policy_groups) do
+    {
+      "dev" => {
+        "appserver" => "1111111111111111111111111111111111111111111111111111111111111111",
+        "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+        "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+      },
+      "preprod" => {
+        "appserver" => "2222222222222222222222222222222222222222222222222222222222222222",
+        "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+        "db" => "9999999999999999999999999999999999999999999999999999999999999999"
+      }
+    }
+  end
+
+
+  let(:empty_policy_groups) do
+    {
+      "dev" => {
+      },
+      "preprod" => {
+      }
+    }
+  end
+
+  let(:chef_config) do
+    double("Chef::Config",
+           chef_server_url: "https://localhost:10443",
+           client_key: "/path/to/client/key.pem",
+           node_name: "deuce")
+  end
+
+  subject(:rm_policy_group_service) do
+    described_class.new(policy_group: policy_group, ui: ui, config: chef_config)
+  end
+
+  let(:undo_record) do
+    rm_policy_group_service.undo_record
+  end
+
+  it "configures an HTTP client" do
+    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+                                                       signing_key_filename: "/path/to/client/key.pem",
+                                                       client_name: "deuce")
+    rm_policy_group_service.http_client
+  end
+
+  context "when the server returns an error fetching the policy data" do
+
+    let(:response) do
+      Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
+        r.instance_variable_set(:@body, "oops")
+      end
+    end
+
+    let(:http_exception) do
+      begin
+        response.error!
+      rescue => e
+        e
+      end
+    end
+
+    before do
+      allow(rm_policy_group_service).to receive(:http_client).and_return(http_client)
+    end
+
+    describe "when getting an error response fetching the policy group" do
+
+      before do
+        expect(http_client).to receive(:get).with("/policy_groups").and_raise(http_exception)
+      end
+
+      it "re-raises the error with a standardized exception class" do
+        expect { rm_policy_group_service.run }.to raise_error(ChefDK::DeletePolicyGroupError)
+      end
+
+    end
+
+    describe "when getting an error fetching policy revisions" do
+
+      before do
+        expect(http_client).to receive(:get).with("/policy_groups").and_return(non_empty_policy_groups)
+        expect(http_client).to receive(:get).
+          with("/policies/appserver/revisions/2222222222222222222222222222222222222222222222222222222222222222").
+          and_raise(http_exception)
+      end
+
+      it "re-raises the error with a standardized exception class" do
+        expect { rm_policy_group_service.run }.to raise_error(ChefDK::DeletePolicyGroupError)
+      end
+
+    end
+
+
+  end
+
+  context "when the given group doesn't exist" do
+
+    let(:policy_group) { "incorrect_policy_group_name" }
+
+    before do
+      allow(rm_policy_group_service).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:get).with("/policy_groups").and_return(non_empty_policy_groups)
+    end
+
+    it "prints a message stating that the group doesn't exist" do
+      expect { rm_policy_group_service.run }.to_not raise_error
+      expect(ui.output).to eq("Policy group 'incorrect_policy_group_name' does not exist on the server\n")
+    end
+
+  end
+
+  context "when the group exists but has no policies assigned to it" do
+
+    before do
+      allow(rm_policy_group_service).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:get).with("/policy_groups").and_return(empty_policy_groups)
+      expect(http_client).to receive(:delete).with("/policy_groups/preprod")
+      expect(undo_record).to receive(:commit!)
+    end
+
+    it "removes the group" do
+      rm_policy_group_service.run
+      expect(ui.output).to include("Removed policy group 'preprod'.")
+    end
+
+    it "stores the group in the restore file" do
+      rm_policy_group_service.run
+      expect(undo_record.policy_groups).to eq( [ policy_group ] )
+      expect(undo_record.policy_revisions).to be_empty
+    end
+
+  end
+
+  context "when the group exists and has policies assigned to it" do
+
+    let(:policy_appserver_2) do
+      {
+        "name" => "appserver",
+        "revision_id" => "2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    end
+
+    let(:policy_load_balancer_5) do
+      {
+        "name" => "load-balancer",
+        "revision_id" => "5555555555555555555555555555555555555555555555555555555555555555"
+      }
+    end
+
+    let(:policy_db_9) do
+      {
+        "name" => "db",
+        "revision_id" => "9999999999999999999999999999999999999999999999999999999999999999"
+      }
+    end
+
+    before do
+      allow(rm_policy_group_service).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:get).with("/policy_groups").and_return(non_empty_policy_groups)
+      expect(http_client).to receive(:get).
+        with("/policies/appserver/revisions/2222222222222222222222222222222222222222222222222222222222222222").
+        and_return(policy_appserver_2)
+      expect(http_client).to receive(:get).
+        with("/policies/load-balancer/revisions/5555555555555555555555555555555555555555555555555555555555555555").
+        and_return(policy_load_balancer_5)
+      expect(http_client).to receive(:get).
+        with("/policies/db/revisions/9999999999999999999999999999999999999999999999999999999999999999").
+        and_return(policy_db_9)
+
+      expect(http_client).to receive(:delete).with("/policy_groups/preprod")
+      expect(undo_record).to receive(:commit!)
+    end
+
+    it "removes the group" do
+      rm_policy_group_service.run
+      expect(ui.output).to include("Removed policy group 'preprod'.")
+    end
+
+    it "stores the group and policyfile revision contents in the restore file" do
+      rm_policy_group_service.run
+      expect(undo_record.policy_groups).to eq( [ policy_group ] )
+
+      expected_policy_revision_undo_data =
+        [
+          { policy_name: "appserver", policy_group: "preprod", data: policy_appserver_2},
+          { policy_name: "load-balancer", policy_group: "preprod", data: policy_load_balancer_5},
+          { policy_name: "db", policy_group: "preprod", data: policy_db_9}
+        ]
+
+      expect(undo_record.policy_revisions.map(&:to_h)).to match_array(expected_policy_revision_undo_data)
+    end
+
+  end
+
+end
+

--- a/spec/unit/policyfile_services/rm_policy_group_spec.rb
+++ b/spec/unit/policyfile_services/rm_policy_group_spec.rb
@@ -66,6 +66,11 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
     rm_policy_group_service.undo_record
   end
 
+  let(:undo_stack) do
+    rm_policy_group_service.undo_stack
+  end
+
+
   it "configures an HTTP client" do
     expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
@@ -145,7 +150,7 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
       allow(rm_policy_group_service).to receive(:http_client).and_return(http_client)
       expect(http_client).to receive(:get).with("/policy_groups").and_return(empty_policy_groups)
       expect(http_client).to receive(:delete).with("/policy_groups/preprod")
-      expect(undo_record).to receive(:commit!)
+      expect(undo_stack).to receive(:push).with(undo_record)
     end
 
     it "removes the group" do
@@ -198,7 +203,7 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
         and_return(policy_db_9)
 
       expect(http_client).to receive(:delete).with("/policy_groups/preprod")
-      expect(undo_record).to receive(:commit!)
+      expect(undo_stack).to receive(:push).with(undo_record)
     end
 
     it "removes the group" do


### PR DESCRIPTION
Relies on APIs that don't exist yet, so it won't actually work. That will be addressed soon, then I'll come back and add CLIs on top of this.

Also adds an undo stack so that we don't need to have a naggy confirmation dialog thing