### PR TITLE
Testing out the update of net-ssh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@
 #
 
 before_install:
+  - gem update --system
+  - gem install bundler --no-ri --no-rdoc
   - gem --version
 
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,11 @@ source 'https://rubygems.org'
 
 gemspec :name => "chef-dk"
 
+# TODO remove when Chef is released with net-ssh pinned
+gem 'chef', github: 'chef/chef', branch: 'tball/netssh'
+# TODO remove when chef-provisioning is released with net-ssh pinned
+gem 'chef-provisioning', github: 'chef/chef-provisioning', branch: 'tball/netssh'
+
 group(:dev) do
   gem 'guard'
   gem 'guard-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ source 'https://rubygems.org'
 gemspec :name => "chef-dk"
 
 # TODO remove when Chef is released with net-ssh pinned
-gem 'chef', github: 'chef/chef', branch: 'tball/netssh'
+gem 'chef', github: 'chef/chef'
 # TODO remove when chef-provisioning is released with net-ssh pinned
 gem 'chef-provisioning', github: 'chef/chef-provisioning', branch: 'tball/netssh'
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gemspec :name => "chef-dk"
 # TODO remove when Chef is released with net-ssh pinned
 gem 'chef', github: 'chef/chef'
 # TODO remove when chef-provisioning is released with net-ssh pinned
-gem 'chef-provisioning', github: 'chef/chef-provisioning', branch: 'tball/netssh'
+gem 'chef-provisioning', github: 'chef/chef-provisioning'
 
 group(:dev) do
   gem 'guard'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200"
+    - ruby_version: "21"
 
 clone_folder: c:\projects\chefdk
 clone_depth: 1
@@ -19,8 +19,9 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%
   - ruby --version
+  - gem update --system
   - gem --version
-  - gem install bundler --quiet --no-ri --no-rdoc
+  - gem install bundler --no-ri --no-rdoc
   - bundler --version
 
 build_script:

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -88,7 +88,7 @@ override :zlib,           version: "1.2.8"
 # Manage the chef-provisioning version via chef-dk.gemspec.
 # TODO delete this when chef-provisioning is released and go back
 # to managing the dependency through chef-dk gemspec
-override :'chef-provisioning', version: "tball/netssh"
+override :'chef-provisioning', version: "master"
 override :'chef-provisioning-aws', version: "v1.7.0"
 override :'chef-provisioning-azure', version: "v0.4.0"
 override :'chef-provisioning-fog', version: "v0.15.0"

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -32,7 +32,7 @@ else
 end
 
 # Uncomment to pin the chef version
-override :chef,             version: "tball/netssh"
+override :chef,             version: "master"
 override :ohai,             version: "master"
 override :inspec,           version: "master"
 override :'kitchen-inspec', version: "v0.10.0"

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -32,14 +32,17 @@ else
 end
 
 # Uncomment to pin the chef version
-override :chef,             version: "master"
+override :chef,             version: "tball/netssh"
 override :ohai,             version: "master"
 override :inspec,           version: "master"
 override :'kitchen-inspec', version: "v0.10.0"
+# TODO delete this and the software def when r-train is released
+override :'r-train',        version: "tball/netssh"
 # We should do a gem release of berkshelf and TK
 # before releasing chefdk.
-override :berkshelf,      version: "master"
-override :'test-kitchen', version: "master"
+# Tyler's master branch pins TK to master
+override :berkshelf,        version: "master", source: { git: "git://github.com/tyler-ball/berkshelf" }
+override :'test-kitchen',   version: "master"
 
 override :'knife-windows', version: "v1.1.1"
 override :'knife-spork',   version: "master"
@@ -83,6 +86,9 @@ override :zlib,           version: "1.2.8"
 
 # NOTE: the base chef-provisioning gem is a dependency of chef-dk (the app).
 # Manage the chef-provisioning version via chef-dk.gemspec.
+# TODO delete this when chef-provisioning is released and go back
+# to managing the dependency through chef-dk gemspec
+override :'chef-provisioning', version: "tball/netssh"
 override :'chef-provisioning-aws', version: "v1.7.0"
 override :'chef-provisioning-azure', version: "v0.4.0"
 override :'chef-provisioning-fog', version: "v0.15.0"

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -37,7 +37,7 @@ override :ohai,             version: "master"
 override :inspec,           version: "master"
 override :'kitchen-inspec', version: "v0.10.0"
 # TODO delete this and the software def when r-train is released
-override :'r-train',        version: "tball/netssh"
+override :'r-train',        version: "master"
 # We should do a gem release of berkshelf and TK
 # before releasing chefdk.
 # Tyler's master branch pins TK to master

--- a/omnibus/config/software/chefdk.rb
+++ b/omnibus/config/software/chefdk.rb
@@ -51,15 +51,16 @@ dependency "rubygems"
 dependency "bundler"
 dependency "appbundler"
 dependency "chef"
+dependency "test-kitchen"
+dependency "r-train"
+dependency "inspec"
+dependency "kitchen-inspec"
+dependency "kitchen-vagrant"
 dependency "berkshelf"
 dependency "chef-vault"
 dependency "foodcritic"
 dependency "ohai"
-dependency "inspec"
 dependency "rubocop"
-dependency "test-kitchen"
-dependency "kitchen-inspec"
-dependency "kitchen-vagrant"
 # This is a TK dependency but isn't declared in that software definition
 # because it is an optional dependency but we want to give it to ChefDK users
 dependency "winrm-transport"
@@ -68,6 +69,7 @@ dependency "knife-windows"
 dependency "knife-spork"
 dependency "fauxhai"
 dependency "chefspec"
+dependency "chef-provisioning"
 
 dependency "chefdk-env-customization" if windows?
 

--- a/omnibus/config/software/r-train.rb
+++ b/omnibus/config/software/r-train.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "r-train"
+default_version "master"
+
+source git: "git://github.com/chef/train.git"
+
+relative_path "r-train"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+dependency "bundler"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  bundle "install --with test integration --without tools", env: env
+
+  gem "build train.gemspec", env: env
+  gem "install r-train-*.gem" \
+      " --no-ri --no-rdoc", env: env
+end


### PR DESCRIPTION
From 2.9.2 to 3.0.2.  The main goal of this branch (right now) is to generate a working package that we can test with.

Before this could be merged we would need to update and probably release the following projects

* Test Kitchen (change already in master, just needs 1.5.0 release)
* R-train (needs a branch merge and release)
  * The software definition can be deleted after it is released
* Chef (needs a branch merge and release)
* Chef Provisioning (needs a branch merge and release)
* Berkshelf (needs a branch merge and release)

I _think_ the above is the order they need releasing it, but we'll need to test that.  There are circular dependencies between a lot of these.

Fixes https://github.com/chef/chef-provisioning/issues/446