### PR TITLE
Show revision id when running `chef install`

### DIFF
--- a/lib/chef-dk/policyfile_services/install.rb
+++ b/lib/chef-dk/policyfile_services/install.rb
@@ -104,6 +104,7 @@ module ChefDK
         ui.msg ""
 
         ui.msg "Lockfile written to #{policyfile_lock_expanded_path}"
+        ui.msg "Policy revision id: #{policyfile_lock.revision_id}"
       rescue => error
         raise PolicyfileInstallError.new("Failed to generate Policyfile.lock", error)
       end

--- a/spec/unit/policyfile_services/install_spec.rb
+++ b/spec/unit/policyfile_services/install_spec.rb
@@ -111,6 +111,26 @@ E
         expect(generated_lock.cookbook_locks).to have_key("local-cookbook")
       end
 
+      it "prints the policy name" do
+        install_service.run
+        expect(ui.output).to include("Building policy install-example")
+      end
+
+      it "prints the expanded run list" do
+        install_service.run
+        expect(ui.output).to include("Expanded run list: recipe[local-cookbook]")
+      end
+
+      it "prints the lockfile path" do
+        install_service.run
+        expect(ui.output).to include("Lockfile written to #{working_dir}/Policyfile.lock.json")
+      end
+
+      it "prints the lockfile's revision id" do
+        install_service.run
+        expect(ui.output).to include("Policy revision id: 60e5ad638dce219d8f87d589463ec4a9884007ba5e2adbb4c0a7021d67204f1a")
+      end
+
     end
 
     context "and a lockfile exists and `overwrite` is specified" do


### PR DESCRIPTION
When I was working with delivery I wanted to be able to access this information in build logs. It's easy to get when you're doing things on your laptop but that's inconvenient when things are happening on some random Ci machine.

@chef/workflow 