### PR TITLE
PowerShell does not like empty line in shell-init

### DIFF
--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -106,7 +106,7 @@ HELP
           export(shell_name, var_name, value)
         end
 
-        msg(completion_for(shell_name))
+        msg(completion_for(shell_name)) unless shell_name == "powershell"
         0
       end
 
@@ -174,5 +174,3 @@ HELP
     end
   end
 end
-
-

--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -106,8 +106,12 @@ HELP
           export(shell_name, var_name, value)
         end
 
-        msg(completion_for(shell_name)) unless shell_name == "powershell"
+        emit_shell_cmd(completion_for(shell_name))
         0
+      end
+
+      def emit_shell_cmd(cmd)
+        msg(cmd) unless cmd.empty?
       end
 
       def completion_for(shell)
@@ -153,7 +157,7 @@ HELP
       end
 
       def posix_shell_export(var, val)
-        msg(%Q(export #{var}="#{val}"))
+        emit_shell_cmd(%Q(export #{var}="#{val}"))
       end
 
       def fish_shell_export(var, val)
@@ -162,14 +166,14 @@ HELP
         # /dev/null to avoid Fish's helpful warnings about nonexistent
         # PATH elements.
         if var == 'PATH'
-          msg(%Q(set -gx #{var} "#{val.split(':').join('" "')}" 2>/dev/null;))
+          emit_shell_cmd(%Q(set -gx #{var} "#{val.split(':').join('" "')}" 2>/dev/null;))
         else
-          msg(%Q(set -gx #{var} "#{val}";))
+          emit_shell_cmd(%Q(set -gx #{var} "#{val}";))
         end
       end
 
       def powershell_export(var, val)
-        msg(%Q($env:#{var}="#{val}"))
+        emit_shell_cmd(%Q($env:#{var}="#{val}"))
       end
     end
   end

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -52,6 +52,13 @@ describe ChefDK::Command::ShellInit do
         command_instance.run(argv)
         expect(stdout_io.string).to include(expected_environment_commands)
       end
+
+      it "does not emit any empty lines", :if => ["powershell", "posh"].include?(shell) do
+        command_instance.run(argv)
+        stdout_io.string.each_line do |s|
+          expect(s.strip).not_to be_empty
+        end
+      end
     end
 
     context "with an explicit omnibus directory as an argument" do
@@ -65,6 +72,13 @@ describe ChefDK::Command::ShellInit do
       it "emits a script to add ChefDK's ruby to the shell environment" do
         command_instance.run(argv)
         expect(stdout_io.string).to include(expected_environment_commands)
+      end
+
+      it "does not emit any empty lines", :if => ["powershell", "posh"].include?(shell) do
+        command_instance.run(argv)
+        stdout_io.string.each_line do |s|
+          expect(s.strip).not_to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
PowerShell fails with an error when doing "chef shell-init powershell | iex".
This is because iex does not like an empty line in an expression.
This is a regression from Chef DK 0.7

cc @danielsdeleo @chef/client-maintainers