### PR TITLE
Add named_run_list support to provisioner

### DIFF
--- a/POLICYFILE_README.md
+++ b/POLICYFILE_README.md
@@ -300,9 +300,9 @@ override["same"]["with"] = "overrides"
 
 ### Testing With Test Kitchen
 
-ChefDK now includes a Test Kitchen provisioner, which allows you to
-converge VMs using Chef Client in policyfile mode, using Chef Zero to
-serve cookbook data. Add the following to your `.kitchen.yml`:
+ChefDK includes a Test Kitchen provisioner, which allows you to converge
+VMs using Chef Client in policyfile mode, using Chef Zero to serve
+cookbook data. Add the following to your `.kitchen.yml`:
 
 ```yaml
 provisioner:
@@ -311,6 +311,35 @@ provisioner:
   # strictly necessary, you should be able to use this with any version
   # of Chef 12.x.
   require_chef_omnibus: true
+```
+
+#### Using Named Run Lists With Kitchen
+
+As of ChefDK 0.11, the Test Kitchen provisioner supports named run
+lists. In addition to testing named run lists that you are using on
+production policies, you can use this feature to test different recipes
+in a library cookbook in isolation.
+
+To use a different named run list on a per-suite basis, specify the
+named run list inside a `provisioner` section, like this:
+
+```yaml
+suites:
+  - name: client
+    provisioner:
+      named_run_list: test_client_recipe
+  - name: server
+    provisioner:
+      named_run_list: test_server_recipe
+```
+
+To use a named run list globally, specify it at the top level of the
+provisioner section:
+
+```yaml
+provisioner:
+  name: policyfile_zero
+  named_run_list: integration_test_run_list
 ```
 
 ## Applying the Policy on a Node

--- a/lib/kitchen/provisioner/policyfile_zero.rb
+++ b/lib/kitchen/provisioner/policyfile_zero.rb
@@ -62,6 +62,7 @@ module Kitchen
       # Since it makes no sense to modify these, they are hardcoded elsewhere.
       default_config :client_rb, {}
       default_config :json_attributes, true
+      default_config :named_run_list, nil
       default_config :chef_zero_host, nil
       default_config :chef_zero_port, 8889
       default_config :policyfile, "Policyfile.rb"
@@ -109,6 +110,10 @@ module Kitchen
         end
         if config[:log_file]
           args << "--logfile #{config[:log_file]}"
+        end
+
+        if config[:named_run_list]
+          args << "--named-run-list #{config[:named_run_list]}"
         end
 
         wrap_shell_code(


### PR DESCRIPTION
Note that kitchen does a little bit of magic to distribute per-suite
configuration to the right place, so to use this to customize suites,
you have to explicitly name it as a provisioner customization, like:

```
suites:
  - name: default
    attributes:
  - name: other
    provisioner:
      named_run_list: example
```

It'd be nice to clean that up when we move policyfile support into kitchen proper. (See: https://github.com/test-kitchen/test-kitchen/blob/9b906c6292d9c183ffb5d631f7355c030790f058/lib/kitchen/data_munger.rb#L625-L688)

@chef/workflow 