### PR TITLE
remove beta warnings from policyfile commands

### DIFF
--- a/lib/chef-dk/command/clean_policy_cookbooks.rb
+++ b/lib/chef-dk/command/clean_policy_cookbooks.rb
@@ -35,8 +35,7 @@ on the server. Note that cookbooks which are referenced by "orphaned" policy
 revisions are not removed, so you may wish to run `chef clean-policy-revisions`
 to remove orphaned policies before running this command.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/clean_policy_revisions.rb
+++ b/lib/chef-dk/command/clean_policy_revisions.rb
@@ -34,8 +34,7 @@ Server. Orphaned policyfile revisions are not associated to any group, and
 therefore not in active use by any nodes. To list orphaned policyfile revisions
 before deleting them, use `chef show-policy --orphans`.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/delete_policy.rb
+++ b/lib/chef-dk/command/delete_policy.rb
@@ -34,8 +34,7 @@ Usage: chef delete-policy POLICY_NAME [options]
 backed up locally, allowing you to undo this operation via the `chef undelete`
 command.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/delete_policy_group.rb
+++ b/lib/chef-dk/command/delete_policy_group.rb
@@ -34,8 +34,7 @@ the configured Chef Server. Policy Revisions associated to the policy group are
 not deleted. The state of the policy group will be backed up locally, allowing
 you to undo this operation via the `chef undelete` command.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -40,8 +40,7 @@ to the target machine, you can apply the policy to the machine with
     versioned_cookbooks true
     policy_document_native_api false
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/install.rb
+++ b/lib/chef-dk/command/install.rb
@@ -37,8 +37,7 @@ lockfile to install the locked cookbooks on another machine. You can also push
 the lockfile to a "policy group" on a Chef Server and apply that exact set of
 cookbooks to nodes in your infrastructure.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -130,10 +130,6 @@ before converging the machine(s) defined in the provision cookbook.
 In the third form of the command, `chef provision` expects to create machines
 that will not operate in policyfile mode.
 
-Note that this command is considered beta. Behavior, the APIs that pass CLI
-data to chef-client, and argument names may change as more experience is gained
-from real-world usage.
-
 Chef Provisioning is documented at https://docs.chef.io/provisioning.html
 
 Options:

--- a/lib/chef-dk/command/push.rb
+++ b/lib/chef-dk/command/push.rb
@@ -35,8 +35,7 @@ with all the cookbooks contained in the policy lock. The policy lock is applied
 to a specific POLICY_GROUP, which is a set of nodes that share the same
 run_list and cookbooks.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -38,8 +38,7 @@ When both POLICY_NAME and POLICY_GROUP are given, the command shows the content
 of a the active policyfile lock for the given POLICY_GROUP. See also the `diff`
 command.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/undelete.rb
+++ b/lib/chef-dk/command/undelete.rb
@@ -44,8 +44,7 @@ previous state.
 The delete commands also do not store access control data, so you may have to
 manually reapply any ACL customizations you have made.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 

--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -37,8 +37,7 @@ NOTE: `chef update` does not yet support granular updates (e.g., just updating
 the `run_list` or a specific cookbook version). Support will be added in a
 future version.
 
-The Policyfile feature is incomplete and beta quality. See our detailed README
-for more information.
+See our detailed README for more information:
 
 https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 


### PR DESCRIPTION
We can stay pre-1.0 while we finish completing the feature set, but things are solid enough we don't need to bang everyone over the head with warnings any more.