### PR TITLE
Include a valid config in exported policies

### DIFF
--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -31,14 +31,12 @@ module ChefDK
 Usage: chef export [ POLICY_FILE ] DESTINATION_DIRECTORY [options]
 
 `chef export` creates a Chef Zero compatible Chef repository containing the
-cookbooks described in a Policyfile.lock.json. Once the exported repo is copied
-to the target machine, you can apply the policy to the machine with
-`chef-client -z`. You will need at least the following config:
+cookbooks described in a Policyfile.lock.json. The exported repository also
+contains a client.rb which configures chef to apply your policy. Once the
+exported repo is copied to the target machine, you can apply the policy to the
+machine with:
 
-    use_policyfile true
-    deployment_group '$POLICY_NAME-local'
-    versioned_cookbooks true
-    policy_document_native_api false
+`chef-client -c client.rb -z`.
 
 See our detailed README for more information:
 

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -97,6 +97,7 @@ module ChefDK
           copy_cookbooks
           create_policyfile_data_item
           copy_policyfile_lock
+          create_client_rb
           if archive?
             create_archive
           else
@@ -189,6 +190,28 @@ module ChefDK
         end
       end
 
+      def create_client_rb
+        File.open(client_rb_staging_path, "wb+") do |f|
+          f.print( <<-CONFIG )
+### Chef Client Configuration ###
+# The settings in this file will configure chef to apply the exported policy in
+# this directory. To use it, run:
+#
+# chef-client -c client.rb -z
+#
+
+use_policyfile true
+
+# compatibility mode settings are used because chef-zero doesn't yet support
+# native mode:
+deployment_group '#{policy_name}-local'
+versioned_cookbooks true
+policy_document_native_api false
+
+CONFIG
+        end
+      end
+
       def mv_staged_repo
         # If we got here, either these dirs are empty/don't exist or force is
         # set to true.
@@ -199,6 +222,7 @@ module ChefDK
         FileUtils.mkdir_p(export_data_bag_dir)
         FileUtils.mv(policyfiles_data_bag_staging_dir, export_data_bag_dir)
         FileUtils.mv(lockfile_staging_path, export_dir)
+        FileUtils.mv(client_rb_staging_path, export_dir)
       end
 
       def validate_lockfile
@@ -272,6 +296,10 @@ module ChefDK
 
       def lockfile_staging_path
         File.join(staging_dir, "Policyfile.lock.json")
+      end
+
+      def client_rb_staging_path
+        File.join(staging_dir, "client.rb")
       end
 
     end

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -251,6 +251,29 @@ E
             expect(policyfile_lock_data).to eq(expected_lock_data)
           end
 
+          it "creates a working local mode configuration file" do
+            expected_config_text = <<-CONFIG
+### Chef Client Configuration ###
+# The settings in this file will configure chef to apply the exported policy in
+# this directory. To use it, run:
+#
+# chef-client -c client.rb -z
+#
+
+use_policyfile true
+
+# compatibility mode settings are used because chef-zero doesn't yet support
+# native mode:
+deployment_group 'install-example-local'
+versioned_cookbooks true
+policy_document_native_api false
+
+CONFIG
+            config_path = File.join(export_dir, "client.rb")
+            expect(File).to exist(config_path)
+            expect(IO.read(config_path)).to eq(expected_config_text)
+          end
+
         end
 
         context "when the export dir is empty" do


### PR DESCRIPTION
This removes a manual step when running exported policy. Now you can just use the included config file, like:

```
chef export /tmp/my-policy
cd /tmp/my-policy
chef-client -c client.rb -z
```