### PR TITLE
We were not actually running chef verify on Windows

### DIFF
--- a/ci/verify-chefdk.bat
+++ b/ci/verify-chefdk.bat
@@ -10,31 +10,5 @@ SET TMP=%TMP%\cheftest
 RMDIR /S /Q %TEMP%
 MKDIR %TEMP%
 
-ECHO(
-
-FOR %%b IN (
-  berks
-  chef
-  chef-client
-  kitchen
-  knife
-  rubocop
-) DO (
-
-
-  ECHO Checking for existence of binfile `%%b`...
-
-  IF EXIST %%b (
-
-    ECHO ...FOUND IT!
-
-  ) ELSE (
-
-    GOTO :error
-
-  )
-  ECHO(
-)
-
 REM ; Run this last so the correct exit code is propagated
 chef verify


### PR DESCRIPTION
\cc @tylercloke @sersut @schisamo 

On our Windows builders we were seeing the following text:

```
============================================================
Running verification for chefdk
============================================================


Checking for existence of binfile `berks`...
...FOUND IT!

Checking for existence of binfile `chef`...
...FOUND IT!

Checking for existence of binfile `chef-client`...
...FOUND IT!

Checking for existence of binfile `kitchen`...
...FOUND IT!

Checking for existence of binfile `knife`...
...FOUND IT!

Checking for existence of binfile `rubocop`...
The system cannot find the batch label specified - error
```

It was failing out without actually running `chef verify`. We also no longer need to check for those binfiles because we do that in `chef verify`.