### PR TITLE
Support custom policyfile filename for policyfile_zero provisioner

### DIFF
--- a/lib/kitchen/provisioner/policyfile_zero.rb
+++ b/lib/kitchen/provisioner/policyfile_zero.rb
@@ -41,6 +41,7 @@ module Kitchen
       default_config :json_attributes, true
       default_config :chef_zero_host, nil
       default_config :chef_zero_port, 8889
+      default_config :policyfile, "Policyfile.rb"
 
       default_config :chef_client_path do |provisioner|
         provisioner.
@@ -122,7 +123,9 @@ module Kitchen
       def policy_exporter
         # Must force this because TK by default copies the current cookbook to the sandbox
         # See ChefDK::PolicyfileServices::ExportRepo#assert_export_dir_clean!
-        @policy_exporter ||= ChefDK::PolicyfileServices::ExportRepo.new(export_dir: sandbox_path, force: true)
+        @policy_exporter ||= ChefDK::PolicyfileServices::ExportRepo.new(policyfile: config[:policyfile],
+                                                                        export_dir: sandbox_path,
+                                                                        force: true)
       end
 
       # Writes a fake (but valid) validation.pem into the sandbox directory.


### PR DESCRIPTION
Allow for a custom policyfile option in .kitchen.yml to specify a policyfile filename other than `Policyfile.rb`.