### PR TITLE
Adding the winrm-fs software definition in omnibus-software

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'omnibus', git: 'https://github.com/chef/omnibus.git'
-gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git'
+gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git', branch: "winrm_fs"
 
 # omnibus pulls in aws-sdk which pulls in aws-sdk-core which pulls in jmespath which pulls in json_pure
 # json_pure breaks us. jmespath added it in 1.2.2. Pin to 1.1.


### PR DESCRIPTION
\cc @mwrock - did you intend for builds of this to float on master?  That is how it will work now.

ChefDK builds are currently failing because there is no `winrm-fs` software definition.  This fixes that.

Depends on https://github.com/chef/omnibus-software/pull/641