### PR TITLE
Point to the right license file for chefdk.

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -19,7 +19,7 @@ friendly_name "Chef Development Kit"
 maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
 license "Apache-2.0"
-license_file "LICENSE"
+license_file "../LICENSE"
 
 build_iteration 1
 require_relative "../../../lib/chef-dk/version"


### PR DESCRIPTION
/cc: @tyler-ball 

Similar to https://github.com/chef/chef/pull/4811 this fixes broken chefdk build by pointing to the right LICENSE file.