### PR TITLE
Native policy export

### DIFF
--- a/POLICYFILE_README.md
+++ b/POLICYFILE_README.md
@@ -302,15 +302,21 @@ override["same"]["with"] = "overrides"
 
 ChefDK includes a Test Kitchen provisioner, which allows you to converge
 VMs using Chef Client in policyfile mode, using Chef Zero to serve
-cookbook data. Add the following to your `.kitchen.yml`:
+cookbook data.
+
+As of ChefDK 0.11, you need to install Chef Client 12.7 in order for
+Chef Client to correctly converge in the VM. As of this writing, Chef
+12.7 is not yet released, so you will need to configure kitchen to pull
+builds from the 'current' channel, as shown in the example:
+
+Add the following to your `.kitchen.yml`:
 
 ```yaml
 provisioner:
   name: policyfile_zero
-  # This line upgrades you to the latest version of Chef. It's not
-  # strictly necessary, you should be able to use this with any version
-  # of Chef 12.x.
-  require_chef_omnibus: true
+  # Chef 12.7 is required but isn't yet released. You can install builds
+  # from the current channel to get a 12.7 "prerelease" build.
+  chef_omnibus_install_options: -c current
 ```
 
 #### Using Named Run Lists With Kitchen

--- a/lib/chef-dk/policyfile/cookbook_locks.rb
+++ b/lib/chef-dk/policyfile/cookbook_locks.rb
@@ -446,7 +446,7 @@ module ChefDK
       # So the cookbook will be located in a path like:
       #   cookbooks/nginx-111.222.333
       def cookbook_path
-        File.join(relative_paths_root, "cookbooks", "#{name}-#{dotted_decimal_identifier}")
+        File.join(relative_paths_root, "cookbook_artifacts", "#{name}-#{identifier}")
       end
 
       # We trust that archived cookbooks haven't been modified, so just return

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -234,6 +234,19 @@ policy_group 'local'
 use_policyfile true
 policy_document_native_api true
 
+# In order to use this repo, you need a version of Chef Client and Chef Zero
+# that supports policyfile "native mode" APIs:
+current_version = Gem::Version.new(Chef::VERSION)
+unless Gem::Requirement.new(">= 12.7").satisfied_by?(current_version)
+  puts("!" * 80)
+  puts(<<-MESSAGE)
+This Chef Repo requires features introduced in Chef 12.7, but you are using
+Chef #{Chef::VERSION}. Please upgrade to Chef 12.7 or later.
+MESSAGE
+  puts("!" * 80)
+  exit!(1)
+end
+
 CONFIG
         end
       end

--- a/lib/chef-dk/policyfile_services/push_archive.rb
+++ b/lib/chef-dk/policyfile_services/push_archive.rb
@@ -90,8 +90,8 @@ module ChefDK
           raise InvalidPolicyArchive, "Archive does not contain a Policyfile.lock.json"
         end
 
-        unless File.directory?(File.join(staging_dir, "cookbooks"))
-          raise InvalidPolicyArchive, "Archive does not contain a cookbooks directory"
+        unless File.directory?(File.join(staging_dir, "cookbook_artifacts"))
+          raise InvalidPolicyArchive, "Archive does not contain a cookbook_artifacts directory"
         end
 
 

--- a/lib/kitchen/provisioner/policyfile_zero.rb
+++ b/lib/kitchen/provisioner/policyfile_zero.rb
@@ -177,9 +177,9 @@ module Kitchen
 
         data["use_policyfile"] = true
         data["versioned_cookbooks"] = true
-        data["deployment_group"] = "#{policy_exporter.policy_name}-local"
-        # TODO this will need to be updated when chef-zero supports erchef paths (policy_group vs policies)
-        data["policy_document_native_api"] = false
+        data["policy_name"] = policy_exporter.policy_name
+        data["policy_group"] = "local"
+        data["policy_document_native_api"] = true
 
         info("Preparing client.rb")
         debug("Creating client.rb from #{data.inspect}")

--- a/spec/unit/policyfile/cookbook_locks_spec.rb
+++ b/spec/unit/policyfile/cookbook_locks_spec.rb
@@ -468,7 +468,7 @@ describe ChefDK::Policyfile::ArchivedCookbook do
     described_class.new(wrapped_cookbook_lock, storage_config)
   end
 
-  let(:archived_cookbook_path) { File.join(storage_config.relative_paths_root, "cookbooks", "nginx-111.222.333") }
+  let(:archived_cookbook_path) { File.join(storage_config.relative_paths_root, "cookbook_artifacts", "nginx-abc123") }
 
   it "sets cookbook_path to the path within the archive" do
     expect(cookbook_lock.cookbook_path).to eq(archived_cookbook_path)

--- a/spec/unit/policyfile_lock_serialization_spec.rb
+++ b/spec/unit/policyfile_lock_serialization_spec.rb
@@ -412,7 +412,7 @@ describe ChefDK::PolicyfileLock, "when reading a Policyfile.lock" do
       cb_foo = locks["foo"]
       expect(cb_foo).to be_a(ChefDK::Policyfile::ArchivedCookbook)
 
