### PR TITLE
Update require_chef_omnibus example in template.

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -16,7 +16,7 @@ provisioner:
 ## also set this to `true` to always use the latest version.
 ## see also: https://docs.chef.io/config_yml_kitchen.html
 
-#  require_chef_omnibus: 12.5.0
+#  require_chef_omnibus: 12.8.1
 
 # Uncomment the following verifier to leverage Inspec instead of Busser (the
 # default verifier)

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -274,7 +274,7 @@ provisioner:
 ## also set this to `true` to always use the latest version.
 ## see also: https://docs.chef.io/config_yml_kitchen.html
 
-#  require_chef_omnibus: 12.5.0
+#  require_chef_omnibus: 12.8.1
 
 # Uncomment the following verifier to leverage Inspec instead of Busser (the
 # default verifier)


### PR DESCRIPTION
The example version value for require_chef_omnibus was 12.5.0, which was never actually released. This changes the value to an actual released version just for sanity. This is just something which was bothering me and I had to fix.