### PR TITLE
Preferred supermarkets for cookbooks

### DIFF
--- a/POLICYFILE_README.md
+++ b/POLICYFILE_README.md
@@ -179,6 +179,51 @@ your Chef repo, or to the `cookbooks` directory within your repo.
 Chef Server cannot be used as a source until the Server implements the
 "universe" endpoint. See [Chef RFC014](https://github.com/chef/chef-rfc/blob/master/rfc014-universe-endpoint.md).
 
+### Using Multiple Default Sources
+
+ChefDK now allows you to specify multiple default sources. For example,
+you may combine cookbooks from your "monolithic repo" with cookbooks
+from the public Supermarket with code like this:
+
+```ruby
+default_source :supermarket
+default_source :chef_repo, "path/to/repo"
+```
+
+Similarly, if you are running a private Supermarket instance, you may
+use that in combination with the public Supermarket with code like:
+
+```ruby
+default_source :supermarket
+default_source :supermarket, "https://supermarket.example"
+```
+
+Note that when your run list or its dependencies require a cookbook that
+is present in more than one source, you must be explict about which
+source you prefer. This prevents the case where you have a working
+policy that suddenly pulls a cookbook from an unexpected source because
+a cookbook with that name was added to one of your default sources. For
+example, if you have an internally developed cookbook named
+"chef-client", it will conflict with the public one maintained by Chef.
+If you want to fetch this cookbook from your private supermarket, you'd
+write:
+
+```ruby
+default_source :supermarket
+default_source :supermarket, "https://supermarket.example" do |s|
+  s.preferred_source_for "chef-client"
+end
+```
+
+To specify multiple cookbooks, list them all on one line, like this:
+
+```ruby
+default_source :supermarket
+default_source :supermarket, "https://supermarket.example" do |s|
+  s.preferred_source_for "chef-client", "nginx", "mysql"
+end
+```
+
 ### `cookbook "NAME" [, "VERSION_CONSTRAINT"] [, SOURCE_OPTIONS]`
 
 The `cookbook` method serves several purposes:

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -103,9 +103,22 @@ module ChefDK
           source_a.universe_graph.key?(cookbook_name) && source_b.universe_graph.key?(cookbook_name)
         end
         "Source #{source_a.desc} and #{source_b.desc} contain conflicting cookbooks:\n" +
-          overlapping_cookbooks.sort.map {|c| "- #{c}"}.join("\n")
+          overlapping_cookbooks.sort.map {|c| "- #{c}"}.join("\n") + "\n\n" +
+          resolution_message(overlapping_cookbooks)
       end
-      conflicting_cookbook_sets.join("\n") + "\n"
+      conflicting_cookbook_sets.join("\n")
+    end
+
+    def resolution_message(overlapping_cookbooks)
+      example_source = cookbook_sources.first
+      source_key, location = example_source.default_source_args
+      <<-EXAMPLE
+You can set a preferred source to resolve this issue with code like:
+
+default_source :#{source_key}, "#{location}", do |s|
+  s.preferred_source_for "#{overlapping_cookbooks.join('", "')}"
+end
+EXAMPLE
     end
 
   end

--- a/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
@@ -41,6 +41,10 @@ module ChefDK
         yield self if block_given?
       end
 
+      def default_source_args
+        [:chef_repo, path]
+      end
+
       def preferred_for(*cookbook_names)
         preferred_cookbooks.concat(cookbook_names)
       end

--- a/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_repo_cookbook_source.rb
@@ -29,16 +29,28 @@ module ChefDK
       # UI object for output
       attr_accessor :ui
 
+      attr_reader :preferred_cookbooks
+
       # Constructor
       #
       # @param path [String] path to a chef-repo or the cookbook path under it
       def initialize(path)
         self.path = path
         @ui = UI.new
+        @preferred_cookbooks = []
+        yield self if block_given?
+      end
+
+      def preferred_for(*cookbook_names)
+        preferred_cookbooks.concat(cookbook_names)
+      end
+
+      def preferred_source_for?(cookbook_name)
+        preferred_cookbooks.include?(cookbook_name)
       end
 
       def ==(other)
-        other.kind_of?(self.class) && other.path == path
+        other.kind_of?(self.class) && other.path == path && other.preferred_cookbooks == preferred_cookbooks
       end
 
       # Calls the slurp_metadata! helper once to calculate the @universe_graph

--- a/lib/chef-dk/policyfile/community_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/community_cookbook_source.rb
@@ -26,14 +26,25 @@ module ChefDK
     class CommunityCookbookSource
 
       attr_reader :uri
+      attr_reader :preferred_cookbooks
 
       def initialize(uri = nil)
         @uri = uri || "https://supermarket.chef.io"
         @http_connections = {}
+        @preferred_cookbooks = []
+        yield self if block_given?
+      end
+
+      def preferred_for(*cookbook_names)
+        preferred_cookbooks.concat(cookbook_names)
+      end
+
+      def preferred_source_for?(cookbook_name)
+        preferred_cookbooks.include?(cookbook_name)
       end
 
       def ==(other)
-        other.kind_of?(self.class) && other.uri == uri
+        other.kind_of?(self.class) && other.uri == uri && other.preferred_cookbooks == preferred_cookbooks
       end
 
       def universe_graph

--- a/lib/chef-dk/policyfile/community_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/community_cookbook_source.rb
@@ -35,6 +35,10 @@ module ChefDK
         yield self if block_given?
       end
 
+      def default_source_args
+        [:supermarket, uri]
+      end
+
       def preferred_for(*cookbook_names)
         preferred_cookbooks.concat(cookbook_names)
       end

--- a/lib/chef-dk/policyfile/delivery_supermarket_source.rb
+++ b/lib/chef-dk/policyfile/delivery_supermarket_source.rb
@@ -63,6 +63,10 @@ module ChefDK
         other.kind_of?(self.class) && other.uri == uri
       end
 
+      def default_source_args
+        [:delivery_supermarket, uri]
+      end
+
       def universe_graph
         @universe_graph ||= begin
           @community_source.universe_graph.inject({}) do |truncated, (cookbook_name, version_and_deps_list)|

--- a/lib/chef-dk/policyfile/delivery_supermarket_source.rb
+++ b/lib/chef-dk/policyfile/delivery_supermarket_source.rb
@@ -50,9 +50,13 @@ module ChefDK
       def_delegator :@community_source, :uri
       def_delegator :@community_source, :source_options_for
       def_delegator :@community_source, :null?
+      def_delegator :@community_source, :preferred_cookbooks
+      def_delegator :@community_source, :preferred_source_for?
+      def_delegator :@community_source, :preferred_for
 
       def initialize(uri)
         @community_source = CommunityCookbookSource.new(uri)
+        yield self if block_given?
       end
 
       def ==(other)

--- a/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
@@ -63,4 +63,26 @@ describe ChefDK::Policyfile::ChefRepoCookbookSource do
     cookbook_source.send(:path=, repo_path)
     expect(cookbook_source.path).to eql("#{repo_path}/cookbooks")
   end
+
+  context "when created with a block to set source preferences" do
+
+    subject(:cookbook_source) do
+      described_class.new(repo_path) do |s|
+        s.preferred_for "foo", "bar", "baz"
+      end
+    end
+
+    it "sets the source preferences as given" do
+      expect(cookbook_source.preferred_cookbooks).to eq( %w[ foo bar baz ] )
+    end
+
+    it "is the preferred source for the requested cookbooks" do
+      expect(cookbook_source.preferred_source_for?("foo")).to be(true)
+      expect(cookbook_source.preferred_source_for?("bar")).to be(true)
+      expect(cookbook_source.preferred_source_for?("baz")).to be(true)
+      expect(cookbook_source.preferred_source_for?("razzledazzle")).to be(false)
+    end
+
+  end
+
 end

--- a/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/chef_repo_cookbook_source_spec.rb
@@ -42,6 +42,11 @@ describe ChefDK::Policyfile::ChefRepoCookbookSource do
       },
     }
   }
