### PR TITLE
bumping berkshelf version to 4.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+sudo: false
 
 before_install:
   - gem update --system

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -38,7 +38,7 @@ override :ohai,             version: "v8.10.0"
 override :inspec,           version: "v0.11.0"
 override :'kitchen-inspec', version: "master"
 
-override :berkshelf,        version: "v4.2.0"
+override :berkshelf,        version: "v4.2.1"
 
 override :'test-kitchen',   version: "v1.5.0"
 


### PR DESCRIPTION
This should get rid of the CookieManager warning