### PR TITLE
Add explicit dependency on devkit

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -97,6 +97,12 @@ dependency "shebang-cleanup"
 dependency "version-manifest"
 dependency "openssl-customization"
 
+if windows?
+  dependency "rb-readline"
+  dependency "ruby-windows-devkit"
+  dependency "ruby-windows-devkit-bash"
+end
+
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
 end


### PR DESCRIPTION
omnibus-software's ruby definitions will no longer be pulling in devkit by default. Projects that want to vendor it must be explicit about this after https://github.com/chef/omnibus-software/pull/593 is merged.