### PR TITLE
Update contributing doc and Github URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,14 +53,14 @@ If you would like to learn about when your code will be available in a release o
 Licensing is very important to open source projects. It helps ensure the
   software continues to be available under the terms that the author desired.
 
-Chef uses [the Apache 2.0 license](https://github.com/opscode/chef/blob/master/LICENSE)
+Chef uses [the Apache 2.0 license](https://github.com/chef/chef/blob/master/LICENSE)
   to strike a balance between open contribution and allowing you to use the
   software however you would like to.
 
 The license tells you what rights you have that are provided by the copyright holder.
   It is important that the contributor fully understands what rights they are
   licensing and agrees to them. Sometimes the copyright holder isn't the contributor,
-  most often when the contributor is doing work for a company.
+  such as when the contributor is doing work for a company.
 
 To make a good faith effort to ensure these criteria are met, Chef requires an Individual CLA
   or a Corporate CLA for contributions. This agreement helps ensure you are aware of the
@@ -71,10 +71,10 @@ To make a good faith effort to ensure these criteria are met, Chef requires an I
 It only takes a few minutes to complete a CLA, and you retain the copyright to your contribution.
 
 You can complete our
-  [Individual CLA](https://secure.echosign.com/public/hostedForm?formid=PJIF5694K6L) online.
+  [Individual CLA](https://supermarket.chef.io/icla-signatures/new) online.
   If you're contributing on behalf of your employer and they retain the copyright for your works,
   have your employer fill out our
-  [Corporate CLA](https://secure.echosign.com/public/hostedForm?formid=PIE6C7AX856) instead.
+  [Corporate CLA](https://supermarket.chef.io/ccla-signatures/new) instead.
 
 ### Chef Obvious Fix Policy
 
@@ -99,7 +99,7 @@ As a rule of thumb, changes are obvious fixes if they do not introduce any new f
 ```
 ------------------------------------------------------------------------
 commit 370adb3f82d55d912b0cf9c1d1e99b132a8ed3b5
-Author: danielsdeleo <dan@opscode.com>
+Author: danielsdeleo <dan@chef.io>
 Date:   Wed Sep 18 11:44:40 2013 -0700
 
   Fix typo in config file docs.
@@ -116,13 +116,13 @@ Chef Issue Tracking is handled using Github Issues.
 If you are familiar with Chef and know the component that is causing you a problem or if you
   have a feature request on a specific component you can file an issue in the corresponding
   Github project. All of our Open Source Software can be found in our
-  [Github organization](https://github.com/opscode/).
+  [Github organization](https://github.com/chef/).
 
-Otherwise you can file your issue in the [Chef project](https://github.com/opscode/chef/issues)
+Otherwise you can file your issue in the [Chef project](https://github.com/chef/chef/issues)
   and we will make sure it gets filed against the appropriate project.
 
-In order to decrease the back and forth an issues and help us get to the bottom of them quickly
-  we use below issue template. You can copy paste this code into the issue you are opening and
+In order to decrease the back and forth in issues, and to help us get to the bottom of them quickly
+  we use the below issue template. You can copy/paste this template into the issue you are opening and
   edit it accordingly.
 
 <a name="issuetemplate"></a>
@@ -135,15 +135,11 @@ In order to decrease the back and forth an issues and help us get to the bottom 
 ### Scenario:
 [What you are trying to achieve and you can't?]
 
-
-
 ### Steps to Reproduce:
 [If you are filing an issue what are the things we need to do in order to repro your problem?]
 
-
 ### Expected Result:
 [What are you expecting to happen as the consequence of above reproduction steps?]
-
 
 ### Actual Result:
 [What actually happens after the reproduction steps?]
@@ -152,9 +148,9 @@ In order to decrease the back and forth an issues and help us get to the bottom 
 ## <a name="release"></a> Chef Release Cycles
 
 Our primary shipping vehicle is operating system specific packages that includes
-  all the requirements of Chef. We call these [Omnibus packages](https://github.com/opscode/omnibus-ruby)
+  all the requirements of Chef. We call these [Omnibus packages](https://github.com/chef/omnibus)
 
-We also release our software as gems to [Rubygems](http://rubygems.org/) but we strongly
+We also release our software as gems to [Rubygems](https://rubygems.org/) but we strongly
   recommend using Chef packages since they are the only combination of native libraries &
   gems required by Chef that we test throughly.
 

--- a/POLICYFILE_README.md
+++ b/POLICYFILE_README.md
@@ -15,7 +15,7 @@ Policyfiles.
 A list of planned features which are not yet implemented is given in the
 "Known Limitations" section below. If your idea/need isn't listed there,
 or if you encounter a bug, file an issue at
-https://github.com/opscode/chef-dk/issues
+https://github.com/chef/chef-dk/issues
 
 ## Ok, I've Been Warned. What Is It?
 

--- a/lib/chef-dk/command/clean_policy_cookbooks.rb
+++ b/lib/chef-dk/command/clean_policy_cookbooks.rb
@@ -37,7 +37,7 @@ to remove orphaned policies before running this command.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/clean_policy_revisions.rb
+++ b/lib/chef-dk/command/clean_policy_revisions.rb
@@ -36,7 +36,7 @@ before deleting them, use `chef show-policy --orphans`.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/delete_policy.rb
+++ b/lib/chef-dk/command/delete_policy.rb
@@ -36,7 +36,7 @@ command.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/delete_policy_group.rb
+++ b/lib/chef-dk/command/delete_policy_group.rb
@@ -36,7 +36,7 @@ you to undo this operation via the `chef undelete` command.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -40,7 +40,7 @@ machine with:
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/install.rb
+++ b/lib/chef-dk/command/install.rb
@@ -39,7 +39,7 @@ cookbooks to nodes in your infrastructure.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/push.rb
+++ b/lib/chef-dk/command/push.rb
@@ -37,7 +37,7 @@ run_list and cookbooks.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/push_archive.rb
+++ b/lib/chef-dk/command/push_archive.rb
@@ -37,7 +37,7 @@ run_list and cookbooks.
 
 For more information about Policyfiles, see our detailed README:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 E

--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -40,7 +40,7 @@ command.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/undelete.rb
+++ b/lib/chef-dk/command/undelete.rb
@@ -46,7 +46,7 @@ manually reapply any ACL customizations you have made.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -42,7 +42,7 @@ future version.
 
 See our detailed README for more information:
 
-https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 Options:
 

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -346,7 +346,7 @@ end
             # `knife exec` forces command loading to happen and this command
             # exits 0, which runs most of the code.
             #
-            # See also: https://github.com/opscode/chef-dk/issues/227
+            # See also: https://github.com/chef/chef-dk/issues/227
             sh!("#{usr_bin_path("knife")} exec -E true")
 
             tmpdir do |dir|

--- a/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
@@ -1,7 +1,7 @@
 # Policyfile.rb - Describe how you want Chef to build your system.
 #
 # For more information on the Policyfile feature, visit
-# https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+# https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 # A name that describes what the system you're building with Chef does.
 name "<%= policy_name %>"

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -74,7 +74,7 @@ changing the list found in the `.kitchen.yml` `platforms` YAML stanza.
 
 This build environment is designed to get you up-and-running quickly. However,
 there is nothing that restricts you to building on other platforms. Simply use
-the [omnibus cookbook](https://github.com/opscode-cookbooks/omnibus) to setup
+the [omnibus cookbook](https://github.com/chef-cookbooks/omnibus) to setup
 your desired platform and execute the build steps listed above.
 
 The default build environment requires Test Kitchen and VirtualBox for local

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -223,7 +223,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 # Policyfile.rb - Describe how you want Chef to build your system.
 #
 # For more information on the Policyfile feature, visit
-# https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+# https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 # A name that describes what the system you're building with Chef does.
 name "new_cookbook"

--- a/spec/unit/command/generator_commands/policyfile_spec.rb
+++ b/spec/unit/command/generator_commands/policyfile_spec.rb
@@ -118,7 +118,7 @@ describe ChefDK::Command::GeneratorCommands::Policyfile do
 # Policyfile.rb - Describe how you want Chef to build your system.
 #
 # For more information on the Policyfile feature, visit
-# https://github.com/opscode/chef-dk/blob/master/POLICYFILE_README.md
+# https://github.com/chef/chef-dk/blob/master/POLICYFILE_README.md
 
 # A name that describes what the system you're building with Chef does.
 name "my-app-frontend"

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -586,7 +586,7 @@ REVISION_STRING
 
         p.cached_cookbook("baz") do |cb|
           cb.cache_key = "baz-f59ee7a5bca6a4e606b67f7f856b768d847c39bb"
-          cb.origin = "git://github.com/opscode-cookbooks/bar.git"
+          cb.origin = "git://github.com/chef-cookbooks/bar.git"
         end
 
         p.cached_cookbook("dep_of_bar") do |cb|
@@ -659,7 +659,7 @@ REVISION_STRING
             "identifier"=> cookbook_baz_cksum,
             "dotted_decimal_identifier" => cookbook_baz_cksum_dotted,
             "cache_key" => "baz-f59ee7a5bca6a4e606b67f7f856b768d847c39bb",
-            "origin" => "git://github.com/opscode-cookbooks/bar.git",
+            "origin" => "git://github.com/chef-cookbooks/bar.git",
             "source_options" => nil
           },
 


### PR DESCRIPTION
Sync the contributing doc with chef/chef doc (where it makes sense) and update the github URLs to the new orgs.