### PR TITLE
Add `chef delete-policy` subcommand

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -52,6 +52,8 @@ ChefDK.commands do |c|
 
   c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on the server"
 
+  c.builtin "delete-policy", :DeletePolicy, desc: "Delete all revisions of a policy on the server"
+
   c.builtin "undelete", :Undelete, desc: "Undo a delete command"
 
   c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications"

--- a/lib/chef-dk/command/delete_policy.rb
+++ b/lib/chef-dk/command/delete_policy.rb
@@ -1,0 +1,123 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/base'
+require 'chef-dk/ui'
+require 'chef-dk/configurable'
+require 'chef-dk/policyfile_services/rm_policy'
+
+module ChefDK
+  module Command
+
+
+    class DeletePolicy < Base
+
+      banner(<<-BANNER)
+Usage: chef delete-policy POLICY_NAME [options]
+
+`chef delete-policy POLICY_NAME` deletes all revisions of the policy
+`POLICY_NAME` on the configured Chef Server. All policy revisions will be
+backed up locally, allowing you to undo this operation via the `chef undelete`
+command.
+
+The Policyfile feature is incomplete and beta quality. See our detailed README
+for more information.
+
+https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+
+Options:
+
+BANNER
+
+      option :config_file,
+        short:        "-c CONFIG_FILE",
+        long:         "--config CONFIG_FILE",
+        description:  "Path to configuration file"
+
+      option :debug,
+        short:        "-D",
+        long:         "--debug",
+        description:  "Enable stacktraces and other debug output",
+        default:      false
+
+      include Configurable
+
+      attr_accessor :ui
+
+      attr_reader :policy_name
+
+      def initialize(*args)
+        super
+        @policy_name = nil
+        @rm_policy_service = nil
+        @ui = UI.new
+      end
+
+      def run(params)
+        return 1 unless apply_params!(params)
+        rm_policy_service.run
+        ui.msg("This operation can be reversed by running `chef undelete --last`.")
+        0
+      rescue PolicyfileServiceError => e
+        handle_error(e)
+        1
+      end
+
+      def rm_policy_service
+        @rm_policy_service ||=
+          PolicyfileServices::RmPolicy.new(config: chef_config,
+                                           ui: ui,
+                                           policy_name: policy_name)
+      end
+
+      def debug?
+        !!config[:debug]
+      end
+
+      def handle_error(error)
+        ui.err("Error: #{error.message}")
+        if error.respond_to?(:reason)
+          ui.err("Reason: #{error.reason}")
+          ui.err("")
+          ui.err(error.extended_error_info) if debug?
+          ui.err(error.cause.backtrace.join("\n")) if debug?
+        end
+      end
+
+      def apply_params!(params)
+        remaining_args = parse_options(params)
+
+        if remaining_args.size == 1
+          @policy_name = remaining_args.first
+          true
+        elsif remaining_args.empty?
+          ui.err("You must specify the POLICY_NAME to delete.")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        else
+          ui.err("Too many arguments")
+          ui.err("")
+          ui.err(opt_parser)
+          false
+        end
+      end
+
+    end
+  end
+end
+

