### PR TITLE
Add `chef clean-policy-cookbooks` subcommand

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -48,6 +48,8 @@ ChefDK.commands do |c|
 
   c.builtin "clean-policy-revisions", :CleanPolicyRevisions, desc: "Delete unused policy revisions on the server"
 
+  c.builtin "clean-policy-cookbooks", :CleanPolicyCookbooks, desc: "Delete unused policyfile cookbooks on the server"
+
   c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on the server"
 
   c.builtin "undelete", :Undelete, desc: "Undo a delete command"

--- a/lib/chef-dk/command/clean_policy_cookbooks.rb
+++ b/lib/chef-dk/command/clean_policy_cookbooks.rb
@@ -1,0 +1,117 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/ui'
+require 'chef-dk/configurable'
+require 'chef-dk/policyfile_services/clean_policy_cookbooks'
+
+module ChefDK
+  module Command
+
+
+    class CleanPolicyCookbooks < Base
+
+      banner(<<-BANNER)
+Usage: chef clean-policy-cookbooks [options]
+
+`chef clean-policy-cookbooks` deletes unused policyfile cookbooks. Cookbooks
+are considered unused when they are not referenced by any policyfile revision
+on the server. Note that cookbooks which are referenced by "orphaned" policy
+revisions are not removed, so you may wish to run `chef clean-policy-revisions`
+to remove orphaned policies before running this command.
+
+The Policyfile feature is incomplete and beta quality. See our detailed README
+for more information.
+
+https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+
+Options:
+
+BANNER
+
+      option :config_file,
+        short:        "-c CONFIG_FILE",
+        long:         "--config CONFIG_FILE",
+        description:  "Path to configuration file"
+
+      option :debug,
+        short:        "-D",
+        long:         "--debug",
+        description:  "Enable stacktraces and other debug output",
+        default:      false
+
+      include Configurable
+
+      attr_accessor :ui
+
+      attr_reader :policy_name
+
+      attr_reader :policy_group
+
+      def initialize(*args)
+        super
+        @ui = UI.new
+
+        @clean_policy_cookbooks_service = nil
+      end
+
+      def run(params)
+        return 1 unless apply_params!(params)
+        clean_policy_cookbooks_service.run
+        0
+      rescue PolicyfileServiceError => e
+        handle_error(e)
+        1
+      end
+
+      def clean_policy_cookbooks_service
+        @clean_policy_cookbooks_service ||=
+          PolicyfileServices::CleanPolicyCookbooks.new(config: chef_config, ui: ui)
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+
+        if !remaining_args.empty?
+          ui.err("Too many arguments")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        else
+          true
+        end
+      end
+
+    end
+  end
+end
+

--- a/spec/unit/command/clean_policy_cookbooks_spec.rb
+++ b/spec/unit/command/clean_policy_cookbooks_spec.rb
@@ -1,0 +1,181 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/clean_policy_cookbooks'
+
+describe ChefDK::Command::CleanPolicyCookbooks do
+
+  it_behaves_like "a command with a UI object"
+
+  subject(:command) do
+    described_class.new
+  end
+
+  let(:clean_policy_cookbooks_service) { command.clean_policy_cookbooks_service }
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:chef_config) { double("Chef::Config") }
+
+  # nil means the config loader will do the default path lookup
+  let(:config_arg) { nil }
+
+  before do
+    stub_const("Chef::Config", chef_config)
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "parsing args and options" do
+    let(:params) { [] }
+
+    before do
+      command.apply_params!(params)
+    end
+
+    context "when given a path to the config" do
+
+      let(:params) { %w[ -c ~/otherstuff/config.rb ] }
+
+      let(:config_arg) { "~/otherstuff/config.rb" }
+
+      before do
+        expect(chef_config_loader).to receive(:load)
+      end
+
+      it "reads the chef/knife config" do
+        expect(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+        expect(command.chef_config).to eq(chef_config)
+        expect(clean_policy_cookbooks_service.chef_config).to eq(chef_config)
+      end
+
+    end
+
+    describe "settings that require loading chef config" do
+
+      before do
+        allow(chef_config_loader).to receive(:load)
+      end
+
+      context "with no params" do
+
+        it "disables debug by default" do
+          expect(command.debug?).to be(false)
+        end
+
+      end
+
+      context "when debug mode is set" do
+
+        let(:params) { [ "-D" ] }
+
+        it "enables debug" do
+          expect(command.debug?).to be(true)
+        end
+
+      end
+
+    end
+
+  end
+
+  describe "running the command" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    before do
+      allow(chef_config_loader).to receive(:load)
+      command.ui = ui
+    end
+
+    context "when given too many arguments" do
+
+      let(:params) { %w[ wut-is-this ] }
+
+      it "shows usage and exits" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+
+    context "when the clean policies service raises an exception" do
+
+      let(:backtrace) { caller[0...3] }
+
+      let(:cause) do
+        e = StandardError.new("some operation failed")
+        e.set_backtrace(backtrace)
+        e
+      end
+
+      let(:exception) do
+        ChefDK::PolicyfileCleanError.new("Failed to delete some policy revisions.", cause)
+      end
+
+      before do
+        allow(clean_policy_cookbooks_service).to receive(:run).and_raise(exception)
+      end
+
+      it "prints a debugging message and exits non-zero" do
+        expect(command.run([])).to eq(1)
+
+        expected_output=<<-E
+Error: Failed to delete some policy revisions.
+Reason: (StandardError) some operation failed
+
+E
+
+        expect(ui.output).to eq(expected_output)
+      end
+
+      context "when debug is enabled" do
+
+        it "includes the backtrace in the error" do
+
+          command.run(%w[ -D ])
+
+          expected_output=<<-E
+Error: Failed to delete some policy revisions.
+Reason: (StandardError) some operation failed
+
+
+E
+          expected_output << backtrace.join("\n") << "\n"
+
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+
+    end
+
+    context "when the clean policies service executes successfully" do
+
+      before do
+        expect(clean_policy_cookbooks_service).to receive(:run)
+      end
+
+      it "exits 0" do
+        expect(command.run([])).to eq(0)
+      end
+
+    end
+
+  end
+end
+

--- a/spec/unit/policyfile_services/clean_policy_cookbooks_spec.rb
+++ b/spec/unit/policyfile_services/clean_policy_cookbooks_spec.rb
@@ -253,6 +253,20 @@ describe ChefDK::PolicyfileServices::CleanPolicyCookbooks do
           clean_policy_cookbooks_service.run
         end
 
+        # Regression test. This was giving us an Argument error for `<Set> - nil`
+        context "when there are no active revisions of a given cookbook" do
+
+          let(:policies_list) { {} }
+
+          it "deletes the non-active cookbooks" do
+            expect(http_client).to receive(:delete).with("/cookbook_artifacts/build-essential/d8ce58401d154378599b0fead81d2c390615602b")
+            expect(http_client).to receive(:delete).with("/cookbook_artifacts/build-essential/2db3df121028894f45497f847de91b91fbf76824")
+            expect(http_client).to receive(:delete).with("/cookbook_artifacts/mysql/6b506252cae939c874bd59b560c339b01c31326b")
+            clean_policy_cookbooks_service.run
+          end
+
+        end
+
       end
     end
   end


### PR DESCRIPTION
CLI front-end for the `clean_policy_cookbooks` service object. Enumerates all policy revisions and cookbooks, then deletes cookbooks that aren't referenced by any policy revision.