### PR TITLE
Ensure runlist recipes exist

### DIFF
--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -38,6 +38,9 @@ module ChefDK
   class CachedCookbookModified < StandardError
   end
 
+  class CookbookDoesNotContainRequiredRecipe < StandardError
+  end
+
   class InvalidPolicyfileAttribute < StandardError
   end
 

--- a/lib/chef-dk/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-dk/policyfile/cookbook_location_specification.rb
@@ -123,6 +123,11 @@ module ChefDK
         cached_cookbook.dependencies
       end
 
+      # TODO: needs unit test, actual behavior
+      def cookbook_has_recipe?(recipe_name)
+        true
+      end
+
       def cached_cookbook
         # TODO: handle 'bad' return values here (cookbook not installed yet)
         installer.cached_cookbook

--- a/lib/chef-dk/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-dk/policyfile/cookbook_location_specification.rb
@@ -124,7 +124,7 @@ module ChefDK
       end
 
       def cookbook_has_recipe?(recipe_name)
-        expected_path = installer.install_path.join("recipes/#{recipe_name}.rb")
+        expected_path = cookbook_path.join("recipes/#{recipe_name}.rb")
         expected_path.exist?
       end
 
@@ -139,6 +139,14 @@ module ChefDK
 
       def source_options_invalid?
         !source_options.empty? && installer.nil?
+      end
+
+      def cookbook_path
+        if installer.respond_to?(:expanded_path)
+          installer.expanded_path
+        else
+          installer.install_path.expand_path
+        end
       end
 
     end

--- a/lib/chef-dk/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-dk/policyfile/cookbook_location_specification.rb
@@ -123,9 +123,9 @@ module ChefDK
         cached_cookbook.dependencies
       end
 
-      # TODO: needs unit test, actual behavior
       def cookbook_has_recipe?(recipe_name)
-        true
+        expected_path = installer.install_path.join("recipes/#{recipe_name}.rb")
+        expected_path.exist?
       end
 
       def cached_cookbook

--- a/spec/unit/policyfile/cookbook_location_specification_spec.rb
+++ b/spec/unit/policyfile/cookbook_location_specification_spec.rb
@@ -138,11 +138,15 @@ describe ChefDK::Policyfile::CookbookLocationSpecification do
     end
 
     it "determines whether a cookbook has a given recipe" do
+      cookbook_path = cookbook_location_spec.cookbook_path
+      # "cache" cookbook_path so we stub the correct object
+      allow(cookbook_location_spec).to receive(:cookbook_path).and_return(cookbook_path)
+
       default_recipe_path = install_path.join("recipes/default.rb")
       nope_recipe_path = install_path.join("recipes/nope.rb")
 
-      expect(install_path).to receive(:join).with("recipes/default.rb").and_return(default_recipe_path)
-      expect(install_path).to receive(:join).with("recipes/nope.rb").and_return(nope_recipe_path)
+      expect(cookbook_path).to receive(:join).with("recipes/default.rb").and_return(default_recipe_path)
+      expect(cookbook_path).to receive(:join).with("recipes/nope.rb").and_return(nope_recipe_path)
 
       expect(default_recipe_path).to receive(:exist?).and_return(true)
       expect(nope_recipe_path).to receive(:exist?).and_return(false)


### PR DESCRIPTION
When I was working on delivery I got quite a ways through the pipeline before I found that I had an incorrect item in my run list. Since the cookbooks are available locally, we should check this when you run `chef install` to save you the time.

Fixes #629

@chef/workflow 