-      expected_path = File.join(storage_config.relative_paths_root, "cookbooks", "foo-111.222.333")
+      expected_path = File.join(storage_config.relative_paths_root, "cookbook_artifacts", "foo-68c13b136a49b4e66cfe9d8aa2b5a85167b5bf9b")
 
       expect(cb_foo.cookbook_path).to eq(expected_path)
       expect(cb_foo.dotted_decimal_identifier).to eq("111.222.333")

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -282,6 +282,19 @@ policy_group 'local'
 use_policyfile true
 policy_document_native_api true
 
+# In order to use this repo, you need a version of Chef Client and Chef Zero
+# that supports policyfile "native mode" APIs:
+current_version = Gem::Version.new(Chef::VERSION)
+unless Gem::Requirement.new(">= 12.7").satisfied_by?(current_version)
+  puts("!" * 80)
+  puts(<<-MESSAGE)
+This Chef Repo requires features introduced in Chef 12.7, but you are using
+Chef 12.7.0. Please upgrade to Chef 12.7 or later.
+MESSAGE
+  puts("!" * 80)
+  exit!(1)
+end
+
 CONFIG
             config_path = File.join(export_dir, "client.rb")
             expect(File).to exist(config_path)

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -221,7 +221,7 @@ E
 
       end
 
-      context "when the archive has no cookbooks/ directory" do
+      context "when the archive has no cookbook_artifacts/ directory" do
 
         let(:archive_files) { [ FileToTar.new("Policyfile.lock.json", "") ] }
 
@@ -229,14 +229,14 @@ E
           expect(exception).to_not be_nil
           expect(exception.message).to eq("Failed to publish archived policy")
           expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
-          expect(exception_cause.message).to eq("Archive does not contain a cookbooks directory")
+          expect(exception_cause.message).to eq("Archive does not contain a cookbook_artifacts directory")
         end
 
       end
 
       context "when the archive has the correct files but the lockfile is invalid" do
 
-        let(:archive_dirs) { ["cookbooks"] }
+        let(:archive_dirs) { ["cookbook_artifacts"] }
 
         let(:archive_files) { [ FileToTar.new("Policyfile.lock.json", lockfile_content) ] }
 
@@ -290,18 +290,18 @@ E
 
     let(:cookbook_name) { "local-cookbook" }
 
-    let(:dotted_decimal_identifier) { "70567763561641081.489844270461035.258281553147148" }
+    let(:identifier) { "fab501cfaf747901bd82c1bc706beae7dc3a350c" }
 
-    let(:cookbook_dir) { File.join("cookbooks", "#{cookbook_name}-#{dotted_decimal_identifier}") }
+    let(:cookbook_artifact_dir) { File.join("cookbook_artifacts", "#{cookbook_name}-#{identifier}") }
 
-    let(:recipes_dir) { File.join(cookbook_dir, "recipes") }
+    let(:recipes_dir) { File.join(cookbook_artifact_dir, "recipes") }
 
-    let(:archive_dirs) { ["cookbooks", cookbook_dir, recipes_dir] }
+    let(:archive_dirs) { ["cookbook_artifacts", cookbook_artifact_dir, recipes_dir] }
 
     let(:archive_files) do
       [
         FileToTar.new("Policyfile.lock.json", lockfile_content),
-        FileToTar.new(File.join(cookbook_dir, "metadata.rb"), "name 'local-cookbook'"),
+        FileToTar.new(File.join(cookbook_artifact_dir, "metadata.rb"), "name 'local-cookbook'"),
         FileToTar.new(File.join(recipes_dir, "default.rb"), "puts 'hello'")
       ]
     end

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -279,6 +279,37 @@ E
           end
 
         end
+
+        # `chef export` previously generated Chef repos designed for
+        # compatibility mode Policyfile usage. We don't intend to be backwards
+        # compatible, but we want to kindly explain what's going on.
+        context "when the archive is in the old format" do
+
+          let(:lockfile_content) { valid_lockfile }
+
+          let(:archive_dirs) { %w{ cookbooks data_bags } }
+
+          let(:archive_files) do
+            [
+              FileToTar.new("Policyfile.lock.json", lockfile_content),
+              FileToTar.new("client.rb", "#content"),
+            ]
+          end
+
+          it "errors out, explaining the compatibility issue" do
+            expect(exception).to_not be_nil
+            expect(exception.message).to eq("Failed to publish archived policy")
+            expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
+
+            msg = <<-MESSAGE
+This archive was created with an older version of ChefDK. This version of
+ChefDK does not support archives in the older format. Re-create the archive
+with a newer version of ChefDK or downgrade ChefDK.
+MESSAGE
+            expect(exception_cause.message).to eq(msg)
+          end
+
+        end
       end
     end
 


### PR DESCRIPTION
Changes `chef export` to create "native format" Chef repos; that is, it creates a Chef repo with `cookbook_artifacts`, `policies`, and `policy_groups` which Chef Zero/local mode will serve over the native policyfile APIs instead of using compat mode. I have confirmed that this fixes https://github.com/sethvargo/chef-sugar/issues/114 in addition to improving usability by making Chef Client configuration work the same as it does when using erchef.

In order to actually use "native format" policy repos with local mode, you need Chef Client with this patch: https://github.com/chef/chef/pull/4479 and a Chef Client or ChefDK package with the latest Chef Zero. Therefore it's probably best to not ship this until Chef 12.7 ships, or else I can rework this patch to provide a compatibility option.