### PR TITLE
`chef undelete` command

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -48,5 +48,7 @@ ChefDK.commands do |c|
 
   c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on the server"
 
+  c.builtin "undelete", :Undelete, desc: "Undo a delete command"
+
   c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications"
 end

--- a/lib/chef-dk/command/delete_policy_group.rb
+++ b/lib/chef-dk/command/delete_policy_group.rb
@@ -32,7 +32,7 @@ Usage: chef delete-policy-group POLICY_GROUP [options]
 `chef delete-policy-group POLICY_GROUP` deletes the policy group POLICY_GROUP on
 the configured Chef Server. Policy Revisions associated to the policy group are
 not deleted. The state of the policy group will be backed up locally, allowing
-you to undo this operation.
+you to undo this operation via the `chef undelete` command.
 
 The Policyfile feature is incomplete and beta quality. See our detailed README
 for more information.
@@ -70,6 +70,7 @@ BANNER
       def run(params)
         return 1 unless apply_params!(params)
         rm_policy_group_service.run
+        ui.msg("This operation can be reversed by running `chef undelete --last`.")
         0
       rescue PolicyfileServiceError => e
         handle_error(e)

--- a/lib/chef-dk/command/undelete.rb
+++ b/lib/chef-dk/command/undelete.rb
@@ -1,0 +1,156 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/ui'
+require 'chef-dk/configurable'
+require 'chef-dk/policyfile_services/undelete'
+
+module ChefDK
+  module Command
+
+    class Undelete < Base
+
+      banner(<<-BANNER)
+Usage: chef undelete [--list | --id ID] [options]
+
+`chef undelete` helps you recover quickly if you've deleted a policy or policy
+group in error. When run with no arguements, it lists the available undo
+operations. To undo the last delete operation, use `chef undelete --last`.
+
+CAVEATS:
+`chef undelete` doesn't detect conflicts. If a deleted item has been recreated,
+running `chef undelete` will overwrite it.
+
+Undo information does not include cookbooks that might be referenced by
+policies. If you have cleaned the policy cookbooks after the delete operation
+you want to reverse, `chef undelete` may not be able to fully restore the
+previous state.
+
+The delete commands also do not store access control data, so you may have to
+manually reapply any ACL customizations you have made.
+
+The Policyfile feature is incomplete and beta quality. See our detailed README
+for more information.
+
+https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+
+Options:
+
+BANNER
+
+      option :undo_last,
+        short:        "-l",
+        long:         "--last",
+        description:  "Undo the most recent delete operation"
+
+      option :undo_record_id,
+        short:        "-i ID",
+        long:         "--id ID",
+        description:  "Undo the delete operation with the given ID"
+
+      option :config_file,
+        short:        "-c CONFIG_FILE",
+        long:         "--config CONFIG_FILE",
+        description:  "Path to configuration file"
+
+      option :debug,
+        short:        "-D",
+        long:         "--debug",
+        description:  "Enable stacktraces and other debug output",
+        default:      false
+
+      include Configurable
+
+      attr_accessor :ui
+
+      attr_reader :undo_record_id
+
+      def initialize(*args)
+        super
+        @list_undo_records = false
+        @undo_record_id = nil
+        @ui = UI.new
+      end
+
+      def run(params)
+        return 1 unless apply_params!(params)
+        if list_undo_records?
+          undelete_service.list
+        else
+          undelete_service.run
+        end
+        0
+      rescue PolicyfileServiceError => e
+        handle_error(e)
+        1
+      end
+
+      def undelete_service
+        @undelete_service ||=
+          PolicyfileServices::Undelete.new(config: chef_config,
+                                             ui: ui,
+                                             undo_record_id: undo_record_id)
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def list_undo_records?
+        @list_undo_records
+      end
+
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+
+        if !remaining_args.empty?
+          ui.err("Too many arguments")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif config[:undo_record_id].nil? && config[:undo_last].nil?
+          @list_undo_records = true
+          true
+        elsif config[:undo_record_id] && config[:undo_last]
+          ui.err("Error: options --last and --id cannot both be given.")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        elsif config[:undo_record_id]
+          @undo_record_id = config[:undo_record_id]
+          true
+        elsif config[:undo_last]
+          @undo_record_id = nil
+          true
+        end
+      end
+
+    end
+  end
+end
+

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -74,6 +74,10 @@ module ChefDK
   class CantUndo < StandardError
   end
 
