### PR TITLE
Verify that generated cookbooks pass chefspec

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -281,6 +281,18 @@ require 'spec_helper'
         end
       end
 
+      add_component "generated-cookbooks-pass-chefspec" do |c|
+
+        c.base_dir = "chef-dk"
+        c.smoke_test do
+          tmpdir do |cwd|
+            sh("chef generate cookbook example", cwd: cwd)
+            cb_cwd = File.join(cwd, "example")
+            sh("rspec", cwd: cb_cwd)
+          end
+        end
+      end
+
       add_component "rubocop" do |c|
         c.gem_base_dir = "rubocop"
         c.smoke_test do

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -43,6 +43,7 @@ describe ChefDK::Command::Verify do
       "chef-dk",
       "chef-provisioning",
       "chefspec",
+      "generated-cookbooks-pass-chefspec",
       "rubocop",
       "fauxhai",
       "knife-spork",


### PR DESCRIPTION
Originally I was planning to do a bigger refactor of `chef verify` to pull out the helper code and separate each component into its own file, but I want to avoid a messy merge with https://github.com/chef/chef-dk/pull/562

This just checks that cookbooks produced by `chef generate cookbook` will pass the generated chefspec tests. I was able to make it fail by temporarily changing the generator to put bad code in the spec_helper.rb