--- a/lib/chef-dk/policyfile_services/rm_policy.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy.rb
@@ -1,0 +1,119 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/service_exceptions'
+require 'chef-dk/authenticated_http'
+require 'chef-dk/policyfile/undo_stack'
+require 'chef-dk/policyfile/undo_record'
+
+module ChefDK
+  module PolicyfileServices
+
+    class RmPolicy
+
+      attr_reader :policy_name
+
+      # @api private
+      attr_reader :chef_config
+
+      # @api private
+      attr_reader :ui
+
+      # @api private
+      attr_reader :undo_record
+
+      # @api private
+      attr_reader :undo_stack
+
+      def initialize(config: nil, ui: nil, policy_name: nil)
+        @chef_config = config
+        @ui = ui
+        @policy_name = policy_name
+
+        @policy_revision_data = nil
+        @policy_exists = false
+
+        @undo_record = Policyfile::UndoRecord.new
+        @undo_stack = Policyfile::UndoStack.new
+      end
+
+      def run
+        unless policy_exists?
+          ui.err("Policy '#{policy_name}' does not exist on the server")
+          return false
+        end
+
+        undo_record.description = "delete-policy #{policy_name}"
+
+        if policy_revision_data.empty? || policy_revision_data["revisions"].empty?
+          # TODO: print some message about this(?)
+        else
+          gather_policy_data_for_undo
+        end
+
+        http_client.delete("/policies/#{policy_name}")
+        undo_stack.push(undo_record)
+        ui.err("Removed policy '#{policy_name}'.")
+      rescue => e
+        pp e
+        raise DeletePolicyError.new("Failed to delete policy '#{policy_name}'", e)
+      end
+
+      # @api private
+      # An instance of ChefDK::AuthenticatedHTTP configured with the user's
+      # server URL and credentials.
+      def http_client
+        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
+                                                       signing_key_filename: chef_config.client_key,
+                                                       client_name: chef_config.node_name)
+      end
+
+      private
+
+      def gather_policy_data_for_undo
+        revisions = policy_revision_data["revisions"].keys
+
+        revisions.each do |revision_id|
+          policy_revision_data = http_client.get("/policies/#{policy_name}/revisions/#{revision_id}")
+          undo_record.add_policy_revision(policy_name, nil, policy_revision_data)
+        end
+      end
+
+
+      def policy_exists?
+        return true if @policy_exists
+        fetch_policy_revision_data
+        @policy_exists
+      end
+
+      def policy_revision_data
+        return @policy_revision_data if @policy_exists
+        fetch_policy_revision_data
+      end
+
+      def fetch_policy_revision_data
+        @policy_revision_data = http_client.get("/policies/#{policy_name}")
+        @policy_exists = true
+      rescue Net::HTTPServerException => e
+        raise unless e.response.code == "404"
+        @policy_exists = false
+      end
+
+    end
+  end
+end
+

--- a/lib/chef-dk/policyfile_services/rm_policy.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy.rb
@@ -60,9 +60,7 @@ module ChefDK
 
         undo_record.description = "delete-policy #{policy_name}"
 
-        if policy_revision_data.empty? || policy_revision_data["revisions"].empty?
-          # TODO: print some message about this(?)
-        else
+        unless policy_has_no_revisions?
           gather_policy_data_for_undo
         end
 
@@ -83,6 +81,10 @@ module ChefDK
       end
 
       private
+
+      def policy_has_no_revisions?
+        policy_revision_data.empty? || policy_revision_data["revisions"].empty?
+      end
 
       def gather_policy_data_for_undo
         revisions = policy_revision_data["revisions"].keys

--- a/lib/chef-dk/policyfile_services/undelete.rb
+++ b/lib/chef-dk/policyfile_services/undelete.rb
@@ -80,11 +80,27 @@ module ChefDK
 
       def restore(undo_record)
         undo_record.policy_revisions.each do |policy_info|
-          rel_uri = "/policy_groups/#{policy_info.policy_group}/policies/#{policy_info.policy_name}"
-          http_client.put(rel_uri, policy_info.data)
-          ui.msg("Restored policy '#{policy_info.policy_name}'")
+          if policy_info.policy_group.nil?
+            recreate_as_orphan(policy_info)
+          else
+            recreate_and_associate_to_group(policy_info)
+          end
         end
-        ui.msg("Restored policy group '#{undo_record.policy_groups.first}'")
+        if ( restored_policy_group = undo_record.policy_groups.first )
+          ui.msg("Restored policy group '#{restored_policy_group}'")
+        end
+      end
+
+      def recreate_as_orphan(policy_info)
+        rel_uri = "/policies/#{policy_info.policy_name}/revisions"
+        http_client.post(rel_uri, policy_info.data)
+        ui.msg("Restored policy '#{policy_info.policy_name}'")
+      end
+
+      def recreate_and_associate_to_group(policy_info)
+        rel_uri = "/policy_groups/#{policy_info.policy_group}/policies/#{policy_info.policy_name}"
+        http_client.put(rel_uri, policy_info.data)
+        ui.msg("Restored policy '#{policy_info.policy_name}'")
       end
 
     end

