### PR TITLE
Make Generated Cookbook Use ChefSpec Policyfile Mode

### DIFF
--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -50,7 +50,7 @@ module ChefDK
     def policy
       return @policy_builder if @policy_builder
 
-      @policy_builder = Chef::PolicyBuilder::ExpandNodeObject.new("chef-dk", ohai.data, {}, nil, formatter)
+      @policy_builder = Chef::PolicyBuilder::Dynamic.new("chef-dk", ohai.data, {}, nil, formatter)
       @policy_builder.load_node
       @policy_builder.build_node
       @policy_builder.node.run_list(*run_list)

--- a/lib/chef-dk/skeletons/code_generator/files/default/spec_helper_policyfile.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/spec_helper_policyfile.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/policyfile'

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -69,6 +69,8 @@ directory "#{cookbook_dir}/spec/unit/recipes" do
 end
 
 cookbook_file "#{cookbook_dir}/spec/spec_helper.rb" do
+  # Change this to "spec_helper.rb" to get the berkshelf version
+  source "spec_helper_policyfile.rb"
   action :create_if_missing
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |c|
   # Avoid loading config.rb/knife.rb unintentionally
   c.before(:each) do
     Chef::Config.reset
+    Chef::Config.treat_deprecation_warnings_as_errors(true)
     allow_any_instance_of(Chef::WorkstationConfigLoader).to receive(:load)
   end
 


### PR DESCRIPTION
With this change, `chef generate cookbook foo; cd foo; chef install; rspec` works out of the box.

I also found and fixed deprecated chef library usage.