### PR TITLE
Catch bad params

### DIFF
--- a/lib/chef-dk/command/base.rb
+++ b/lib/chef-dk/command/base.rb
@@ -57,7 +57,7 @@ module ChefDK
           run(params)
         end
       rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
-        err(e.message)
+        err("ERROR: #{e.message}\n")
         msg(opt_parser)
         1
       end

--- a/lib/chef-dk/command/base.rb
+++ b/lib/chef-dk/command/base.rb
@@ -56,7 +56,7 @@ module ChefDK
         else
           run(params)
         end
-      rescue OptionParser::InvalidOption => e
+      rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
         err(e.message)
         msg(opt_parser)
         1

--- a/lib/chef-dk/command/generate.rb
+++ b/lib/chef-dk/command/generate.rb
@@ -86,6 +86,14 @@ E
           msg(banner)
           1
         end
+      rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
+        # ChefDK::Command::Base also handles this error in the same way, but it
+        # does not have access to the correct option parser, so it cannot print
+        # the usage correctly. Therefore, invalid CLI usage needs to be handled
+        # here.
+        err("ERROR: #{e.message}\n")
+        msg(generator.opt_parser)
+        1
       end
 
       def generator_for(arg)

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -101,7 +101,7 @@ describe ChefDK::Command::Base do
     it "prints the help banner and exits gracefully" do
       expect(run_command(%w[-foo])).to eq(1)
 
-      expect(stderr).to eq("invalid option: -foo\n")
+      expect(stderr).to eq("ERROR: invalid option: -foo\n\n")
 
       expected = <<-E
 use me please
@@ -119,7 +119,7 @@ E
     it "prints the help banner and exits gracefully" do
       expect(run_command(%w[-a])).to eq(1)
 
-      expect(stderr).to eq("missing argument: -a\n")
+      expect(stderr).to eq("ERROR: missing argument: -a\n\n")
 
       expected = <<-E
 use me please

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -22,6 +22,11 @@ describe ChefDK::Command::Base do
   class TestCommand < ChefDK::Command::Base
     banner "use me please"
 
+    option :argue,
+      short:       "-a ARG",
+      long:        "--arg ARG",
+      description: "An option with a required argument"
+
     option :user,
       :short        => "-u",
       :long         => "--user",
@@ -100,6 +105,7 @@ describe ChefDK::Command::Base do
 
       expected = <<-E
 use me please
+    -a, --arg ARG                    An option with a required argument
     -u, --user                       If the user exists
 
 E

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -114,4 +114,23 @@ E
 
   end
 
+  describe "when given an option that requires an argument with no argument" do
+
+    it "prints the help banner and exits gracefully" do
+      expect(run_command(%w[-a])).to eq(1)
+
+      expect(stderr).to eq("missing argument: -a\n")
+
+      expected = <<-E
+use me please
+    -a, --arg ARG                    An option with a required argument
+    -u, --user                       If the user exists
+
+E
+      expect(stdout).to eq(expected)
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Adds error handling for the case where a CLI option requires an argument but none is given. For example, the `-c` option requires an argument (path to a config file), so a command like `chef show-policy -c` is not valid. Currently, this error bubbles up for most commands so you get output like this:

```
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/mixlib-cli-1.5.0/lib/mixlib/cli.rb:191:in `parse_options': missing argument: -c (OptionParser::MissingArgument)
	from /opt/chefdk/embedded/apps/chef-dk/lib/chef-dk/command/show_policy.rb:136:in `apply_params!'
	from /opt/chefdk/embedded/apps/chef-dk/lib/chef-dk/command/show_policy.rb:90:in `run'
	from /opt/chefdk/embedded/apps/chef-dk/lib/chef-dk/command/base.rb:57:in `run_with_default_options'
	from /opt/chefdk/embedded/apps/chef-dk/lib/chef-dk/cli.rb:73:in `run'
	from /opt/chefdk/embedded/apps/chef-dk/bin/chef:25:in `<top (required)>'
	from /usr/bin/chef:74:in `load'
	from /usr/bin/chef:74:in `<main>'
```

With this patch, the output is now:

```
bundle exec bin/chef show-policy -c
ERROR: missing argument: -c

Usage: chef show-policy [POLICY_NAME [POLICY_GROUP]] [options]

`chef show-policy` Displays the revisions of policyfiles on the server. By
default, only active policy revisions are shown. Use the `--orphans` options to
show policy revisions that are not assigned to any policy group.

When both POLICY_NAME and POLICY_GROUP are given, the command shows the content
of a the active policyfile lock for the given POLICY_GROUP. See also the `diff`
command.

The Policyfile feature is incomplete and beta quality. See our detailed README
for more information.

https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md

Options:

    -c, --config CONFIG_FILE         Path to configuration file
    -D, --debug                      Enable stacktraces and other debug output
        --[no-]pager                 Enable/disable paged policyfile lock ouput (default: enabled)
    -o, --orphans                    Show policy revisions that are unassigned
```

I think this is more verbose than is ideal, but it's simple and it at least shows the usage for the option. Without the usage, the user's next step would probably be to run `command -h` to see the usage, which would be equally verbose. Improving this significantly (such as omitting the text description of the command) would require a bunch more changes. Since this error case shouldn't be _that_ frequent, this seems reasonable to me.