### PR TITLE
Better "not a cookbook" errors

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "solve", "~> 2.0", ">= 2.0.1"
 
-  gem.add_dependency "cookbook-omnifetch", "~> 0.2"
+  gem.add_dependency "cookbook-omnifetch", "~> 0.2", ">= 0.2.2"
 
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", "~> 1.0"

--- a/lib/chef-dk/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-dk/policyfile/cookbook_location_specification.rb
@@ -60,6 +60,14 @@ module ChefDK
           other.source_options == source_options
       end
 
+      def to_s
+        # Note, this may appear in exceptions
+        s = "Cookbook '#{name}'"
+        s << " #{version_constraint}"
+        s << " #{source_options}" unless source_options.empty?
+        s
+      end
+
       def mirrors_canonical_upstream?
         [:git, :github, :artifactserver].include?(source_type)
       end

--- a/spec/unit/policyfile/cookbook_location_specification_spec.rb
+++ b/spec/unit/policyfile/cookbook_location_specification_spec.rb
@@ -77,6 +77,11 @@ describe ChefDK::Policyfile::CookbookLocationSpecification do
     expect(cookbook_location_spec.source_options_for_lock).to eq(lock_data)
   end
 
+  it "converts to a readable string with all relevant info" do
+    expected_s = "Cookbook 'my_cookbook' >= 0.0.0"
+    expect(cookbook_location_spec.to_s).to eq(expected_s)
+  end
+
   describe "fetching and querying a cookbook" do
 
     before do


### PR DESCRIPTION
Fixes https://github.com/chef/chef-dk/issues/564 and a similar bug I discovered in testing.

Error messages now look like:

```
Building policy example-application-service
Expanded run list: recipe[apt::default]
Caching Cookbooks...
Installing foo >= 0.0.0 from path
Error: Failed to generate Policyfile.lock
Reason: (CookbookOmnifetch::NotACookbook) The resource at '/Users/ddeleo/oc/chef-dk/no/such/dir/foo' does not appear to be a valid cookbook. Does it have a metadata.rb?
```