+
+  it "gives the set of arguments to `default_source` used to create it" do
+    expect(cookbook_source.default_source_args).to eq([:chef_repo, repo_path])
+  end
+
   it "fetches the universe graph" do
     actual_universe = cookbook_source.universe_graph
     expect(actual_universe).to eql(local_repo_universe)

--- a/spec/unit/policyfile/community_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/community_cookbook_source_spec.rb
@@ -30,6 +30,14 @@ describe ChefDK::Policyfile::CommunityCookbookSource do
 
   let(:pruned_universe) { JSON.parse(IO.read(File.join(fixtures_path, "cookbooks_api/pruned_small_universe.json"))) }
 
+  it "defaults to using the public supermarket over HTTPS" do
+    expect(cookbook_source.uri).to eq(default_community_uri)
+  end
+
+  it "gives the set of arguments to `default_source` used to create it" do
+    expect(cookbook_source.default_source_args).to eq([:supermarket, default_community_uri])
+  end
+
   describe "fetching the Universe graph over HTTP" do
 
     before do

--- a/spec/unit/policyfile/community_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/community_cookbook_source_spec.rb
@@ -20,7 +20,7 @@ require 'chef-dk/policyfile/community_cookbook_source'
 
 describe ChefDK::Policyfile::CommunityCookbookSource do
 
