### PR TITLE
elevate chef shell shortcuts and keep shell icons

### DIFF
--- a/omnibus/resources/chefdk/msi/assets/Set-ElevatedDkShortcut.ps1
+++ b/omnibus/resources/chefdk/msi/assets/Set-ElevatedDkShortcut.ps1
@@ -1,0 +1,20 @@
+Import-Module C:\windows\system32\windowspowershell\v1.0\Modules\Microsoft.PowerShell.Utility\Microsoft.PowerShell.Utility.psd1
+Import-Module C:\windows\system32\windowspowershell\v1.0\Modules\Microsoft.PowerShell.Management\Microsoft.PowerShell.Management.psd1
+
+@(
+  [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::CommonDesktopDirectory),
+  [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::CommonPrograms)
+) | % {
+  $linkFile = Join-Path $_ "Chef Development Kit.lnk"
+
+  if(Test-Path($linkFile)) {
+    Write-Output "Editing Elevation level of $linkFile"
+
+    $bytes = [System.IO.File]::ReadAllBytes($linkFile)
+
+    # Setting the 22nd byte to 34 will elevate the shortcut
+    $bytes[21] = 34
+
+    [System.IO.File]::WriteAllBytes($linkFile, $bytes)
+  }
+}

--- a/omnibus/resources/chefdk/msi/assets/start-chefdk.ps1
+++ b/omnibus/resources/chefdk/msi/assets/start-chefdk.ps1
@@ -1,27 +1,27 @@
 Try {
     $conemulocation = "$env:programfiles\ConEmu\Conemu64.exe"
-    # We don't want the current path to affect which "chef shell-init powershell" we run, so we need to set the PATH to include the current omnibus.
     $chefdk_bin = (split-path $MyInvocation.MyCommand.Definition -Parent)
-    $chefdkinit = '"$env:PATH = ''' + $chefdk_bin + ';'' + $env:PATH; $env:CHEFDK_ENV_FIX = 1; chef shell-init powershell | out-string | iex; Import-Module chef -DisableNameChecking"'
-    $chefdkgreeting = "echo 'PowerShell $($PSVersionTable.psversion.tostring()) ($([System.Environment]::OSVersion.VersionString))';write-host -foregroundcolor darkyellow 'Ohai, welcome to ChefDK!`n'"
-    $chefdkcommand = "$chefdkinit;$chefdkgreeting"
-    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
-    $principal = [Security.Principal.WindowsPrincipal] $identity
-    $titleprefix = ""
-    if($principal.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
-    {
-        $titleprefix = "Administrator: "
-    }
 
-    $chefdktitle = "$($titleprefix)ChefDK ($env:username)"
+    $block = @"
+        # We don't want the current path to affect which "chef shell-init powershell" we run, so we need to set the PATH to include the current omnibus.
+        `$env:PATH = "$chefdk_bin" + ';' + `$env:PATH
+        `$env:CHEFDK_ENV_FIX = 1
+        chef shell-init powershell | out-string | iex
+        Import-Module chef -DisableNameChecking
+        write-host "PowerShell `$(`$PSVersionTable.psversion.tostring()) (`$([System.Environment]::OSVersion.VersionString))"
+        write-host -foregroundcolor darkyellow 'Ohai, welcome to ChefDK!`n'
+"@
+    $chefdktitle = "ChefDK ($env:username)"
 
     if ( test-path $conemulocation )
     {
-        start-process $conemulocation -argumentlist '/title',"`"$chefdktitle`"",'/cmd','powershell.exe','-noexit','-command',$chefdkcommand
+        $encoded = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($block))
+        start-process $conemulocation -argumentlist '/title',"`"$chefdktitle`"",'/cmd','powershell.exe','-noexit','-EncodedCommand',$encoded
+        Stop-Process $PID
     }
     else
     {
-        start-process powershell.exe -argumentlist '-noexit','-command',"$chefdkcommand; (get-host).ui.rawui.windowtitle = '$chefdktitle'"
+        Invoke-Expression $block
     }
 }
 Catch

--- a/omnibus/resources/chefdk/msi/source.wxs.erb
+++ b/omnibus/resources/chefdk/msi/source.wxs.erb
@@ -41,6 +41,19 @@
                  Sequence="execute"
                  Before="FastUnzip" />
 
+    <Property Id="POWERSHELLEXE">
+      <RegistrySearch Id="POWERSHELLEXE"
+                      Type="raw"
+                      Root="HKLM"
+                      Key="SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell"
+                      Name="Path" />
+    </Property>
+
+    <SetProperty Id="ElevateShellShortcuts"
+                 Value="&quot;[POWERSHELLEXE]&quot; -NoLogo -NonInteractive -InputFormat None -NoProfile -ExecutionPolicy Bypass -File [#ElevateScriptPS1]"
+                 Sequence="execute"
+                 Before="ElevateShellShortcuts" />
+
     <CustomAction Id="FastUnzip"
                   BinaryKey="CustomActionFastMsiDLL"
                   DllEntry="FastUnzip"
@@ -57,10 +70,18 @@
                   Execute="deferred"
                   Impersonate="no"
                   Return="ignore" />
+ 
+    <CustomAction Id="ElevateShellShortcuts"
+                  BinaryKey="WixCA"
+                  DllEntry="CAQuietExec64"
+                  Execute="deferred"
+                  Return="check"
+                  Impersonate="no" />
 
     <InstallExecuteSequence>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
+      <Custom Action="ElevateShellShortcuts" After="CreateShortcuts">NOT Installed</Custom>
     </InstallExecuteSequence>
 
     <UI>
@@ -82,6 +103,9 @@
               </Component>
               <Component Id="StartChefDk" Guid="{A8378BA1-85D7-4F11-B1C0-52BF84B4730A}" >
                 <File Id="StartChefDkScript" Source="Resources\assets\start-chefdk.ps1" KeyPath="yes" />
+              </Component>
+              <Component Id="ElevateStartChefDk" Guid="{943d3808-69db-41b9-8e47-8729f0794177}" >
+                <File Id="ElevateScriptPS1" Source="Resources\assets\Set-ElevatedDkShortcut.ps1" />
               </Component>
             </Directory>
             <Directory Id="PSMODULES" Name="modules" >
@@ -108,7 +132,7 @@
                     Name="!(loc.ChefDkShortcutDefName)"
                     Description="!(loc.ChefDkShortcutDefDescription)"
                     Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-                    Arguments="-ExecutionPolicy Bypass -File [#StartChefDkScript]"
+                    Arguments="-ExecutionPolicy Bypass -NoExit -File [#StartChefDkScript]"
                     Icon="oc.ico"/>
         </Component>
       </Directory>
@@ -119,7 +143,7 @@
                     Name="!(loc.ChefDkShortcutDefName)"
                     Description="!(loc.ChefDkShortcutDefDescription)"
                     Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-                    Arguments="-ExecutionPolicy Bypass -File [#StartChefDkScript]"
+                    Arguments="-ExecutionPolicy Bypass -NoExit -File [#StartChefDkScript]"
                     Icon="oc.ico"/>
         </Component>
       </Directory>
@@ -135,11 +159,13 @@
     <Feature Id="ChefDkStartMenuShortcutFeature" Title="!(loc.FeatureChefDkStartMenuShortcut)" Description="!(loc.FeatureChefDkStartMenuShortcutDescription)" Level="1" AllowAdvertise="no" >
       <ComponentRef Id="StartChefDk" />
       <ComponentRef Id="StartMenuShortcut" />
+      <ComponentRef Id="ElevateStartChefDk" />
     </Feature>
 
     <Feature Id="ChefDkDesktopShortcutFeature" Title="!(loc.FeatureChefDkDesktopShortcut)" Description="!(loc.FeatureChefDkDesktopShortcutDescription)" Level="1" AllowAdvertise="no" >
       <ComponentRef Id="StartChefDk" />
       <ComponentRef Id="DesktopShortcut" />
+      <ComponentRef Id="ElevateStartChefDk" />
     </Feature>
 
     <Feature Id="ChefDkEnvHacks" Title="!(loc.FeatureChefDkEnvHacks)" Description="!(loc.FeatureChefDkEnvHacksDesc)" Level="1000" AllowAdvertise="no">


### PR DESCRIPTION
This flips the 22nd byte of the shortcut file to `34` which will elevate the process.

**Note:** I did not realize until this was nearly completed, that the shortcut script spawns a new process window - either powershell or conemu (if its installed). Had I known that, I would have made the more trivial change of adding `-Verb RunAs` to the `Start-Process` calls. I'm open to dumping this implementation for that. Really the only other benefit to this method is that the powershell window no longer needs to spawn a new window (unless spawning conemu) and then the window icon and the taskbar icon are chef icons and not powershell icons. So if we see no value in that, I vote scrapping this.