--- a/lib/chef-dk/service_exceptions.rb
+++ b/lib/chef-dk/service_exceptions.rb
@@ -121,6 +121,8 @@ module ChefDK
   class DeletePolicyGroupError < PolicyfileNestedException
   end
 
+  class DeletePolicyError < PolicyfileNestedException
+  end
   class PolicyCookbookCleanError < PolicyfileNestedException
   end
 

--- a/spec/unit/command/delete_policy_group_spec.rb
+++ b/spec/unit/command/delete_policy_group_spec.rb
@@ -151,7 +151,7 @@ describe ChefDK::Command::DeletePolicyGroup do
       end
 
       let(:exception) do
-        ChefDK::PolicyfileListError.new("Failed to list policies", cause)
+        ChefDK::DeletePolicyGroupError.new("Failed to delete policy group", cause)
       end
 
       before do
@@ -162,7 +162,7 @@ describe ChefDK::Command::DeletePolicyGroup do
         expect(command.run(%w[example-policy-group])).to eq(1)
 
         expected_output=<<-E
-Error: Failed to list policies
+Error: Failed to delete policy group
 Reason: (StandardError) some operation failed
 
 E
@@ -176,7 +176,7 @@ E
           command.run(%w[ example-policy-group -D ])
 
           expected_output=<<-E
-Error: Failed to list policies
+Error: Failed to delete policy group
 Reason: (StandardError) some operation failed
 
 
@@ -190,7 +190,7 @@ E
 
     end
 
-    context "when the list service executes successfully" do
+    context "when the rm policy group service executes successfully" do
 
       before do
         expect(command.rm_policy_group_service).to receive(:run)

