### PR TITLE
Ensure tests are last command in test scripts

### DIFF
--- a/ci/verify-chefdk.bat
+++ b/ci/verify-chefdk.bat
@@ -36,7 +36,5 @@ FOR %%b IN (
   ECHO(
 )
 
+REM ; Run this last so the correct exit code is propagated
 chef verify
-
-REM ; Destroy everything at the end for good measure.
-RMDIR /S /Q %TEMP%

--- a/ci/verify-chefdk.sh
+++ b/ci/verify-chefdk.sh
@@ -25,7 +25,6 @@ do
   unset $ruby_env_var
 done
 
+# This has to be the last thing we run so that we return the correct exit code
+# to the Ci system.
 sudo chef verify --unit
-
-# Clean up the tmpdir at the end for good measure.
-rm -rf $TMPDIR


### PR DESCRIPTION
Similar to https://github.com/chef/chef/commit/01147dc69cf1f62b03400e3292c5d7c5d5d7e95f
We need to run the test command last to ensure the exit code passed to
the Ci system is the one from the tests.