### PR TITLE
Fix incorrect suggested code in errors

### DIFF
--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -115,8 +115,8 @@ module ChefDK
       <<-EXAMPLE
 You can set a preferred source to resolve this issue with code like:
 
-default_source :#{source_key}, "#{location}", do |s|
-  s.preferred_source_for "#{overlapping_cookbooks.join('", "')}"
+default_source :#{source_key}, "#{location}" do |s|
+  s.preferred_for "#{overlapping_cookbooks.join('", "')}"
 end
 EXAMPLE
     end

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -859,8 +859,8 @@ Source supermarket(https://supermarket.chef.io) and chef_repo(#{repo_path}) cont
 
 You can set a preferred source to resolve this issue with code like:
 
-default_source :supermarket, "https://supermarket.chef.io", do |s|
-  s.preferred_source_for "remote-cb", "remote-cb-two"
+default_source :supermarket, "https://supermarket.chef.io" do |s|
+  s.preferred_for "remote-cb", "remote-cb-two"
 end
 ERROR
 
@@ -961,8 +961,8 @@ Source supermarket(https://supermarket.chef.io) and chef_repo(#{repo_path}) cont
 
 You can set a preferred source to resolve this issue with code like:
 
-default_source :supermarket, "https://supermarket.chef.io", do |s|
-  s.preferred_source_for "remote-cb-two"
+default_source :supermarket, "https://supermarket.chef.io" do |s|
+  s.preferred_for "remote-cb-two"
 end
 ERROR
 


### PR DESCRIPTION
The current suggested code has bad syntax and uses an incorrect method name.

@chef/workflow 