--- a/spec/unit/command/delete_policy_spec.rb
+++ b/spec/unit/command/delete_policy_spec.rb
@@ -1,0 +1,207 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/command_with_ui_object'
+require 'chef-dk/command/delete_policy'
+
+describe ChefDK::Command::DeletePolicy do
+
+  it_behaves_like "a command with a UI object"
+
+  subject(:command) do
+    described_class.new
+  end
+
+  let(:chef_config_loader) { instance_double("Chef::WorkstationConfigLoader") }
+
+  let(:chef_config) { double("Chef::Config") }
+
+  # nil means the config loader will do the default path lookup
+  let(:config_arg) { nil }
+
+  before do
+    stub_const("Chef::Config", chef_config)
+    allow(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+  end
+
+  describe "parsing args and options" do
+
+    let(:base_params) { ["example-policy"] }
+
+    before do
+      command.apply_params!(params)
+    end
+
+    context "when given just the policy name" do
+
+      let(:params) { base_params }
+
+      it "sets the policy name" do
+        expect(command.policy_name).to eq("example-policy")
+      end
+
+      it "configures the rm_policy service" do
+        expect(chef_config_loader).to receive(:load)
+        service = command.rm_policy_service
+        expect(service).to be_a(ChefDK::PolicyfileServices::RmPolicy)
+        expect(service.chef_config).to eq(chef_config)
+        expect(service.ui).to eq(command.ui)
+        expect(service.policy_name).to eq("example-policy")
+      end
+    end
+
+    context "when given a path to the config" do
+
+      let(:params) { base_params + %w[ -c ~/otherstuff/config.rb ] }
+
+      let(:config_arg) { "~/otherstuff/config.rb" }
+
+      before do
+        expect(chef_config_loader).to receive(:load)
+      end
+
+      it "reads the chef/knife config" do
+        expect(Chef::WorkstationConfigLoader).to receive(:new).with(config_arg).and_return(chef_config_loader)
+        expect(command.chef_config).to eq(chef_config)
+        expect(command.rm_policy_service.chef_config).to eq(chef_config)
+      end
+
+    end
+
+    describe "settings that require loading chef config" do
+
+      before do
+        allow(chef_config_loader).to receive(:load)
+      end
+
+      context "with no params" do
+
+        let(:params) { base_params }
+
+        it "disables debug by default" do
+          expect(command.debug?).to be(false)
+        end
+
+      end
+
+      context "when debug mode is set" do
+
+        let(:params) { base_params + [ "-D" ] }
+
+        it "enables debug" do
+          expect(command.debug?).to be(true)
+        end
+
+      end
+    end
+  end
+
+  describe "running the command" do
+
+    let(:ui) { TestHelpers::TestUI.new }
+
+    before do
+      allow(chef_config_loader).to receive(:load)
+      command.ui = ui
+    end
+
+    context "when given too few arguments" do
+
+      let(:params) { %w[ ] }
+
+      it "shows usage and exits" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+
+    context "when given too many arguments" do
+
+      let(:params) { %w[ a-policy-name wut-is-this ] }
+
+      it "shows usage and exits" do
+        expect(command.run(params)).to eq(1)
+      end
+
+    end
+
+    context "when the rm_policy service raises an exception" do
+
+      let(:backtrace) { caller[0...3] }
+
+      let(:cause) do
+        e = StandardError.new("some operation failed")
+        e.set_backtrace(backtrace)
+        e
+      end
+
+      let(:exception) do
+        ChefDK::DeletePolicyError.new("Failed to delete policy.", cause)
+      end
+
+      before do
+        allow(command.rm_policy_service).to receive(:run).and_raise(exception)
+      end
+
+      it "prints a debugging message and exits non-zero" do
+        expect(command.run(%w[example-policy])).to eq(1)
+
+        expected_output=<<-E
+Error: Failed to delete policy.
+Reason: (StandardError) some operation failed
+
+E
+
+        expect(ui.output).to eq(expected_output)
+      end
+
+      context "when debug is enabled" do
+
+        it "includes the backtrace in the error" do
+          command.run(%w[ example-policy -D ])
+
+          expected_output=<<-E
+Error: Failed to delete policy.
+Reason: (StandardError) some operation failed
+
+
+E
+          expected_output << backtrace.join("\n") << "\n"
+
+          expect(ui.output).to eq(expected_output)
+        end
+
+      end
+
+    end
+
+    context "when the rm_policy service executes successfully" do
+
+      before do
+        expect(command.rm_policy_service).to receive(:run)
+      end
+
+      it "exits 0" do
+        expect(command.run(%w[example-policy])).to eq(0)
+      end
+
+    end
+
+  end
+end
+

--- a/spec/unit/policyfile_services/rm_policy_spec.rb
+++ b/spec/unit/policyfile_services/rm_policy_spec.rb
@@ -1,0 +1,201 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'chef-dk/policyfile_services/rm_policy'
+
+describe ChefDK::PolicyfileServices::RmPolicy do
+
+  let(:policy_name) { "appserver" }
+
+  let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+
+  let(:policy_revisions_data) do
+    {
+      "revisions" => {
+        "2222222222222222222222222222222222222222222222222222222222222222" => {},
+      }
+    }
+  end
+
+  let(:ui) { TestHelpers::TestUI.new }
+
+  let(:chef_config) do
+    double("Chef::Config",
+           chef_server_url: "https://localhost:10443",
+           client_key: "/path/to/client/key.pem",
+           node_name: "deuce")
+  end
+
+  subject(:rm_policy_service) do
+    described_class.new(policy_name: policy_name, ui: ui, config: chef_config)
+  end
+
+  let(:undo_record) do
+    rm_policy_service.undo_record
+  end
+
+  let(:undo_stack) do
+    rm_policy_service.undo_stack
+  end
+
+
+  it "configures an HTTP client" do
+    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+                                                       signing_key_filename: "/path/to/client/key.pem",
+                                                       client_name: "deuce")
+    rm_policy_service.http_client
+  end
+
+  context "when the server returns an error fetching the policy data" do
+
+    let(:response) do
+      Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
+        r.instance_variable_set(:@body, "oops")
+      end
+    end
+
+    let(:http_exception) do
+      begin
+        response.error!
+      rescue => e
+        e
+      end
+    end
+
+    before do
+      allow(rm_policy_service).to receive(:http_client).and_return(http_client)
+    end
+
+    describe "when getting an error fetching policy revisions" do
+
+      before do
+        expect(http_client).to receive(:get).with("/policies/appserver").and_return(policy_revisions_data)
+        expect(http_client).to receive(:get).
+          with("/policies/appserver/revisions/2222222222222222222222222222222222222222222222222222222222222222").
+          and_raise(http_exception)
+      end
+
+      it "re-raises the error with a standardized exception class" do
+        expect { rm_policy_service.run }.to raise_error(ChefDK::DeletePolicyError)
+      end
+
+    end
+
+
+  end
+
+  context "when the given policy doesn't exist" do
+
+    let(:policy_group) { "incorrect_policy_group_name" }
+
+    let(:response) do
+      Net::HTTPResponse.send(:response_class, "404").new("1.0", "404", "Not Found").tap do |r|
+        r.instance_variable_set(:@body, "not found")
+      end
+    end
+
+    let(:http_exception) do
+      begin
+        response.error!
+      rescue => e
+        e
+      end
+    end
+
+    before do
+      allow(rm_policy_service).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:get).with("/policies/appserver").and_raise(http_exception)
+    end
+
+    it "prints a message stating that the policy doesn't exist" do
+      expect { rm_policy_service.run }.to_not raise_error
+      expect(ui.output).to eq("Policy 'appserver' does not exist on the server\n")
+    end
+
+  end
+
+  context "when the policy exists but has no revisions" do
+
+    let(:empty_policy_data) { {} }
+
+    before do
+      allow(rm_policy_service).to receive(:http_client).and_return(http_client)
+      expect(http_client).to receive(:get).with("/policies/appserver").and_return(empty_policy_data)
+      expect(http_client).to receive(:delete).with("/policies/appserver")
+
+      # or expect it not to ?
+      expect(undo_stack).to receive(:push).with(undo_record)
+    end
+
+    it "removes the policy" do
+      rm_policy_service.run
+    end
+
+    # this is tricky, we won't be able to undo this b/c we cannot create a
+    # policy_name directly, we have to create a revision. However, this case is
+    # likely to be very rare, as the user has to manually send a DELETE to
+    # /policy_groups/:group/policies/:policy for each group the policy used to
+    # belong to, or delete every policy group that it belonged to, in order to
+    # create this situation.
+    it "explains that there were no revisions, so there is nothing to undo"
+
+  end
+
+  context "when the policy has several revisions" do
+
+    let(:policy_appserver_2) do
+      {
+        "name" => "appserver",
+        "revision_id" => "2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    end
+
+    before do
+      allow(rm_policy_service).to receive(:http_client).and_return(http_client)
+
+      expect(http_client).to receive(:get).with("/policies/appserver").and_return(policy_revisions_data)
+      expect(http_client).to receive(:get).
+        with("/policies/appserver/revisions/2222222222222222222222222222222222222222222222222222222222222222").
+        and_return(policy_appserver_2)
+      expect(http_client).to receive(:delete).with("/policies/appserver")
+
+      expect(undo_stack).to receive(:push).with(undo_record)
+    end
+
+    it "removes the policy" do
+      rm_policy_service.run
+      expect(ui.output).to include("Removed policy 'appserver'.")
+    end
+
+    it "stores the policy revisions in the restore file" do
+      rm_policy_service.run
+
+      expect(undo_record.description).to eq("delete-policy appserver")
+      expect(undo_record.policy_groups).to eq( [ ] )
+      expect(undo_record.policy_revisions.size).to eq(1)
+      stored_revision_info = undo_record.policy_revisions.first
+      expect(stored_revision_info.policy_group).to be_nil
+      expect(stored_revision_info.policy_name).to eq("appserver")
+      expect(stored_revision_info.data).to eq(policy_appserver_2)
+    end
+
+  end
+
+
+end
+


### PR DESCRIPTION
Adds `chef delete-policy POLICY_NAME` subcommand. Like `chef delete-policy-group`, this provides undo via `chef undelete`. I've tested both delete and undelete manually against a Chef Server nightly (12.2 will be the actual release with the required APIs).