### PR TITLE
We default to policyfile, so should spec_helper

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/spec_helper.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/spec_helper.rb
@@ -1,2 +1,2 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'


### PR DESCRIPTION
Since the default generator doesn't create a berksfile, but does create a policyfile.rb, we need to use policyfile from chefspec to resolve dependencies.