+  class UndoRecordNotFound < StandardError
+  end
+
+
   class BUG < RuntimeError
   end
 

--- a/lib/chef-dk/policyfile/undo_record.rb
+++ b/lib/chef-dk/policyfile/undo_record.rb
@@ -45,6 +45,8 @@ module ChefDK
 
       attr_reader :policy_revisions
 
+      attr_accessor :description
+
       def initialize
         reset!
       end
@@ -69,10 +71,13 @@ module ChefDK
         unless data.kind_of?(Hash)
           raise InvalidUndoRecord, "Undo data is incorrectly formatted. Must be a Hash, got '#{data}'."
         end
-        missing_fields = %w[ format_version backup_data ].select { |key| !data.key?(key) }
+        missing_fields = %w[ format_version description backup_data ].select { |key| !data.key?(key) }
         unless missing_fields.empty?
           raise InvalidUndoRecord, "Undo data is missing mandatory field(s) #{missing_fields.join(', ')}. Undo data: '#{data}'"
         end
+
+        @description = data["description"]
+
         policy_data = data["backup_data"]
         unless policy_data.kind_of?(Hash)
           raise InvalidUndoRecord, "'backup_data' in the undo record is incorrectly formatted. Must be a Hash, got '#{policy_data}'"
@@ -113,6 +118,7 @@ module ChefDK
       def for_serialization
         {
           "format_version" => 1,
+          "description" => description,
           "backup_data" => {
             "policy_groups" => policy_groups,
             "policy_revisions" => policy_revisions.map(&:for_serialization)
@@ -123,6 +129,7 @@ module ChefDK
       private
 
       def reset!
+        @description = ""
         @policy_groups = []
         @policy_revisions = []
       end

--- a/lib/chef-dk/policyfile/undo_stack.rb
+++ b/lib/chef-dk/policyfile/undo_stack.rb
@@ -39,6 +39,17 @@ module ChefDK
         undo_record_files.size
       end
 
+      def empty?
+        size == 0
+      end
+
+      # TODO: unit test
+      def each_with_id
+        undo_record_files.each do |filename|
+          yield File.basename(filename), load_undo_record(filename)
+        end
+      end
+
       def undo_records
         undo_record_files.map { |f| load_undo_record(f) }
       end

--- a/lib/chef-dk/policyfile_services/rm_policy_group.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy_group.rb
@@ -49,6 +49,7 @@ module ChefDK
       end
 
       def run
+        undo_record.description = "delete-policy-group #{policy_group}"
         policy_group_list = http_client.get("/policy_groups")
 
         unless policy_group_list.has_key?(policy_group)

--- a/lib/chef-dk/policyfile_services/undelete.rb
+++ b/lib/chef-dk/policyfile_services/undelete.rb
@@ -23,19 +23,6 @@ module ChefDK
   module PolicyfileServices
     class Undelete
 
-      # TODO: this is for the command's banner:
-      # Usage: chef undelete [undo_record_timestamp] [options]
-      #
-      # `chef undelete` helps you recover quickly if you've deleted a policy or
-      # policy group in error.
-      #
-      # Note that the delete commands do not copy cookbooks that might be
-      # referenced by policies. If you have cleaned the policy cookbooks after
-      # the delete operation you want to reverse, `chef undelete` may not be
-      # able to fully restore the previous state. The delete commands also do
-      # not store access control data, so you may have to manually reapply any
-      # ACL customizations you have made.
-
       attr_reader :ui
 
       attr_reader :chef_config

--- a/lib/chef-dk/policyfile_services/undelete.rb
+++ b/lib/chef-dk/policyfile_services/undelete.rb
@@ -1,0 +1,105 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/authenticated_http'
+require 'chef-dk/service_exceptions'
+require 'chef-dk/policyfile/undo_stack'
+
+module ChefDK
+  module PolicyfileServices
+    class Undelete
+
+      # TODO: this is for the command's banner:
+      # Usage: chef undelete [undo_record_timestamp] [options]
+      #
+      # `chef undelete` helps you recover quickly if you've deleted a policy or
+      # policy group in error.
+      #
+      # Note that the delete commands do not copy cookbooks that might be
+      # referenced by policies. If you have cleaned the policy cookbooks after
+      # the delete operation you want to reverse, `chef undelete` may not be
+      # able to fully restore the previous state. The delete commands also do
+      # not store access control data, so you may have to manually reapply any
+      # ACL customizations you have made.
+
+      attr_reader :ui
+
+      attr_reader :chef_config
+
+      attr_reader :undo_record_id
+
+      def initialize(undo_record_id: nil, config: nil, ui: nil)
+        @chef_config = config
+        @ui = ui
+        @undo_record_id = undo_record_id
+
+        @http_client = nil
+        @undo_stack = nil
+      end
+
+      # In addition to the #run method, this class also has #list as a public
+      # entry point. This prints the list of undoable items, with descriptions.
+      def list
+        if undo_stack.empty?
+          ui.err("Nothing to undo.")
+        else
+          messages = []
+          undo_stack.each_with_id do |timestamp, undo_record|
+            messages.unshift("#{timestamp}: #{undo_record.description}")
+          end
+          messages.each { |m| ui.msg(m) }
+        end
+      end
+
+      def run
+        if undo_record_id
+          if undo_stack.has_id?(undo_record_id)
+            undo_stack.delete(undo_record_id) { |undo_record| restore(undo_record) }
+          else
+            ui.err("No undo record with id '#{undo_record_id}' exists")
+          end
+        else
+          undo_stack.pop { |undo_record| restore(undo_record) }
+        end
+      rescue => e
+        raise UndeleteError.new("Failed to undelete.", e)
+      end
+
+      def undo_stack
+        @undo_stack ||= Policyfile::UndoStack.new
+      end
+
+      def http_client
+        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
+                                                       signing_key_filename: chef_config.client_key,
+                                                       client_name: chef_config.node_name)
+      end
+
+      private
+
+      def restore(undo_record)
+        undo_record.policy_revisions.each do |policy_info|
+          rel_uri = "/policy_groups/#{policy_info.policy_group}/policies/#{policy_info.policy_name}"
+          http_client.put(rel_uri, policy_info.data)
+          ui.msg("Restored policy '#{policy_info.policy_name}'")
+        end
+        ui.msg("Restored policy group '#{undo_record.policy_groups.first}'")
+      end
+
+    end
+  end
+end

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -124,6 +124,9 @@ module ChefDK
   class PolicyCookbookCleanError < PolicyfileNestedException
   end
 
+  class UndeleteError < PolicyfileNestedException
+  end
+
   class ChefRunnerError < StandardError
 
     include NestedExceptionWithInspector

--- a/spec/unit/command/undelete_spec.rb
+++ b/spec/unit/command/undelete_spec.rb
@@ -1,0 +1,246 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/undelete'
+
+describe ChefDK::Command::Undelete do
+
+  it_behaves_like "a command with a UI object"
+
+  subject(:command) do
+    described_class.new
+  end
+
+  let(:undelete_service) { command.undelete_service }
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:chef_config) { double("Chef::Config") }
+
+  # nil means the config loader will do the default path lookup
+  let(:config_arg) { nil }
+
+  before do
+    stub_const("Chef::Config", chef_config)
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "parsing args and options" do
+    let(:params) { [] }
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    before do
+      command.ui = ui
+      command.apply_params!(params)
+    end
+
+    context "when given a path to the config" do
+
+      let(:params) { %w[ -c ~/otherstuff/config.rb ] }
+
+      let(:config_arg) { "~/otherstuff/config.rb" }
+
+      before do
+        expect(chef_config_loader).to receive(:load)
+      end
+
+      it "reads the chef/knife config" do
+        expect(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+        expect(command.chef_config).to eq(chef_config)
+        expect(undelete_service.chef_config).to eq(chef_config)
+      end
+
+    end
+
+    describe "settings that require loading chef config" do
+
+      before do
+        allow(chef_config_loader).to receive(:load)
+      end
+
+      context "with no params" do
+
+        it "disables debug by default" do
+          expect(command.debug?).to be(false)
+        end
+
+        it "enables listing undo records" do
+          expect(command.list_undo_records?).to be(true)
+        end
+
+      end
+
+      context "when debug mode is set" do
+
+        let(:params) { [ "-D" ] }
+
+        it "enables debug" do
+          expect(command.debug?).to be(true)
+        end
+
+      end
+
+      context "when --last is given" do
+
+        let(:params) { %w[ -l ] }
+
+        it "disables list mode" do
+          expect(command.list_undo_records?).to be(false)
+        end
+
+        it "has no undo id" do
+          expect(command.undo_record_id).to be_nil
+          expect(command.undelete_service.undo_record_id).to be_nil
+        end
+
+      end
+
+      context "when given a undo record id via --id" do
+
+        let(:undo_id) { "20150827180422" }
+
+        let(:params) { [ "-i", undo_id ] }
+
+        it "disables list mode" do
+          expect(command.list_undo_records?).to be(false)
+        end
+
+        it "is configured to perform undo for the given undo id" do
+          expect(command.undo_record_id).to eq(undo_id)
+          expect(command.undelete_service.undo_record_id).to eq(undo_id)
+        end
+
+      end
+
+      context "when exclusive options --last and --id are given" do
+
+        let(:params) { %w[ --last --id foo ] }
+
+        it "emits an error message saying they are exclusive and exits" do
+          expect(ui.output).to include("Error: options --last and --id cannot both be given.")
+          expect(ui.output).to include(command.opt_parser.to_s)
+        end
+
+      end
+
+    end
+  end
+
+
+  describe "running the command" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    before do
+      allow(chef_config_loader).to receive(:load)
+      command.ui = ui
+    end
+
+    context "when given too many arguments" do
+
+      let(:params) { %w[ extra-thing ] }
+
+      it "shows usage and exits" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+
+    describe "running the command in list mode" do
+
+      let(:params) { [] }
+
+      it "lists the undo operations" do
+        expect(command.undelete_service).to receive(:list)
+        expect(command.run(params)).to eq(0)
+      end
+
+    end
+
+    context "when the undelete service raises an exception" do
+
+      let(:params) { %w[ --last ] }
+
+      let(:backtrace) { caller[0...3] }
+
+      let(:cause) do
+        e = StandardError.new("some operation failed")
+        e.set_backtrace(backtrace)
+        e
+      end
+
+      let(:exception) do
+        ChefDK::UndeleteError.new("Failed to undelete.", cause)
+      end
+
+      before do
+        allow(command.undelete_service).to receive(:run).and_raise(exception)
+      end
+
+      it "prints a debugging message and exits non-zero" do
+        expect(command.run(params)).to eq(1)
+
+        expected_output=<<-E
+Error: Failed to undelete.
+Reason: (StandardError) some operation failed
+
+E
+
+        expect(ui.output).to eq(expected_output)
+      end
+
+      context "when debug is enabled" do
+
+        it "includes the backtrace in the error" do
+
+          command.run(params + %w[ -D ])
+
+        expected_output=<<-E
+Error: Failed to undelete.
+Reason: (StandardError) some operation failed
+
+
+E
+          expected_output << backtrace.join("\n") << "\n"
+
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+
+    end
+
+    context "when the undelete service executes successfully" do
+
+      let(:params) { %w[ --last ] }
+
+      before do
+        expect(command.undelete_service).to receive(:run)
+      end
+
+      it "exits 0" do
+        expect(command.run(params)).to eq(0)
+      end
+
+    end
+
+  end
+end
+

--- a/spec/unit/policyfile/undo_record_spec.rb
+++ b/spec/unit/policyfile/undo_record_spec.rb
@@ -31,6 +31,10 @@ describe ChefDK::Policyfile::UndoRecord do
 
   context "when empty" do
 
+    it "has an empty description" do
+      expect(undo_record.description).to eq("")
+    end
+
     it "has an empty set of policy groups" do
       expect(undo_record.policy_groups).to eq([])
     end
@@ -42,6 +46,7 @@ describe ChefDK::Policyfile::UndoRecord do
     it "converts to a serializable data structure" do
       expected = {
         "format_version" => 1,
+        "description" => "",
         "backup_data" => {
           "policy_groups" => [],
           "policy_revisions" => []
@@ -54,8 +59,13 @@ describe ChefDK::Policyfile::UndoRecord do
   context "with policy data" do
 
     before do
+      undo_record.description = "delete-policy-group preprod"
       undo_record.add_policy_group("preprod")
       undo_record.add_policy_revision("appserver", "preprod", policy_revision)
+    end
+
+    it "has a description" do
+      expect(undo_record.description).to eq("delete-policy-group preprod")
     end
 
     it "has a policy group" do
@@ -73,6 +83,7 @@ describe ChefDK::Policyfile::UndoRecord do
     it "converts to a serializable data structure" do
       expected = {
         "format_version" => 1,
+        "description" => "delete-policy-group preprod",
         "backup_data" => {
           "policy_groups" => [ "preprod" ],
           "policy_revisions" => [
@@ -118,6 +129,7 @@ describe ChefDK::Policyfile::UndoRecord do
         let(:serialized_data) do
           {
             "format_version" => 1,
+            "description" => "delete-policy-group preprod",
             "backup_data" => []
           }
         end
@@ -133,6 +145,7 @@ describe ChefDK::Policyfile::UndoRecord do
         let(:serialized_data) do
           {
             "format_version" => 1,
+            "description" => "delete-policy-group preprod",
             "backup_data" => {}
           }
         end
@@ -148,6 +161,7 @@ describe ChefDK::Policyfile::UndoRecord do
         let(:serialized_data) do
           {
             "format_version" => 1,
+            "description" => "delete-policy-group preprod",
             "backup_data" => {
               "policy_groups" => nil,
               "policy_revisions" => []
@@ -166,6 +180,7 @@ describe ChefDK::Policyfile::UndoRecord do
         let(:serialized_data) do
           {
             "format_version" => 1,
+            "description" => "delete-policy-group preprod",
             "backup_data" => {
               "policy_groups" => [],
               "policy_revisions" => nil
@@ -184,6 +199,7 @@ describe ChefDK::Policyfile::UndoRecord do
         let(:serialized_data) do
           {
             "format_version" => 1,
+            "description" => "delete-policy-group preprod",
             "backup_data" => {
               "policy_groups" => [],
               "policy_revisions" => [ nil ]
@@ -202,6 +218,7 @@ describe ChefDK::Policyfile::UndoRecord do
       let(:serialized_data) do
         {
           "format_version" => 1,
+          "description" => "delete-policy-group preprod",
           "backup_data" => {
             "policy_groups" => [ "preprod" ],
             "policy_revisions" => [

--- a/spec/unit/policyfile_services/rm_policy_group_spec.rb
+++ b/spec/unit/policyfile_services/rm_policy_group_spec.rb
@@ -168,6 +168,7 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
 
     it "stores the group in the restore file" do
       rm_policy_group_service.run
+      expect(undo_record.description).to eq("delete-policy-group preprod")
       expect(undo_record.policy_groups).to eq( [ policy_group ] )
       expect(undo_record.policy_revisions).to be_empty
     end
@@ -221,6 +222,7 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
 
     it "stores the group and policyfile revision contents in the restore file" do
       rm_policy_group_service.run
+      expect(undo_record.description).to eq("delete-policy-group preprod")
       expect(undo_record.policy_groups).to eq( [ policy_group ] )
 
       expected_policy_revision_undo_data =

--- a/spec/unit/policyfile_services/undelete_spec.rb
+++ b/spec/unit/policyfile_services/undelete_spec.rb
@@ -1,0 +1,259 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile_services/undelete'
+
+describe ChefDK::PolicyfileServices::Undelete do
+
+  let(:chef_config) { double("Chef::Config") }
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  let(:policy_name) { nil }
+
+  let(:policy_group) { nil }
+
+  let(:show_orphans) { false }
+
+  let(:summary_diff) { false }
+
+  let(:undo_dir) { tempdir }
+
+  let(:undo_record_id) { nil }
+
+  subject(:undelete_service) do
+    described_class.new(config: chef_config,
+                        ui: ui,
+                        undo_record_id: undo_record_id)
+  end
+
+  describe "listing undo operations" do
+
+    before do
+      allow(undelete_service.undo_stack).to receive(:undo_dir).and_return(undo_dir)
+    end
+
+    after do
+      clear_tempdir
+    end
+
+    context "when the undo dir doesn't exist" do
+
+      let(:undo_dir) { File.join(tempdir, "this", "isnt", "here") }
+
+      it "prints a message saying there aren't any things to undo to stderr" do
+        undelete_service.list
+        expect(ui.output).to eq("Nothing to undo.\n")
+      end
+
+    end
+
+    context "when the undo dir exists, but it empty" do
+
+      it "prints a message saying there aren't any things to undo to stderr" do
+        undelete_service.list
+        expect(ui.output).to eq("Nothing to undo.\n")
+      end
+
+    end
+
+    context "when the undo dir exists and there are undo records in it" do
+
+      let(:policy_revision) do
+        {
+          "name" => "appserver",
+          "revision_id" => "1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      end
+
+      let(:undo_record1) do
+        ChefDK::Policyfile::UndoRecord.new.tap do |undo_record|
+          undo_record.description = "delete-policy-group example1"
+          undo_record.add_policy_group("example1")
+          undo_record.add_policy_revision("appserver", "example1", policy_revision)
+        end
+      end
+
+      let(:undo_record2) do
+        ChefDK::Policyfile::UndoRecord.new.tap do |undo_record|
+          undo_record.description = "delete-policy-group example2"
+          undo_record.add_policy_group("example2")
+          undo_record.add_policy_revision("appserver", "example2", policy_revision)
+        end
+      end
+
+      let(:undo_record3) do
+        ChefDK::Policyfile::UndoRecord.new.tap do |undo_record|
+          undo_record.description = "delete-policy-group example3"
+          undo_record.add_policy_group("example3")
+          undo_record.add_policy_revision("appserver", "example3", policy_revision)
+        end
+      end
+
+      # `Time.new` is stubbed later on, need to force it to be evaluated before
+      # then.
+      let!(:start_time) { Time.new }
+
+      def next_time
+        @increment ||= 0
+        @increment += 1
+
+        start_time + @increment
+      end
+
+      let(:times) { [] }
+
+      before do
+        allow(Time).to receive(:new) do
+          t = next_time
+          times << t
+          t
+        end
+        undo_stack = ChefDK::Policyfile::UndoStack.new
+        allow(undo_stack).to receive(:undo_dir).and_return(undo_dir)
+        undo_stack.push(undo_record1).push(undo_record2).push(undo_record3)
+      end
+
+      it "prints the items in reverse chronological order" do
+        undelete_service.list
+
+        timestamps = times.map { |t| t.utc.strftime("%Y%m%d%H%M%S") }
+
+        expected_output = <<-OUTPUT
+#{timestamps[2]}: delete-policy-group example3
+#{timestamps[1]}: delete-policy-group example2
+#{timestamps[0]}: delete-policy-group example1
+OUTPUT
+        expect(ui.output).to eq(expected_output)
+      end
+
+    end
+
+  end
+
+  describe "undoing a policy group delete" do
+
+    let(:policy_revision) do
+      {
+        "name" => "appserver",
+        "revision_id" => "1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    end
+
+    let(:undo_record1) do
+      ChefDK::Policyfile::UndoRecord.new.tap do |undo_record|
+        undo_record.description = "delete-policy-group example1"
+        undo_record.add_policy_group("example1")
+        undo_record.add_policy_revision("appserver", "example1", policy_revision)
+      end
+    end
+
+    let(:undo_stack) do
+      instance_double(ChefDK::Policyfile::UndoStack).tap do |s|
+        allow(s).to receive(:pop).and_yield(undo_record1)
+      end
+    end
+
+    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+
+    before do
+      allow(undelete_service).to receive(:http_client).and_return(http_client)
+      allow(undelete_service).to receive(:undo_stack).and_return(undo_stack)
+    end
+
+    describe "when an error occurs posting data to the server" do
+
+      let(:response) do
+        Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
+          r.instance_variable_set(:@body, "oops")
+        end
+      end
+
+      let(:http_exception) do
+        begin
+          response.error!
+        rescue => e
+          e
+        end
+      end
+
+      before do
+        expect(http_client).to receive(:put).
+          with("/policy_groups/example1/policies/appserver", policy_revision).
+          and_raise(http_exception)
+      end
+
+      it "raises an error" do
+        expect { undelete_service.run }.to raise_error(ChefDK::UndeleteError)
+      end
+
+    end
+
+    context "when the undelete is successful" do
+
+      before do
+        expect(http_client).to receive(:put).
+          with("/policy_groups/example1/policies/appserver", policy_revision)
+      end
+
+      it "uploads all policies to the server" do
+        undelete_service.run
+        expect(ui.output).to eq("Restored policy 'appserver'\nRestored policy group 'example1'\n")
+      end
+
+    end
+
+    context "when given a specific undo record id to undo" do
+
+      let(:undo_record_id) { "20150827172127" }
+
+      context "and the id doesn't exist" do
+
+        before do
+          expect(undo_stack).to receive(:has_id?).with(undo_record_id).and_return(false)
+        end
+
+        it "prints an error message that the id doesn't exist" do
+          undelete_service.run
+          expect(ui.output).to eq("No undo record with id '#{undo_record_id}' exists\n")
+        end
+
+      end
+
+      context "and the id exists" do
+        before do
+          expect(undo_stack).to receive(:has_id?).with(undo_record_id).and_return(true)
+          expect(undo_stack).to receive(:delete).with(undo_record_id).and_yield(undo_record1)
+          expect(http_client).to receive(:put).
+            with("/policy_groups/example1/policies/appserver", policy_revision)
+        end
+
+        it "uploads all policies to the server" do
+          undelete_service.run
+          expect(ui.output).to eq("Restored policy 'appserver'\nRestored policy group 'example1'\n")
+        end
+
+      end
+
+    end
+
+  end
+
+
+end
+


### PR DESCRIPTION
Adds the `chef undelete` subcommand. This reads undo records created by `chef delete-policy-group` (and `chef delete-policy` in the future) and loads the backup data back on to the Chef Server. It works in one of 3 ways:

* `chef undelete` lists the undo operations available.
* `chef undelete --last` undoes the last delete operation you did
* `chef undelete --id ID` undoes a specific delete operation (you can get the ID from the list).