### PR TITLE
Unfloat kitchen-inspec to v0.11.0

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -36,7 +36,7 @@ end
 override :chef,             version: "12.7.2"
 override :ohai,             version: "v8.10.0"
 override :inspec,           version: "v0.11.0"
-override :'kitchen-inspec', version: "master"
+override :'kitchen-inspec', version: "v0.11.0"
 
 override :berkshelf,        version: "v4.2.0"
 


### PR DESCRIPTION
Pin kitchen-inspec for chef-dk patch release.

@chef/omnibus-maintainers @jaym 