### PR TITLE
Show full usage when given invalid args

### DIFF
--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -140,7 +140,8 @@ E
         when 2
           @policyfile_relative_path, @export_dir = remaining_args
         else
-          ui.err(banner)
+          ui.err(opt_parser)
+          ui.err("\n")
           return false
         end
         true

--- a/lib/chef-dk/command/generator_commands/app.rb
+++ b/lib/chef-dk/command/generator_commands/app.rb
@@ -46,7 +46,7 @@ module ChefDK
             setup_context
             chef_runner.converge
           else
-            msg(banner)
+            err(opt_parser)
             1
           end
         rescue ChefDK::ChefRunnerError => e

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -49,7 +49,7 @@ module ChefDK
             setup_context
             chef_runner.converge
           else
-            msg(banner)
+            err(opt_parser)
             1
           end
         rescue ChefDK::ChefRunnerError => e

--- a/lib/chef-dk/command/generator_commands/policyfile.rb
+++ b/lib/chef-dk/command/generator_commands/policyfile.rb
@@ -52,7 +52,7 @@ module ChefDK
             chef_runner.converge
             0
           else
-            msg(banner)
+            err(opt_parser)
             1
           end
         end

--- a/lib/chef-dk/command/generator_commands/repo.rb
+++ b/lib/chef-dk/command/generator_commands/repo.rb
@@ -52,7 +52,7 @@ module ChefDK
             setup_context
             chef_runner.converge
           else
-            msg(banner)
+            err(opt_parser)
             1
           end
         end

--- a/lib/chef-dk/command/install.rb
+++ b/lib/chef-dk/command/install.rb
@@ -62,7 +62,7 @@ E
       end
 
       def run(params = [])
-        apply_params!(params)
+        return 1 unless apply_params!(params)
         installer.run
         0
       rescue PolicyfileServiceError => e
@@ -91,10 +91,11 @@ E
       def apply_params!(params)
         remaining_args = parse_options(params)
         if remaining_args.size > 1
-          ui.err(banner)
-          return 1
+          ui.err(opt_parser)
+          return false
         else
           @policyfile_relative_path = remaining_args.first
+          true
         end
       end
 

--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -74,7 +74,7 @@ BANNER
       end
 
       def run(params = [])
-        apply_params!(params)
+        return 1 unless apply_params!(params)
         if update_attributes?
           attributes_updater.run
         else
@@ -116,10 +116,11 @@ BANNER
       def apply_params!(params)
         remaining_args = parse_options(params)
         if remaining_args.size > 1
-          ui.err(banner)
-          return 1
+          ui.err(opt_parser)
+          false
         else
           @policyfile_relative_path = remaining_args.first
+          true
         end
       end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -99,7 +99,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
     it "prints usage when args are empty" do
       with_argv([]).run
-      expect(stdout_io.string).to eq(expected_help_message)
+      expect(stderr_io.string).to include(expected_help_message)
     end
 
   end

--- a/spec/unit/command/generator_commands/policyfile_spec.rb
+++ b/spec/unit/command/generator_commands/policyfile_spec.rb
@@ -115,7 +115,7 @@ describe ChefDK::Command::GeneratorCommands::Policyfile do
       expected_stdout = "Usage: chef generate policyfile [NAME] [options]"
 
       expect(generator.run).to eq(1)
-      expect(stdout).to include(expected_stdout)
+      expect(stderr).to include(expected_stdout)
     end
 
   end


### PR DESCRIPTION
I noticed that we were only displaying the banner and not the options when commands are given too many or not enough arguments. This fixes all instances I could find with `git grep` where this happened. Also standardizes on displaying this output on stderr.