### PR TITLE
Update chef dependency to ~> 12.5

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "minitar", "~> 0.5.4"
 
-  gem.add_dependency "chef", "~> 12.0", ">= 12.2.1"
+  gem.add_dependency "chef", "~> 12.5"
 
   gem.add_dependency "solve", "~> 2.0", ">= 2.0.1"
 

--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -17,6 +17,7 @@
 
 require 'chef-dk/exceptions'
 require 'chef-dk/service_exceptions'
+require 'chef/policy_builder/dynamic'
 require 'chef'
 
 module ChefDK


### PR DESCRIPTION
`Chef::PolicyBuilder::Dynamic` was added in Chef 12.5, so that is now our minimum version. I also added an explicit require for it, though it should get brought in from `require 'chef'`