### PR TITLE
Allow recent omnibus-software ruby version convention

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: git://github.com/chef/omnibus-software.git
-  revision: 56f4933c94cfcb85be7b3564ccab280769d90d12
+  revision: 45fc26cf6b4692860bd44dc154c690e1e9265870
   specs:
     omnibus-software (4.0.0)
 
 GIT
   remote: git://github.com/chef/omnibus.git
-  revision: d66b7fcafd5f8fb55e974913999fd1b9db564f1e
+  revision: 884a22a0d25edb9193947e411a0a9a4047e662d4
   specs:
     omnibus (5.0.0)
       aws-sdk (~> 2)

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -57,14 +57,12 @@ override :libtool,        version: "2.4.2"
 # override :libxml2,        version: "2.9.3"
 override :libxslt,        version: "1.1.28"
 
-override :ruby,           version: "2.1.6"
-######
-# Ruby 2.1/2.2 has an error on Windows - HTTPS gem downloads aren't working
-# https://bugs.ruby-lang.org/issues/11033
-# Going to leave 2.1.5 for now since there is a workaround
-override :'ruby-windows', version: "2.1.6"
-override :'ruby-windows-devkit', version: "4.7.2-20130224"
-######
+if windows?
+  override :'ruby-windows', version: "2.1.6"
+  override :'ruby-windows-devkit', version: "4.7.2-20130224"
+else
+  override :ruby,           version: "2.1.6"
+end
 
 ######
 # This points to jay's patched version for now to avoid a security

--- a/omnibus/config/software/chefdk-env-customization.rb
+++ b/omnibus/config/software/chefdk-env-customization.rb
@@ -21,7 +21,7 @@ name "chefdk-env-customization"
 
 source path: "#{project.files_path}/#{name}"
 
-dependency "ruby-windows"
+dependency "ruby"
 
 build do
   block "Add chefdk_env_customization file" do

--- a/omnibus/config/software/chefdk.rb
+++ b/omnibus/config/software/chefdk.rb
@@ -39,13 +39,7 @@ end
 
 relative_path "chef-dk"
 
-if windows?
-  dependency "ruby-windows"
-  dependency "ruby-windows-devkit"
-else
-  dependency "libffi" if debian?
-  dependency "ruby"
-end
+dependency "ruby"
 
 dependency "rubygems"
 dependency "bundler"

--- a/omnibus/config/software/rubygems-customization.rb
+++ b/omnibus/config/software/rubygems-customization.rb
@@ -19,12 +19,7 @@ name "rubygems-customization"
 
 source path: "#{project.files_path}/#{name}"
 
-if windows?
-  dependency "ruby-windows"
-else
-  dependency "ruby"
-end
-
+dependency "ruby"
 dependency "rubygems"
 
 build do


### PR DESCRIPTION
This allows master to build at chef/omnibus-software#556