### PR TITLE
Update berkshelf pin and chefdk version

### DIFF
--- a/lib/chef-dk/version.rb
+++ b/lib/chef-dk/version.rb
@@ -16,5 +16,5 @@
 #
 
 module ChefDK
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
 end

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -38,7 +38,8 @@ override :ohai,             version: "v8.10.0"
 override :inspec,           version: "v0.11.0"
 override :'kitchen-inspec', version: "master"
 
-override :berkshelf,        version: "v4.1.1"
+override :berkshelf,        version: "v4.2.0"
+
 override :'test-kitchen',   version: "v1.5.0"
 
 override :'knife-windows', version: "v1.2.1"


### PR DESCRIPTION
Pin berkshelf to a commit that bumps up chef config to 12.7.2 to work around a delivery issue.

Also bump chef-dk version to 0.11.1 for a new release.

@jaym @tyler-ball @chef/client-core 