### PR TITLE
Add basic zsh completion for chef command

### DIFF
--- a/lib/chef-dk/completions/zsh.zsh.erb
+++ b/lib/chef-dk/completions/zsh.zsh.erb
@@ -1,0 +1,21 @@
+function _chef() {
+
+  local -a _1st_arguments
+  _1st_arguments=(
+  <% commands.each do |command, desc| -%>
+    '<%=command%>:<%=desc%>'
+  <% end -%>
+  )
+
+  _arguments \
+    '(-v --version)'{-v,--version}'[version information]' \
+    '*:: :->subcmds' && return 0
+
+  if (( CURRENT == 1 )); then
+    _describe -t commands "chef subcommand" _1st_arguments
+    return
+  fi
+}
+
+compdef _chef chef
+


### PR DESCRIPTION
Adds very simple completion of subcommand names for zsh with subcommand descriptions. For example, typing `chef` and hitting <TAB> will show the following:

```
ddeleo@lorentz chef-dk git:(complete-zsh)> chef
diff          -- Generate an itemized diff of two Policyfile lock documents
env           -- Prints environment variables used by ChefDK
exec          -- Runs the command in context of the embedded ruby
export        -- Export a policy lock as a Chef Zero code repo
gem           -- Runs the `gem` command in context of the embedded ruby
generate      -- Generate a new app, cookbook, or component
install       -- Install cookbooks from a Policyfile and generate a locked cookbook set
provision     -- Provision VMs and clusters via cookbook
push          -- Push a local policy lock to a policy group on the server
push-archive  -- Push a policy archive to a policy group on the server
shell-init    -- Initialize your shell to use ChefDK as your primary ruby
show-policy   -- Show policyfile objects on you Chef Server
update        -- Updates a Policyfile.lock.json with latest run_list and cookbooks
verify        -- Test the embedded ChefDK applications
```

subcommands complete according to the normal way zsh does it.