### PR TITLE
Bump kitchen-inspec to master

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -36,7 +36,7 @@ end
 override :chef,             version: "12.7.2"
 override :ohai,             version: "v8.10.0"
 override :inspec,           version: "v0.11.0"
-override :'kitchen-inspec', version: "v0.11.0"
+override :'kitchen-inspec', version: "master"
 
 # We should do a gem release of berkshelf and TK
 # before releasing chefdk.


### PR DESCRIPTION
The gemfile for v0.11.0 was pointing at a branch that no
longer exists. Bundler would try to fetch it and fail.
This has been fixed in master.