### PR TITLE
DTRT on Windows

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/serverspec_spec_helper.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/serverspec_spec_helper.rb
@@ -1,3 +1,8 @@
 require 'serverspec'
 
-set :backend, :exec
+if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
+  set :backend, :exec
+else
+  set :backend, :cmd
+  set :os, family: 'windows'
+end


### PR DESCRIPTION
As it was, it would just bomb out on any Windows integration testing. Solution found here: http://stackoverflow.com/questions/31418609/test-kitchen-serverspec-testing-exception-on-windows