### PR TITLE
Run commands from /usr/local/bin on Mac during 'package installation' smoke tests

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -238,13 +238,13 @@ end
 
         c.smoke_test do
 
-          if File.directory?("/usr/bin")
-            sh!("/usr/bin/berks -v")
+          if File.directory?(usr_bin_prefix)
+            sh!("#{usr_bin_path("berks")} -v")
 
-            sh!("/usr/bin/chef -v")
+            sh!("#{usr_bin_path("chef")} -v")
 
-            sh!("/usr/bin/chef-client -v")
-            sh!("/usr/bin/chef-solo -v")
+            sh!("#{usr_bin_path("chef-client")} -v")
+            sh!("#{usr_bin_path("chef-solo")} -v")
 
             # In `knife`, `knife -v` follows a different code path that skips
             # command/plugin loading; `knife -h` loads commands and plugins, but
@@ -253,17 +253,17 @@ end
             # exits 0, which runs most of the code.
             #
             # See also: https://github.com/opscode/chef-dk/issues/227
-            sh!("/usr/bin/knife exec -E true")
+            sh!("#{usr_bin_path("knife")} exec -E true")
 
             tmpdir do |dir|
               # Kitchen tries to create a .kitchen dir even when just running
               # `kitchen -v`:
-              sh!("/usr/bin/kitchen -v", cwd: dir)
+              sh!("#{usr_bin_path("kitchen")} -v", cwd: dir)
             end
 
-            sh!("/usr/bin/ohai -v")
+            sh!("#{usr_bin_path("ohai")} -v")
 
-            sh!("/usr/bin/foodcritic -V")
+            sh!("#{usr_bin_path("foodcritic")} -V")
           end
 
           # Test blocks are expected to return a Mixlib::ShellOut compatible

--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -86,6 +86,18 @@ module ChefDK
                        end
     end
 
+    # Returns the directory that contains our main symlinks.
+    # On Mac we place all of our symlinks under /usr/local/bin on other
+    # platforms they are under /usr/bin
+    def usr_bin_prefix
+      @usr_bin_prefix ||= os_x? ? "/usr/local/bin" : "/usr/bin"
+    end
+
+    # Returns the full path to the given command under usr_bin_prefix
+    def usr_bin_path(command)
+      File.join(usr_bin_prefix, command)
+    end
+
     private
 
     def omnibus_expand_path(*paths)
@@ -137,6 +149,11 @@ module ChefDK
       self.instance_variables.each do |ivar|
         self.instance_variable_set(ivar, nil)
       end
+    end
+
+    # Returns true if we are on Mac OS X. Otherwise false
+    def os_x?
+      !!(RUBY_PLATFORM =~ /darwin/)
     end
   end
 end

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -64,5 +64,29 @@ describe ChefDK::Helpers do
       end
     end
 
+    context 'using usr_bin_prefix' do
+      before do
+        stub_const('RUBY_PLATFORM', ruby_platform_string)
+      end
+
+      context 'on Mac' do
+        let(:ruby_platform_string) { 'x86_64-darwin12.0' }
+
+        it 'uses /usr/local/bin' do
+          expect(helpers.usr_bin_prefix).to eq('/usr/local/bin')
+          expect(helpers.usr_bin_path('berks')).to eq('/usr/local/bin/berks')
+        end
+      end
+
+      context 'on other systems' do
+        let(:ruby_platform_string) { 'x86_64-linux' }
+
+        it 'uses /usr/bin' do
+          expect(helpers.usr_bin_prefix).to eq('/usr/bin')
+          expect(helpers.usr_bin_path('berks')).to eq('/usr/bin/berks')
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Since we have move our symlinks from `/usr/bin` to `/usr/local/bin` on Mac OS X currently smoke tests of `"package installation"` component are failing.