### PR TITLE
Generate Policyfiles instead of Berksfiles in new cookbooks

### DIFF
--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -63,6 +63,17 @@ module ChefDK
           Generator.add_attr_to_context(:cookbook_root, cookbook_root)
           Generator.add_attr_to_context(:cookbook_name, cookbook_name)
           Generator.add_attr_to_context(:recipe_name, recipe_name)
+          Generator.add_attr_to_context(:policy_name, policy_name)
+          Generator.add_attr_to_context(:policy_run_list, policy_run_list)
+          Generator.add_attr_to_context(:policy_local_cookbook, ".")
+        end
+
+        def policy_name
+          cookbook_name
+        end
+
+        def policy_run_list
+          "#{cookbook_name}::#{recipe_name}"
         end
 
         def recipe

--- a/lib/chef-dk/command/generator_commands/policyfile.rb
+++ b/lib/chef-dk/command/generator_commands/policyfile.rb
@@ -43,6 +43,9 @@ module ChefDK
           super
           Generator.add_attr_to_context(:policyfile_dir, policyfile_dir)
           Generator.add_attr_to_context(:new_file_basename, new_file_basename)
+          Generator.add_attr_to_context(:policy_name, "example-application-service")
+          Generator.add_attr_to_context(:policy_run_list, "example_cookbook::default")
+          Generator.add_attr_to_context(:policy_local_cookbook, nil)
         end
 
         def run

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -36,7 +36,10 @@ end
 
 # TK & Serverspec
 template "#{cookbook_dir}/.kitchen.yml" do
-  source 'kitchen.yml.erb'
+  ## Uncomment this and delete the following `source` line to generate
+  ## non-Policyfile kitchen.yml files (do this if you're using berks):
+  # source 'kitchen.yml.erb'
+  source 'kitchen_policyfile.yml.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -20,10 +20,19 @@ end
 # chefignore
 cookbook_file "#{cookbook_dir}/chefignore"
 
-# Berks
-cookbook_file "#{cookbook_dir}/Berksfile" do
-  action :create_if_missing
+# Policyfile
+template "#{cookbook_dir}/Policyfile.rb" do
+  source "Policyfile.rb.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
 end
+
+###
+# Berks is no longer the default, uncomment this to enable it.
+#
+# # Berks
+# cookbook_file "#{cookbook_dir}/Berksfile" do
+#   action :create_if_missing
+# end
 
 # TK & Serverspec
 template "#{cookbook_dir}/.kitchen.yml" do

--- a/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
@@ -4,13 +4,17 @@
 # https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 
 # A name that describes what the system you're building with Chef does.
-name "example_application"
+name "<%= policy_name %>"
 
 # Where to find external cookbooks:
 default_source :supermarket
 
 # run_list: chef-client will run these recipes in the order specified.
-run_list "cookbook::recipe", "other_cookbook::recipe"
+run_list "<%= policy_run_list %>"
 
 # Specify a custom source for a single cookbook:
-# cookbook "development_cookbook", path: "../cookbooks/development_cookbook"
+<% if policy_local_cookbook.nil? %>
+# cookbook "example_cookbook", path: "../cookbooks/example_cookbook"
+<% else %>
+cookbook "<%= cookbook_name %>", path: "."
+<% end %>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
@@ -7,7 +7,7 @@
 name "example_application"
 
 # Where to find external cookbooks:
-default_source :community
+default_source :supermarket
 
 # run_list: chef-client will run these recipes in the order specified.
 run_list "cookbook::recipe", "other_cookbook::recipe"

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -1,0 +1,27 @@
+---
+driver:
+  name: vagrant
+
+## The forwarded_port port feature lets you connect to ports on the VM guest via
+## localhost on the host.
+## see also: https://docs.vagrantup.com/v2/networking/forwarded_ports.html
+
+#  network:
+#    - ["forwarded_port", {guest: 80, host: 8080}]
+
+provisioner:
+  name: policyfile_zero
+
+## require_chef_omnibus specifies a specific chef version to install. You can
+## also set this to `true` to always use the latest version.
+## see also: https://docs.chef.io/config_yml_kitchen.html
+
+#  require_chef_omnibus: 12.5.0
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-7.1
+
+suites:
+  - name: default
+    attributes:

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -191,11 +191,53 @@ POLICYFILE_RB
     end
 
     describe ".kitchen.yml" do
+
+      before do
+        Dir.chdir(tempdir) do
+          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+          cookbook_generator.run
+        end
+      end
+
       let(:file) { File.join(tempdir, "new_cookbook", ".kitchen.yml") }
 
-      include_examples "a generated file", :cookbook_name do
-        let(:line) { /\s*- recipe\[new_cookbook::default\]/ }
+      let(:expected_content) do
+        <<-KITCHEN_YML
+---
+driver:
+  name: vagrant
+
+## The forwarded_port port feature lets you connect to ports on the VM guest via
+## localhost on the host.
+## see also: https://docs.vagrantup.com/v2/networking/forwarded_ports.html
+
+#  network:
+#    - ["forwarded_port", {guest: 80, host: 8080}]
+
+provisioner:
+  name: policyfile_zero
+
+## require_chef_omnibus specifies a specific chef version to install. You can
+## also set this to `true` to always use the latest version.
+## see also: https://docs.chef.io/config_yml_kitchen.html
+
+#  require_chef_omnibus: 12.5.0
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-7.1
+
+suites:
+  - name: default
+    attributes:
+KITCHEN_YML
       end
+
+
+      it "uses the policyfile_zero provisioner" do
+        expect(IO.read(file)).to eq(expected_content)
+      end
+
     end
 
     describe "test/integration/default/serverspec/default_spec.rb" do

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -36,7 +36,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       test/integration/default/serverspec
       test/integration/default/serverspec/default_spec.rb
       test/integration/helpers/serverspec/spec_helper.rb
-      Berksfile
+      Policyfile.rb
       chefignore
       metadata.rb
       README.md
@@ -150,6 +150,44 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       include_examples "a generated file", :cookbook_name do
         let(:line) { "# new_cookbook" }
       end
+    end
+
+    describe "Policyfile.rb" do
+
+      let(:file) { File.join(tempdir, "new_cookbook", "Policyfile.rb") }
+
+      let(:expected_content) do
+        <<-POLICYFILE_RB
+# Policyfile.rb - Describe how you want Chef to build your system.
+#
+# For more information on the Policyfile feature, visit
+# https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+
+# A name that describes what the system you're building with Chef does.
+name "new_cookbook"
+
+# Where to find external cookbooks:
+default_source :supermarket
+
+# run_list: chef-client will run these recipes in the order specified.
+run_list "new_cookbook::default"
+
+# Specify a custom source for a single cookbook:
+cookbook "new_cookbook", path: "."
+POLICYFILE_RB
+      end
+
+      before do
+        Dir.chdir(tempdir) do
+          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+          cookbook_generator.run
+        end
+      end
+
+      it "has a run_list and cookbook path that will work out of the box" do
+        expect(IO.read(file)).to eq(expected_content)
+      end
+
     end
 
     describe ".kitchen.yml" do


### PR DESCRIPTION
* Update Policyfile template so it can be setup to work out of the box
* Comment-out berksfile generation in the cookbook generator recipe (this allows end users to generate a generator and uncomment the berksfile part if they want)
* Generate a Policyfile.rb in the cookbook generator
* Use the policyfile provisioner in the generated kitchen YAML.

