### PR TITLE
add git init condition to prevent init inside an existing git repository

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -89,6 +89,9 @@ if context.have_git
   execute("initialize-git") do
     command("git init .")
     cwd app_dir
+    ## if we're already in a git repo, dont init.
+    ## exits 0 if we're in a repo, 128 if we're not.
+    not_if "git rev-parse"
   end
 
   cookbook_file "#{app_dir}/.gitignore" do

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -83,6 +83,9 @@ if context.have_git
     execute("initialize-git") do
       command("git init .")
       cwd cookbook_dir
+      ## if we're already in a git repo, dont init.
+      ## exits 0 if we're in a repo, 128 if we're not.
+      not_if "git rev-parse"
     end
   end
 

--- a/lib/chef-dk/skeletons/code_generator/recipes/repo.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/repo.rb
@@ -38,6 +38,9 @@ if context.have_git
     command("git init .")
     cwd repo_dir
     not_if { File.exist?("#{repo_dir}/.gitignore") }
+    ## if we're already in a git repo, dont init.
+    ## exits 0 if we're in a repo, 128 if we're not.
+    not_if "git rev-parse"
   end
 
   template "#{repo_dir}/.gitignore" do


### PR DESCRIPTION

after fixing the git init condition for repo in #551 , I realized that now we'll git init, even inside an existing git repository.

So add a condition to prevent that - I suspect this would be the desired case for everyone.   If you're creating a standalone cookbook/etc you wouldn't be in a git repo.  If you're not, you would (or might)



