### PR TITLE
Make sure $CHEFDK/bin/rubocop exists

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -336,7 +336,7 @@ def foo
 end
               EOF
             end
-            sh("#{embedded_bin("rubocop")} foo.rb -l", cwd: cwd)
+            sh("#{bin("rubocop")} foo.rb -l", cwd: cwd)
           end
         end
       end

--- a/omnibus/config/software/chef-dk-appbundle.rb
+++ b/omnibus/config/software/chef-dk-appbundle.rb
@@ -18,6 +18,7 @@ build do
   appbundle_gem "test-kitchen"
   appbundle_gem "opscode-pushy-client"
   appbundle_gem "cookstyle"
+  appbundle_gem "rubocop"
 
   # These are not appbundled, but need to have their Gemfiles locked down so that their tests will run
 

--- a/omnibus/files/chef-dk/build-chef-dk.rb
+++ b/omnibus/files/chef-dk/build-chef-dk.rb
@@ -93,8 +93,11 @@ module BuildChefDK
         if line =~ /^\s*\*\s*(\S+)\s+\((\S+).*\)\s*$/
           name, version = $1, $2
           # rubocop is an exception, since different projects disagree
-          next if GEMS_ALLOWED_TO_FLOAT.include?(name)
-          gem_pins << "gem #{name.inspect}, #{version.inspect}, override: true\n"
+          if GEMS_ALLOWED_TO_FLOAT.include?(name)
+            gem_pins << "gem #{name.inspect}, #{version.inspect}, overrideable: true unless being_included\n"
+          else
+            gem_pins << "gem #{name.inspect}, #{version.inspect}, override: true\n"
+          end
         end
       end
 
@@ -112,6 +115,8 @@ module BuildChefDK
         # Override any existing gems with our own.
         require_relative "#{gemfile_util}"
         extend GemfileUtil
+        being_included = (__FILE__ != Bundler.default_gemfile)
+
         #{gem_pins}
       EOM
     end

--- a/spec/unit/gemfile_util_spec.rb
+++ b/spec/unit/gemfile_util_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require_relative '../../tasks/gemfile_util'
+
+class GemfileSuper
+  def gem(*args)
+    :superclass
+  end
+end
+
+class GemfileUtilUser < GemfileSuper
+  include GemfileUtil
+end
+
+describe GemfileUtil do
+  let (:gem_name) { "uncle_bobs_json_parser" }
+  let (:gemfile_util) { GemfileUtilUser.new }
+
+  context "#gem", :skip do
+    it "calls the superclass method by default" do
+      expect(gemfile_util).to receive(:gem).and_return(:superclass)
+      gemfile_util.gem(gem_name)
+    end
+
+    # :path and :override follow the same code path, but for clarity get unrefactored specs.
+    it "overrides gems with :path" do
+      expect(gemfile_util).to receive(:warn_if_replacing)
+      expect(gemfile_util.gem(gem_name, path: true)).to be_nil
+      expect(gemfile_util.overridden_gems).to eq({ gem_name => [{ path: true }] })
+    end
+
+    it "overrides gems with :override" do
+      expect(gemfile_util).to receive(:warn_if_replacing)
+      expect(gemfile_util.gem(gem_name, override: true)).to be_nil
+      expect(gemfile_util.overridden_gems).to eq({ gem_name => [{ }] })
+    end
+
+    it "does not override gems with :overrideable" do
+      expect(gemfile_util.gem(gem_name, override: true)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Acceptance criteria:
  1. Rubocop is available in `/opt/chefdk/bin` (or platform-specific analogue).
  1. Tests make sure # 1 is true.