-  let(:cookbook_source) { ChefDK::Policyfile::CommunityCookbookSource.new }
+  subject(:cookbook_source) { ChefDK::Policyfile::CommunityCookbookSource.new }
 
   let(:default_community_uri) { "https://supermarket.chef.io" }
 
@@ -30,21 +30,46 @@ describe ChefDK::Policyfile::CommunityCookbookSource do
 
   let(:pruned_universe) { JSON.parse(IO.read(File.join(fixtures_path, "cookbooks_api/pruned_small_universe.json"))) }
 
-  before do
-    expect(Chef::HTTP::Simple).to receive(:new).with(default_community_uri).and_return(http_connection)
-    expect(http_connection).to receive(:get).with("/universe").and_return(universe_response_encoded)
+  describe "fetching the Universe graph over HTTP" do
+
+    before do
+      expect(Chef::HTTP::Simple).to receive(:new).with(default_community_uri).and_return(http_connection)
+      expect(http_connection).to receive(:get).with("/universe").and_return(universe_response_encoded)
+    end
+
+    it "fetches the universe graph" do
+      actual_universe = cookbook_source.universe_graph
+      expect(actual_universe).to have_key("apt")
+      expect(actual_universe["apt"]).to eq(pruned_universe["apt"])
+      expect(cookbook_source.universe_graph).to eq(pruned_universe)
+    end
+
+    it "generates location options for a cookbook from the given graph" do
+      expected_opts = { artifactserver: "https://supermarket.chef.io/api/v1/cookbooks/apache2/versions/1.10.4/download", version: "1.10.4" }
+      expect(cookbook_source.source_options_for("apache2", "1.10.4")).to eq(expected_opts)
+    end
+
   end
 
-  it "fetches the universe graph" do
-    actual_universe = cookbook_source.universe_graph
-    expect(actual_universe).to have_key("apt")
-    expect(actual_universe["apt"]).to eq(pruned_universe["apt"])
-    expect(cookbook_source.universe_graph).to eq(pruned_universe)
-  end
+  context "when created with a block to set source preferences" do
 
