### PR TITLE
Clean up static libs at build time

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -96,6 +96,7 @@ dependency "rubygems-customization"
 dependency "shebang-cleanup"
 dependency "version-manifest"
 dependency "openssl-customization"
+dependency "clean-static-libs"
 
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']


### PR DESCRIPTION
Cleaning up un-used .a files at build time.

@chef/client-core @lamont-granquist 