### PR TITLE
Better invalid run list errors

### DIFF
--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -202,7 +202,14 @@ module ChefDK
           cookbook, separator, recipe = item_name.partition('::')
 
           if RUN_LIST_ITEM_COMPONENT.match(cookbook).nil?
-            @errors << "#{run_list_desc} has invalid cookbook name '#{cookbook}'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
+            message = "#{run_list_desc} has invalid cookbook name '#{cookbook}'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
+
+            # Special case when there's only one colon instead of two:
+            if cookbook =~ /[^:]:[^:]/
+              message << "\nDid you mean '#{item.sub(":", "::")}'?"
+            end
+
+            @errors << message
           end
           unless separator.empty?
             # we have a cookbook and recipe

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -202,12 +202,12 @@ module ChefDK
           cookbook, separator, recipe = item_name.partition('::')
 
           if RUN_LIST_ITEM_COMPONENT.match(cookbook).nil?
-            @errors << "#{run_list_desc} has invalid cookbook name '#{cookbook}'.\nCookbook names can only contain alphanumerics, hypens, and underscores."
+            @errors << "#{run_list_desc} has invalid cookbook name '#{cookbook}'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
           end
           unless separator.empty?
             # we have a cookbook and recipe
             if RUN_LIST_ITEM_COMPONENT.match(recipe).nil?
-              @errors << "#{run_list_desc} has invalid recipe name '#{recipe}'.\nRecipe names can only contain alphanumerics, hypens, and underscores."
+              @errors << "#{run_list_desc} has invalid recipe name '#{recipe}'.\nRecipe names can only contain alphanumerics, hyphens, and underscores."
             end
           end
         end

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -103,7 +103,7 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Run List Item 'foo:bar' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hypens, and underscores."
+            expected_message = "Run List Item 'foo:bar' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
             expect(policyfile.errors.first).to eq(expected_message)
           end
         end
@@ -121,7 +121,7 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Run List Item 'recipe[foo:bar]' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hypens, and underscores."
+            expected_message = "Run List Item 'recipe[foo:bar]' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
             expect(policyfile.errors.first).to eq(expected_message)
           end
         end
@@ -139,7 +139,7 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Run List Item 'foo::' has invalid recipe name ''.\nRecipe names can only contain alphanumerics, hypens, and underscores."
+            expected_message = "Run List Item 'foo::' has invalid recipe name ''.\nRecipe names can only contain alphanumerics, hyphens, and underscores."
             expect(policyfile.errors.first).to eq(expected_message)
           end
 
@@ -160,7 +160,7 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Named Run List 'oops' Item 'foo:bar' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hypens, and underscores."
+            expected_message = "Named Run List 'oops' Item 'foo:bar' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
             expect(policyfile.errors.first).to eq(expected_message)
           end
 

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -103,7 +103,9 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Run List Item 'foo:bar' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
+            expected_message = "Run List Item 'foo:bar' has invalid cookbook name 'foo:bar'.\n" +
+              "Cookbook names can only contain alphanumerics, hyphens, and underscores.\n" +
+              "Did you mean 'foo::bar'?"
             expect(policyfile.errors.first).to eq(expected_message)
           end
         end
@@ -121,7 +123,9 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Run List Item 'recipe[foo:bar]' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
+            expected_message = "Run List Item 'recipe[foo:bar]' has invalid cookbook name 'foo:bar'.\n" +
+              "Cookbook names can only contain alphanumerics, hyphens, and underscores.\n" +
+              "Did you mean 'recipe[foo::bar]'?"
             expect(policyfile.errors.first).to eq(expected_message)
           end
         end
@@ -160,7 +164,9 @@ E
 
           it "has an error message with the offending run list item" do
             expect(policyfile.errors).to_not be_empty
-            expected_message = "Named Run List 'oops' Item 'foo:bar' has invalid cookbook name 'foo:bar'.\nCookbook names can only contain alphanumerics, hyphens, and underscores."
+            expected_message = "Named Run List 'oops' Item 'foo:bar' has invalid cookbook name 'foo:bar'.\n" +
+              "Cookbook names can only contain alphanumerics, hyphens, and underscores.\n" +
+              "Did you mean 'foo::bar'?"
             expect(policyfile.errors.first).to eq(expected_message)
           end
 


### PR DESCRIPTION
* fix a typo in the error message that was already there
* add special case handling for when the user separates cookbook and recipe with a single colon instead of two.