-  it "generates location options for a cookbook from the given graph" do
-    expected_opts = { artifactserver: "https://supermarket.chef.io/api/v1/cookbooks/apache2/versions/1.10.4/download", version: "1.10.4" }
-    expect(cookbook_source.source_options_for("apache2", "1.10.4")).to eq(expected_opts)
+    subject(:cookbook_source) do
+      ChefDK::Policyfile::CommunityCookbookSource.new do |s|
+        s.preferred_for "foo", "bar", "baz"
+      end
+    end
+
+    it "sets the source preferences as given" do
+      expect(cookbook_source.preferred_cookbooks).to eq( %w[ foo bar baz ] )
+    end
+
+    it "is the preferred source for the requested cookbooks" do
+      expect(cookbook_source.preferred_source_for?("foo")).to be(true)
+      expect(cookbook_source.preferred_source_for?("bar")).to be(true)
+      expect(cookbook_source.preferred_source_for?("baz")).to be(true)
+      expect(cookbook_source.preferred_source_for?("razzledazzle")).to be(false)
+    end
+
   end
 
 end

--- a/spec/unit/policyfile/delivery_supermarket_source_spec.rb
+++ b/spec/unit/policyfile/delivery_supermarket_source_spec.rb
@@ -80,6 +80,10 @@ describe ChefDK::Policyfile::DeliverySupermarketSource do
     expect(cookbook_source.desc).to eq("delivery_supermarket(https://delivery-supermarket.example)")
   end
 
+  it "gives the set of arguments to `default_source` used to create it" do
+    expect(cookbook_source.default_source_args).to eq([:delivery_supermarket, supermarket_uri])
+  end
+
   describe "when fetching the /universe graph" do
 
     before do

--- a/spec/unit/policyfile/delivery_supermarket_source_spec.rb
+++ b/spec/unit/policyfile/delivery_supermarket_source_spec.rb
@@ -101,5 +101,26 @@ describe ChefDK::Policyfile::DeliverySupermarketSource do
 
   end
 
+  context "when created with a block to set source preferences" do
+
+    subject(:cookbook_source) do
+      described_class.new(supermarket_uri) do |s|
+        s.preferred_for "foo", "bar", "baz"
+      end
+    end
+
+    it "sets the source preferences as given" do
+      expect(cookbook_source.preferred_cookbooks).to eq( %w[ foo bar baz ] )
+    end
+
+    it "is the preferred source for the requested cookbooks" do
+      expect(cookbook_source.preferred_source_for?("foo")).to be(true)
+      expect(cookbook_source.preferred_source_for?("bar")).to be(true)
+      expect(cookbook_source.preferred_source_for?("baz")).to be(true)
+      expect(cookbook_source.preferred_source_for?("razzledazzle")).to be(false)
+    end
+
+  end
+
 end
 

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -856,6 +856,12 @@ describe ChefDK::PolicyfileCompiler, "when expressing the Policyfile graph deman
 Source supermarket(https://supermarket.chef.io) and chef_repo(#{repo_path}) contain conflicting cookbooks:
 - remote-cb
 - remote-cb-two
+
+You can set a preferred source to resolve this issue with code like:
+
+default_source :supermarket, "https://supermarket.chef.io", do |s|
+  s.preferred_source_for "remote-cb", "remote-cb-two"
+end
 ERROR
 
             expect { policyfile.remote_artifacts_graph }.to raise_error do |error|
@@ -952,6 +958,12 @@ ERROR
           expected_err = <<-ERROR
 Source supermarket(https://supermarket.chef.io) and chef_repo(#{repo_path}) contain conflicting cookbooks:
 - remote-cb-two
+
+You can set a preferred source to resolve this issue with code like:
+
+default_source :supermarket, "https://supermarket.chef.io", do |s|
+  s.preferred_source_for "remote-cb-two"
+end
 ERROR
 
           expect { policyfile.remote_artifacts_graph }.to raise_error do |error|


### PR DESCRIPTION
Implements a DSL syntax to specify that a given source is the preferred one for a given cookbook. It looks like this:

```ruby
default_source :supermarket

default_source :supermarket, "https://my.supermarket.example" do |s|
  # This will use the chef-client cookbook from the private supermarket
  # instead of the one on the public supermarket:
  s.preferred_source_for "chef-client"
end
```

Still todo:

- [x] Add to POLICYFILE_README
- [x] Update error messages for cookbook conflicts to produce example code with this syntax
