### PR TITLE
Always show 'no policy' message when policy doesn't exist

### DIFF
--- a/lib/chef-dk/policyfile/lister.rb
+++ b/lib/chef-dk/policyfile/lister.rb
@@ -67,6 +67,8 @@ module ChefDK
 
     class PolicyGroupRevIDMap
 
+      include Enumerable
+
       attr_reader :policy_name
       attr_reader :revision_ids_by_group
 

--- a/lib/chef-dk/policyfile_services/show_policy.rb
+++ b/lib/chef-dk/policyfile_services/show_policy.rb
@@ -163,7 +163,7 @@ module ChefDK
         report.h1(policy_name)
         rev_id_by_group = policy_lister.revision_ids_by_group_for(policy_name)
 
-        if rev_id_by_group.empty?
+        if rev_id_by_group.empty? || rev_id_by_group.all? { |_k, rev| rev.nil? }
           ui.err("No policies named '#{policy_name}' are associated with a policy group")
           ui.err("")
         elsif show_summary_diff?

--- a/spec/unit/policyfile_services/show_policy_spec.rb
+++ b/spec/unit/policyfile_services/show_policy_spec.rb
@@ -499,7 +499,7 @@ OUTPUT
         show_policy_service.run
       end
 
-      context "when there are no revisions of the policy on the server" do
+      context "when there are no policies or groups on the server" do
 
         let(:policies_by_name) do
           {}
@@ -507,6 +507,56 @@ OUTPUT
 
         let(:policies_by_group) do
           {}
+        end
+
+        it "prints a message to stderr that there are no copies of the policy on the server" do
+          expected_output = <<-OUTPUT
+appserver
+=========
+
+No policies named 'appserver' are associated with a policy group
+
+OUTPUT
+
+          expect(ui.output).to eq(expected_output)
+        end
+      end
+
+      context "when there are no revisions of the policy on the server" do
+
+        let(:policies_by_name) do
+          {
+            "load-balancer" => {
+              "5555555555555555555555555555555555555555555555555555555555555555" => {},
+              "6666666666666666666666666666666666666666666666666666666666666666" => {},
+            },
+            "db" => {
+              "9999999999999999999999999999999999999999999999999999999999999999" => {},
+              "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" => {}
+            },
+            "memcache" => {
+              "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd" => {}
+            }
+          }
+        end
+
+        let(:policies_by_group) do
+          {
+            "dev" => {
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999",
+              "memcache" => "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            },
+            "staging" => {
+              "load-balancer" => "5555555555555555555555555555555555555555555555555555555555555555",
+              "db" => "9999999999999999999999999999999999999999999999999999999999999999",
+              "memcache" => "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            },
+            "prod" => {
+              "load-balancer" => "6666666666666666666666666666666666666666666666666666666666666666",
+              "db" => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
         end
 
         it "prints a message to stderr that there are no copies of the policy on the server" do
@@ -782,7 +832,7 @@ OUTPUT
       end
 
       before do
-        allow(http_client).to receive(:get).with("policy_groups/dev/policies/appserver").and_raise(http_exception)
+        expect(http_client).to receive(:get).with("policy_groups/dev/policies/appserver").and_raise(http_exception)
       end
 
       it "prints a message saying there is no policy assigned" do


### PR DESCRIPTION
Fixes a bug where showing a policy that doesn't exist would show that
policy as not being applied to any groups (but not indicating that it
doesn't exist), like this:

```
prompt$ chef show-policy nope-nope-nope -c ~/.chef/localserver.rb
nope-nope-nope
==============

* dev:         *NOT APPLIED*
* example:     *NOT APPLIED*
* production:  *NOT APPLIED*
* staging:     *NOT APPLIED*
```

Now the output is like:

```
nope-nope-nope
==============

No policies named 'nope-nope-nope' are associated with a policy group
```