### PR TITLE
By default, install the chefdk environment fix

### DIFF
--- a/omnibus/resources/chefdk/msi/source.wxs.erb
+++ b/omnibus/resources/chefdk/msi/source.wxs.erb
@@ -142,7 +142,7 @@
       <ComponentRef Id="DesktopShortcut" />
     </Feature>
 
-    <Feature Id="ChefDkEnvHacks" Title="!(loc.FeatureChefDkEnvHacks)" Description="!(loc.FeatureChefDkEnvHacksDesc)" Level="1000" AllowAdvertise="no">
+    <Feature Id="ChefDkEnvHacks" Title="!(loc.FeatureChefDkEnvHacks)" Description="!(loc.FeatureChefDkEnvHacksDesc)" Level="1" AllowAdvertise="no">
       <ComponentRef Id="ChefDkEnvHacks" />
     </Feature>
 


### PR DESCRIPTION
We will make this feature opt out intead of opt in. Basically,
people with a proper home wont be affected, and people with
an unavailable home will