### PR TITLE
Add a Rakefile to the default cookbook generator

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/Rakefile
+++ b/lib/chef-dk/skeletons/code_generator/files/default/Rakefile
@@ -1,0 +1,79 @@
+
+# Copyright 2012, 2013, 2014, 2015 Datadog, Inc.
+# Copyright 2015 Clinton C Wolfe
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+require 'foodcritic'
+
+task default: [
+  :syntax,
+  :style,
+  :test
+]
+
+# Syntax checks
+namespace :syntax do
+  desc 'Ruby .rb syntax checks'
+  task :ruby do |_t|
+    Dir.glob('**/*.rb').each do |f|
+      print f + ': '
+      system("ruby -wc #{f}")
+    end
+  end
+
+  desc 'Ruby template syntax checks'
+  task :erb do |_t|
+    Dir.glob('**/*.erb').each do |f|
+      print f + ': '
+      system("erb -x #{f} | ruby -c")
+    end
+  end
+end
+
+desc 'Run all syntax checks'
+task syntax: ['syntax:ruby', 'syntax:erb']
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef) do |t|
+    t.options = { fail_tags: ['correctness'] }
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+# Tests, spec and test kitchen
+namespace :test do
+  # Rspec and ChefSpec
+  desc 'Run ChefSpec examples'
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.verbose = false
+  end
+
+  # Test kitchen
+  desc 'Run kitchen test'
+  task :kitchen do
+    sh 'kitchen test'
+  end
+end
+
+desc 'Run all tests'
+task test: ['test:spec', 'test:kitchen']

--- a/lib/chef-dk/skeletons/code_generator/files/default/gitignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/gitignore
@@ -14,3 +14,4 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+test/reports/*

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -20,6 +20,9 @@ end
 # chefignore
 cookbook_file "#{cookbook_dir}/chefignore"
 
+# Rakefile
+cookbook_file "#{cookbook_dir}/Rakefile"
+
 # Policyfile
 template "#{cookbook_dir}/Policyfile.rb" do
   source "Policyfile.rb.erb"

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -48,7 +48,9 @@ template "#{cookbook_dir}/.kitchen.yml" do
 end
 
 # Directory to collect CI reports
-directory "#{cookbook_dir}/test/reports"
+directory "#{cookbook_dir}/test/reports" do
+  recursive true
+end
 file "#{cookbook_dir}/test/reports/.keep"
 
 directory "#{cookbook_dir}/test/integration/default/serverspec" do

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -47,6 +47,10 @@ template "#{cookbook_dir}/.kitchen.yml" do
   action :create_if_missing
 end
 
+# Directory to collect CI reports
+directory "#{cookbook_dir}/test/reports"
+file "#{cookbook_dir}/test/reports/.keep"
+
 directory "#{cookbook_dir}/test/integration/default/serverspec" do
   recursive true
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
@@ -4,17 +4,17 @@
 # https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 
 # A name that describes what the system you're building with Chef does.
-name "<%= policy_name %>"
+name '<%= policy_name %>'
 
 # Where to find external cookbooks:
 default_source :supermarket
 
 # run_list: chef-client will run these recipes in the order specified.
-run_list "<%= policy_run_list %>"
+run_list '<%= policy_run_list %>'
 
 # Specify a custom source for a single cookbook:
 <% if policy_local_cookbook.nil? %>
-# cookbook "example_cookbook", path: "../cookbooks/example_cookbook"
+# cookbook "example_cookbook", path: '../cookbooks/example_cookbook'
 <% else %>
-cookbook "<%= cookbook_name %>", path: "."
+cookbook '<%= cookbook_name %>', path: '.'
 <% end %>

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -165,16 +165,16 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 # https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
 
 # A name that describes what the system you're building with Chef does.
-name "new_cookbook"
+name 'new_cookbook'
 
 # Where to find external cookbooks:
 default_source :supermarket
 
 # run_list: chef-client will run these recipes in the order specified.
-run_list "new_cookbook::default"
+run_list 'new_cookbook::default'
 
 # Specify a custom source for a single cookbook:
-cookbook "new_cookbook", path: "."
+cookbook 'new_cookbook', path: '.'
 POLICYFILE_RB
       end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -36,6 +36,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       test/integration/default/serverspec
       test/integration/default/serverspec/default_spec.rb
       test/integration/helpers/serverspec/spec_helper.rb
+      Rakefile
       Policyfile.rb
       chefignore
       metadata.rb

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -31,6 +31,8 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       .gitignore
       .kitchen.yml
       test
+      test/reports
+      test/reports/.keep
       test/integration
       test/integration/default
       test/integration/default/serverspec


### PR DESCRIPTION
Adds a Rakefile to perform syntax checking, style checking, and testing, using tools already included with the Chef DK.

Also makes some effort to ensure that a newly generated cookbook will not immediately fail style checks, but Policyfile.rb fails a filename rubocop check.