### PR TITLE
'chef export' respects chefignore

### DIFF
--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -204,6 +204,11 @@ E
           let(:expected_files_relative) do
             metadata_rb = Pathname.new("metadata.rb")
             expected = cookbook_files.delete_if { |p| p == metadata_rb }
+
+            # Berksfile is chefignored
+            berksfile = Pathname.new("Berksfile")
+            expected = expected.delete_if { |p| p == berksfile }
+
             expected << Pathname.new("metadata.json")
           end
 


### PR DESCRIPTION
Makes `chef export` respect the `chefignore` file. Frequently very large files like a VM image are stored in a cookbook's ignored directories, which can be bad when trying to copy cookbooks into a VM for testing.

Fixes https://github.com/chef/chef-dk/issues/519

@tbunnyman I pulled in your commit and cleaned it up a little. It turns out there is already a chefignored file in the fixture data, so the existing tests only needed to be modified a little bit to handle the new behavior.

cc @chef/workflow 