### PR TITLE
Create parent directory before generate policyfile

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/policyfile.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/policyfile.rb
@@ -2,6 +2,11 @@
 context = ChefDK::Generator.context
 policyfile_path = File.join(context.policyfile_dir, "#{context.new_file_basename}.rb")
 
+directory File.dirname(policyfile_path) do
+  action :create
+  recursive true
+end
+
 template policyfile_path do
   source "Policyfile.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)


### PR DESCRIPTION
Hi,

`chef generate policyfile` fails when missing parent directory. We might as well create it automatically.