### PR TITLE
Fixup chef export

### DIFF
--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -85,6 +85,12 @@ E
         return 1 unless apply_params!(params)
         export_service.run
         ui.msg("Exported policy '#{export_service.policyfile_lock.name}' to #{export_target}")
+        unless archive?
+          ui.msg("")
+          ui.msg("To converge this system with the exported policy, run:")
+          ui.msg("  cd #{export_dir}")
+          ui.msg("  chef-client -z")
+        end
         0
       rescue ExportDirNotEmpty => e
         ui.err("ERROR: " + e.message)

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -101,6 +101,7 @@ module ChefDK
           create_policy_group_repo_item
           copy_policyfile_lock
           create_client_rb
+          create_readme_md
           if archive?
             create_archive
           else
@@ -252,6 +253,49 @@ CONFIG
         end
       end
 
+      def create_readme_md
+        File.open(readme_staging_path, "wb+") do |f|
+          f.print( <<-README )
+# Exported Chef Repository for Policy '#{policy_name}'
+
+Policy revision: #{policyfile_lock.revision_id}
+
+This directory contains all the cookbooks and configuration necessary for Chef
+to converge a system using this exported policy. To converge a system with the
+exported policy, use a privileged account to run `chef-client -z` from the
+directory containing the exported policy.
+
+## Contents:
+
+### Policyfile.lock.json
+
+A copy of the exported policy, used by the `chef push-archive` command.
+
+### .chef/config.rb
+
+A configuration file for Chef Client. This file configures Chef Client to use
+the correct `policy_name` and `policy_group` for this exported repository. Chef
+Client will use this configuration automatically if you've set your working
+directory properly.
+
+### cookbook_artifacts/
+
+All of the cookbooks required by the policy will be stored in this directory.
+
+### policies/
+
+A different copy of the exported policy, used by the `chef-client` command.
+
+### policy_groups/
+
+Policy groups are used by Chef Server to manage multiple revisions of the same
+policy. However, exported policies contain only a single policy revision, so
+this policy group name is hardcoded to "local" and should not be changed.
+
+README
+        end
+      end
+
       def mv_staged_repo
         # If we got here, either these dirs are empty/don't exist or force is
         # set to true.
@@ -264,6 +308,7 @@ CONFIG
         FileUtils.mv(policy_groups_staging_dir, export_dir)
         FileUtils.mv(lockfile_staging_path, export_dir)
         FileUtils.mv(dot_chef_staging_dir, export_dir)
+        FileUtils.mv(readme_staging_path, export_dir)
       end
 
       def validate_lockfile
@@ -351,6 +396,10 @@ CONFIG
 
       def client_rb_staging_path
         File.join(dot_chef_staging_dir, "config.rb")
+      end
+
+      def readme_staging_path
+        File.join(staging_dir, "README.md")
       end
 
     end

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -241,7 +241,7 @@ unless Gem::Requirement.new(">= 12.7").satisfied_by?(current_version)
   puts("!" * 80)
   puts(<<-MESSAGE)
 This Chef Repo requires features introduced in Chef 12.7, but you are using
-Chef #{Chef::VERSION}. Please upgrade to Chef 12.7 or later.
+Chef \#{Chef::VERSION}. Please upgrade to Chef 12.7 or later.
 MESSAGE
   puts("!" * 80)
   exit!(1)

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -227,7 +227,7 @@ module ChefDK
 # The settings in this file will configure chef to apply the exported policy in
 # this directory. To use it, run:
 #
-# chef-client -c client.rb -z
+# chef-client -z
 #
 
 policy_name '#{policy_name}'
@@ -302,6 +302,7 @@ README
         FileUtils.rm_rf(cookbook_artifacts_dir)
         FileUtils.rm_rf(policies_dir)
         FileUtils.rm_rf(policy_groups_dir)
+        FileUtils.rm_rf(dot_chef_dir)
 
         FileUtils.mv(cookbook_artifacts_staging_dir, export_dir)
         FileUtils.mv(policies_staging_dir, export_dir)
@@ -363,6 +364,10 @@ README
 
       def policy_groups_dir
         File.join(export_dir, "policy_groups")
+      end
+
+      def dot_chef_dir
+        File.join(export_dir, ".chef")
       end
 
       def policyfile_repo_item_path

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -141,6 +141,7 @@ module ChefDK
 
       def create_repo_structure
         FileUtils.mkdir_p(export_dir)
