### PR TITLE
add delivery-cli to chefdk

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -281,6 +281,7 @@ EOS
         end
       end
 
+
       add_component "chefspec" do |c|
         c.gem_base_dir = "chefspec"
         c.unit_test do
@@ -448,6 +449,18 @@ end
             end
             # TODO when we appbundle inspec, no longer `chef exec`
             sh("#{bin("chef")} exec #{bin("inspec")} exec .", cwd: cwd)
+          end
+        end
+      end
+
+      unless Gem.win_platform?
+        add_component "delivery-cli" do |c|
+          # We'll want to come back and revisit getting unit tests added -
+          # currently running the tests depends on cargo , which is not included
+          # in our package.
+
+          c.smoke_test do
+            sh!(bin("delivery-cli --help"))
           end
         end
       end

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -44,6 +44,14 @@ dependency "preparation"
 # or removal of a dependency doesn't dirty the entire project file
 dependency "chef-dk-complete"
 
+unless windows?
+  # For now, Delivery CLI is *nix only.
+  dependency "delivery-cli"
+
+  # This is a build-time dependency, so we won't leave it behind:
+  dependency "rust-uninstall"
+end
+
 package :rpm do
   signing_passphrase ENV['OMNIBUS_RPM_SIGNING_PASSPHRASE']
 end

--- a/omnibus/config/software/delivery-cli.rb
+++ b/omnibus/config/software/delivery-cli.rb
@@ -1,0 +1,42 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "delivery-cli"
+default_version "mp/build-via-chefdk"
+
+source git: "https://github.com/chef/delivery-cli.git"
+
+dependency "openssl"
+dependency "rust"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # The rust core libraries are dynamicaly linked
+  env['LD_LIBRARY_PATH']            = "#{install_dir}/embedded/lib"
+  env['DYLD_FALLBACK_LIBRARY_PATH'] = "#{install_dir}/embedded/lib:" if mac_os_x?
+
+  # Allows us to build with kitchen builders on virtualbox -
+  # due to a bug in virtualbox vboxsf, libgit2 (used by cargo) will
+  # encounter failures when using the default vboxsf-mounted
+  # /home/vagrant/.cargo location
+  env['CARGO_HOME']                 = "#{Omnibus::Config.base_dir}/cargo"
+
+  env['OPENSSL_PREFIX']             = "#{install_dir}/embedded/lib"
+  command "cargo build -j #{workers} --release", env: env
+  mkdir "#{install_dir}/bin"
+  copy "#{project_dir}/target/release/delivery", "#{install_dir}/bin/delivery"
+end

--- a/omnibus/config/software/rust-uninstall.rb
+++ b/omnibus/config/software/rust-uninstall.rb
@@ -1,0 +1,29 @@
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rust-uninstall"
+default_version "0.0.1"
+
+dependency "rust"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # Until Omnibus has full support for build depedencies (see chef/omnibus#483)
+  # we don't want to ship the Rust and Cargo in our final artifact. Luckily
+  # Rust ships with a nice uninstall script which makes it easy to strip
+  # everything out.
+  command "#{install_dir}/embedded/lib/rustlib/uninstall.sh", env: env
+end

--- a/omnibus/config/software/rust.rb
+++ b/omnibus/config/software/rust.rb
@@ -1,0 +1,47 @@
+#
+# Copyright 2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rust"
+default_version "2015-10-03"
+
+
+if mac_os_x?
+  host_triple = "apple-darwin"
+  md5sum = "0485cb9902a3b3c563c6c6e20b311419"
+else
+  host_triple = "unknown-linux-gnu"
+  md5sum = "eff35d920b30f191b659075a563197a6"
+end
+
+relative_path "rust-nightly-x86_64-#{host_triple}"
+version "2015-10-03" do
+  source url: "https://static.rust-lang.org/dist/#{version}/rust-nightly-x86_64-#{host_triple}.tar.gz",
+         md5: md5sum
+end
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  # Allows us to build with kitchen builders on  virtuablox -
+  # due to a bug in virtualbox vboxsf, libgit2 (used by cargo) will
+  # encounter failures when using the default vboxsf-mounted
+  # /home/vagrant/.cargo location
+  env['CARGO_HOME']      = "#{Omnibus::Config.base_dir}/cargo"
+
+  command "./install.sh" \
+          " --prefix=#{install_dir}/embedded" \
+          " --components=rustc,cargo" \
+          " --verbose", env: env
+end

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -35,7 +35,7 @@ windows_arch   %w{x86 x64}.include?((ENV['OMNIBUS_WINDOWS_ARCH'] || '').downcase
 
 # Enable S3 asset caching
 # ------------------------------
-use_s3_caching true
+use_s3_caching false 
 s3_access_key  ENV['AWS_ACCESS_KEY_ID']
 s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
 s3_bucket      'opscode-omnibus-cache'

--- a/omnibus/package-scripts/chefdk/postinst
+++ b/omnibus/package-scripts/chefdk/postinst
@@ -36,7 +36,7 @@ fi
 
 # We test for the presence of /usr/bin/chef-client to know if this script succeeds,
 # so chef-client must appear as the last item here.
-binaries="chef chef-solo chef-apply chef-shell knife ohai berks fauxhai foodcritic kitchen rubocop chef-client"
+binaries="chef chef-solo chef-apply chef-shell knife ohai berks fauxhai foodcritic kitchen rubocop delivery chef-client"
 
 # rm -f before ln -sf is required for solaris 9
 for binary in $binaries; do

--- a/omnibus/package-scripts/chefdk/postrm
+++ b/omnibus/package-scripts/chefdk/postrm
@@ -25,7 +25,9 @@ else
 fi
 
 cleanup_symlinks() {
-  binaries="chef chef-solo chef-apply chef-shell knife ohai berks chef-zero fauxhai foodcritic kitchen rubocop strain strainer chef-client"
+  # Keep removed symlinks in this list, so that removal of upgraded packages still cleans up
+  # leftovers from older versions.
+  binaries="berks chef chef-apply chef-shell chef-solo chef-zero delivery fauxhai foodcritic kitchen knife ohai rubocop chef-client"
   for binary in $binaries; do
     rm -f $PREFIX/bin/$binary
   done


### PR DESCRIPTION
This includes the delivery CLI tool in the chefdk package.

Pending: 

* [ ]  get the verify task working - currently assumptions around where things live (eg not in 'chefdk/bin') \
* [ ] merge temporary branch of delivery-cli in use, change software def to refer to master instead of branch. 
* [ ] update  s3 cache and re-enable caching

Ping @tyler-ball 

Still outstanding:

* windows build
* determining whether to include cargo to allow
  unit tests to be run in verify.

Note for Reviewers: 

THis PR is  against the set of related changes in the branch `unified_workflow_spike`, and not against `master`. 

Reference: https://chefio.atlassian.net/secure/RapidBoard.jspa?rapidView=174&projectKey=UW&selectedIssue=UW-1
