### PR TITLE
Create a custom TEMPDIR and blow it away before and after tests

### DIFF
--- a/ci/verify-chefdk.bat
+++ b/ci/verify-chefdk.bat
@@ -3,6 +3,13 @@
 
 cd C:\opscode\chefdk\bin
 
+REM ; Set the temporary directory to a custom location, and wipe it before
+REM ; and after the tests run.
+SET TEMP=%TEMP%\cheftest
+SET TMP=%TMP%\cheftest
+RMDIR /S /Q %TEMP%
+MKDIR %TEMP%
+
 ECHO(
 
 FOR %%b IN (
@@ -30,3 +37,6 @@ FOR %%b IN (
 )
 
 chef verify
+
+REM ; Destroy everything at the end for good measure.
+RMDIR /S /Q %TEMP%

--- a/ci/verify-chefdk.sh
+++ b/ci/verify-chefdk.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Set up a custom tmpdir, and clean it up before and after the tests
+TMPDIR="${TMPDIR:-/tmp}/cheftest"
+export TMPDIR
+rm -rf $TMPDIR
+mkdir -p $TMPDIR
+
 export PATH=/opt/chefdk/bin:$PATH
 
 # Ensure the calling environment (disapproval look Bundler) does not
@@ -20,3 +26,6 @@ do
 done
 
 sudo chef verify --unit
+
+# Clean up the tmpdir at the end for good measure.
+rm -rf $TMPDIR


### PR DESCRIPTION
Sometimes tests crash and don't clean up their symlinks; some tests don't clean up their symlinks at all. This makes it a non-issue by removing all the things.