### PR TITLE
Return correct type when filtering out cookbooks from graph

### DIFF
--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -224,6 +224,8 @@ module ChefDK
               elsif cookbook_could_appear_in_solution?(conflicting_cb_name)
                 conflicting_cb_names << conflicting_cb_name
                 {} # return empty set of versions
+              else
+                {} # return empty set of versions
               end
             end
           end

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -977,8 +977,14 @@ ERROR
 
         let(:run_list) { [ 'local_cookbook' ] }
 
-        it "solves the graph" do
+        it "creates the merged graph without error" do
           expect { policyfile.remote_artifacts_graph }.to_not raise_error
+          expect { policyfile.graph }.to_not raise_error
+        end
+
+        it "has an empty set of artifacts for the conflicting cookbook" do
+          expect(policyfile.remote_artifacts_graph["remote-cb"]).to eq({})
+          expect(policyfile.remote_artifacts_graph["remote-cb-two"]).to eq({})
         end
 
       end


### PR DESCRIPTION
When running `chef install` and there are two cookbook sources that have
a cookbook of the same name, there would be an implicit nil return when
filtering that cookbook from the graph, which would lead to:

```
Error: Failed to generate Policyfile.lock
Reason: (NoMethodError) undefined method `each' for nil:NilClass
```
...when generating the Solve::Graph. Returning an empty Hash causes the
coobkook to be omitted from the Solve::Graph, which is what we want.

@chef/workflow 