### PR TITLE
Dependency bump to get the latest Chef release, 12.9.38

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group(:omnibus_package) do
   gem "chef-provisioning-vagrant", ">= 0.11.0"
   gem "chef-vault"
   # The chef version is pinned by "rake dependencies", which grabs the current version from omnibus.
-  gem "chef", github: "chef/chef", branch: "v12.9.36"
+  gem "chef", github: "chef/chef", branch: "v12.9.38"
   gem "cheffish", ">= 2.0.3"
   gem "chefspec"
   gem "fauxhai"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GIT
   remote: git://github.com/chef/appbundler.git
-  revision: 9e6ef05fecd0972e10aaaba674739ebe3186ed82
+  revision: a8376ff735ec63d6f4e3cffe971223516890239c
   specs:
-    appbundler (0.8.0)
+    appbundler (0.9.0)
       mixlib-cli (~> 1.4)
 
 GIT
   remote: git://github.com/chef/chef.git
-  revision: ff6d2337ee830854c4489d860955609aeaec9674
-  branch: v12.9.36
+  revision: 5371a896228647bdb1b9260bc36b3afc756897c7
+  branch: v12.9.38
   specs:
-    chef (12.9.36)
+    chef (12.9.38)
       bundler (>= 1.10)
-      chef-config (= 12.9.36)
+      chef-config (= 12.9.38)
       chef-zero (~> 4.5)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -36,7 +36,7 @@ GIT
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (12.9.36)
+    chef-config (12.9.38)
       fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
@@ -86,12 +86,12 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.2.33)
-      aws-sdk-resources (= 2.2.33)
-    aws-sdk-core (2.2.33)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.33)
-      aws-sdk-core (= 2.2.33)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -460,7 +460,7 @@ GEM
       rspec-mocks (~> 3.2)
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
-    mixlib-install (1.0.4)
+    mixlib-install (1.0.5)
       artifactory (>= 2.3.0)
       mixlib-shellout (>= 2.2.6)
       mixlib-versioning (>= 1.1.0)

--- a/Gemfile.windows.lock
+++ b/Gemfile.windows.lock
@@ -1,19 +1,19 @@
 GIT
   remote: git://github.com/chef/appbundler.git
-  revision: 9e6ef05fecd0972e10aaaba674739ebe3186ed82
-  ref: 9e6ef05fecd0972e10aaaba674739ebe3186ed82
+  revision: a8376ff735ec63d6f4e3cffe971223516890239c
+  ref: a8376ff735ec63d6f4e3cffe971223516890239c
   specs:
-    appbundler (0.8.0)
+    appbundler (0.9.0)
       mixlib-cli (~> 1.4)
 
 GIT
   remote: git://github.com/chef/chef.git
-  revision: ff6d2337ee830854c4489d860955609aeaec9674
-  ref: ff6d2337ee830854c4489d860955609aeaec9674
+  revision: 5371a896228647bdb1b9260bc36b3afc756897c7
+  ref: 5371a896228647bdb1b9260bc36b3afc756897c7
   specs:
-    chef (12.9.36-universal-mingw32)
+    chef (12.9.38-universal-mingw32)
       bundler (>= 1.10)
-      chef-config (= 12.9.36)
+      chef-config (= 12.9.38)
       chef-zero (~> 4.5)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -48,7 +48,7 @@ GIT
       win32-service (~> 0.8.7)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (12.9.36)
+    chef-config (12.9.38)
       fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
@@ -99,12 +99,12 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.2.33)
-      aws-sdk-resources (= 2.2.33)
-    aws-sdk-core (2.2.33)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.33)
-      aws-sdk-core (= 2.2.33)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -473,7 +473,7 @@ GEM
       rspec-mocks (~> 3.2)
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
-    mixlib-install (1.0.4)
+    mixlib-install (1.0.5)
       artifactory (>= 2.3.0)
       mixlib-shellout (>= 2.2.6)
       mixlib-versioning (>= 1.1.0)
@@ -721,9 +721,9 @@ DEPENDENCIES
   artifactory (= 2.3.2)
   ast (= 2.2.0)
   autoparse (= 0.3.3)
-  aws-sdk (= 2.2.33)
-  aws-sdk-core (= 2.2.33)
-  aws-sdk-resources (= 2.2.33)
+  aws-sdk (= 2.2.34)
+  aws-sdk-core (= 2.2.34)
+  aws-sdk-resources (= 2.2.34)
   aws-sdk-v1 (= 1.66.0)
   berkshelf (= 4.3.2)
   berkshelf-api-client (= 2.0.2)
@@ -846,7 +846,7 @@ DEPENDENCIES
   mixlib-authentication (= 1.4.0)
   mixlib-cli (= 1.5.0)
   mixlib-config (= 2.2.1)
-  mixlib-install (= 1.0.4)
+  mixlib-install (= 1.0.5)
   mixlib-log (= 1.6.0)
   mixlib-shellout (= 2.2.6)
   mixlib-versioning (= 1.1.0)

--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/chef-acceptance.git
-  revision: 455676a8bd3155a3f565791d225707ad2302f8b8
+  revision: 49458ec493dbd12588680eea9f2f9beb76463d09
   specs:
     chef-acceptance (0.2.0)
       mixlib-shellout (~> 2.0)
@@ -24,12 +24,12 @@ GEM
   specs:
     addressable (2.4.0)
     artifactory (2.3.2)
-    aws-sdk (2.2.33)
-      aws-sdk-resources (= 2.2.33)
-    aws-sdk-core (2.2.33)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.33)
-      aws-sdk-core (= 2.2.33)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     berkshelf (4.3.2)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -86,7 +86,7 @@ GEM
     hashie (3.4.3)
     hitimes (1.2.3)
     httpclient (2.7.1)
-    inspec (0.17.1)
+    inspec (0.18.0)
       json (~> 1.8)
       method_source (~> 0.8)
       pry (~> 0)
@@ -117,7 +117,7 @@ GEM
       rspec-expectations (~> 3.2)
       rspec-mocks (~> 3.2)
     mixlib-config (2.2.1)
-    mixlib-install (1.0.4)
+    mixlib-install (1.0.5)
       artifactory (>= 2.3.0)
       mixlib-shellout (>= 2.2.6)
       mixlib-versioning (>= 1.1.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 15fc7bab524b26b09539c477bcedb2b2efc9fffc
+  revision: e73722f46fbd5f302d9e1541aaae0b2f8be2110e
   specs:
     omnibus (5.3.0)
       aws-sdk (~> 2)
@@ -38,12 +38,12 @@ GEM
     addressable (2.4.0)
     artifactory (2.3.2)
     awesome_print (1.6.1)
-    aws-sdk (2.2.33)
-      aws-sdk-resources (= 2.2.33)
-    aws-sdk-core (2.2.33)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.33)
-      aws-sdk-core (= 2.2.33)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     berkshelf (4.3.2)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -119,7 +119,7 @@ GEM
       rspec-mocks (~> 3.2)
     mixlib-cli (1.5.0)
     mixlib-config (2.2.1)
-    mixlib-install (1.0.4)
+    mixlib-install (1.0.5)
       artifactory (>= 2.3.0)
       mixlib-shellout (>= 2.2.6)
       mixlib-versioning (>= 1.1.0)
@@ -136,7 +136,7 @@ GEM
     nori (2.6.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.13.0)
+    ohai (8.14.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)


### PR DESCRIPTION
This is to make sure that delivery is using the pending Chef release of 12.9.38

\cc @jkeiser @danielsdeleo @randomcamel @chefsalim 