+        FileUtils.mkdir_p(dot_chef_staging_dir)
         FileUtils.mkdir_p(cookbook_artifacts_staging_dir)
         FileUtils.mkdir_p(policies_staging_dir)
         FileUtils.mkdir_p(policy_groups_staging_dir)
@@ -262,7 +263,7 @@ CONFIG
         FileUtils.mv(policies_staging_dir, export_dir)
         FileUtils.mv(policy_groups_staging_dir, export_dir)
         FileUtils.mv(lockfile_staging_path, export_dir)
-        FileUtils.mv(client_rb_staging_path, export_dir)
+        FileUtils.mv(dot_chef_staging_dir, export_dir)
       end
 
       def validate_lockfile
@@ -328,6 +329,10 @@ CONFIG
         File.join(staging_dir, "policy_groups", "local.json")
       end
 
+      def dot_chef_staging_dir
+        File.join(staging_dir, ".chef")
+      end
+
       def cookbook_artifacts_staging_dir
         File.join(staging_dir, "cookbook_artifacts")
       end
@@ -345,7 +350,7 @@ CONFIG
       end
 
       def client_rb_staging_path
-        File.join(staging_dir, "client.rb")
+        File.join(dot_chef_staging_dir, "config.rb")
       end
 
     end

--- a/lib/chef-dk/policyfile_services/push_archive.rb
+++ b/lib/chef-dk/policyfile_services/push_archive.rb
@@ -88,6 +88,8 @@ module ChefDK
 
         if looks_like_old_format_archive?(staging_dir)
           raise InvalidPolicyArchive, <<-MESSAGE
+This archive is in an unsupported format.
+
 This archive was created with an older version of ChefDK. This version of
 ChefDK does not support archives in the older format. Re-create the archive
 with a newer version of ChefDK or downgrade ChefDK.

--- a/spec/unit/command/export_spec.rb
+++ b/spec/unit/command/export_spec.rb
@@ -128,6 +128,17 @@ describe ChefDK::Command::Export do
       it "returns 0" do
         expect(command.run(params)).to eq(0)
       end
+
+      it "prints instructions for running chef-client in the repo" do
+        command.run(params)
+
+        expected_message = <<-MESSAGE
+To converge this system with the exported policy, run:
+  cd /path/to/export
+  chef-client -z
+MESSAGE
+        expect(ui.output).to include(expected_message)
+      end
     end
 
     context "when the command is unsuccessful" do

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -301,6 +301,11 @@ CONFIG
             expect(IO.read(config_path)).to eq(expected_config_text)
           end
 
+          it "generates a README.md in the exported repo" do
+            readme_path = File.join(export_dir, "README.md")
+            expect(File).to exist(readme_path)
+          end
+
         end
 
         context "when the export dir is empty" do

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -273,7 +273,7 @@ E
 # The settings in this file will configure chef to apply the exported policy in
 # this directory. To use it, run:
 #
-# chef-client -c client.rb -z
+# chef-client -z
 #
 
 policy_name 'install-example'

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -289,7 +289,7 @@ unless Gem::Requirement.new(">= 12.7").satisfied_by?(current_version)
   puts("!" * 80)
   puts(<<-MESSAGE)
 This Chef Repo requires features introduced in Chef 12.7, but you are using
-Chef 12.7.0. Please upgrade to Chef 12.7 or later.
+Chef \#{Chef::VERSION}. Please upgrade to Chef 12.7 or later.
 MESSAGE
   puts("!" * 80)
   exit!(1)

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -296,7 +296,7 @@ MESSAGE
 end
 
 CONFIG
-            config_path = File.join(export_dir, "client.rb")
+            config_path = File.join(export_dir, ".chef", "config.rb")
             expect(File).to exist(config_path)
             expect(IO.read(config_path)).to eq(expected_config_text)
           end

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -302,6 +302,8 @@ E
             expect(exception_cause).to be_a(ChefDK::InvalidPolicyArchive)
 
             msg = <<-MESSAGE
+This archive is in an unsupported format.
+
 This archive was created with an older version of ChefDK. This version of
 ChefDK does not support archives in the older format. Re-create the archive
 with a newer version of ChefDK or downgrade ChefDK.


### PR DESCRIPTION
Fixes some issues with error messages in the `chef export` command, adds a README to the generated repository, moves the generated configuration to `.chef/config.rb` so you don't need to pass `-c` to `chef-client`, and adds a "next step" instruction to `chef export`.