### PR TITLE
Point knife-spork to master until knife-spork#198 is fixed

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -42,7 +42,7 @@ override :berkshelf,      version: "master"
 override :'test-kitchen', version: "master"
 
 override :'knife-windows', version: "v1.1.1"
-override :'knife-spork',   version: "1.6.1"
+override :'knife-spork',   version: "master"
 override :fauxhai,         version: "master"
 override :chefspec,        version: "v4.5.0"
 


### PR DESCRIPTION
There has been no recent activity and master is pointing to the same commit that 1.6.1 was released at.