### PR TITLE
Improve Chef-DK shortcut startup time by skipping powershell profile

### DIFF
--- a/omnibus/resources/chefdk/msi/source.wxs.erb
+++ b/omnibus/resources/chefdk/msi/source.wxs.erb
@@ -108,7 +108,7 @@
                     Name="!(loc.ChefDkShortcutDefName)"
                     Description="!(loc.ChefDkShortcutDefDescription)"
                     Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-                    Arguments="-ExecutionPolicy Bypass -File [#StartChefDkScript]"
+                    Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefDkScript]"
                     Show="minimized"
                     Icon="oc.ico"/>
         </Component>
@@ -120,7 +120,7 @@
                     Name="!(loc.ChefDkShortcutDefName)"
                     Description="!(loc.ChefDkShortcutDefDescription)"
                     Target="[WindowsFolder]\System32\WindowsPowerShell\v1.0\powershell.exe"
-                    Arguments="-ExecutionPolicy Bypass -File [#StartChefDkScript]"
+                    Arguments="-NoProfile -ExecutionPolicy Bypass -File [#StartChefDkScript]"
                     Show="minimized"
                     Icon="oc.ico"/>
         </Component>


### PR DESCRIPTION
We use powershell.exe to launch a script that itself launches conemu or powershell with `chef shell-init powershell` to initialize the shell environment. When we use powershell.exe, we don't specify `-noprofile`, which results in powershell needlessly running the current profile (which may be slow depending on what's in it). Using `-noprofile` speeds things up since that powershell.exe instance itself is throwaway and profile customizations are never used since there is no interaction of that shell with the user.