### PR TITLE
Only consume push jobs client with version from the stable channel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,8 @@ group(:omnibus_package) do
   gem "knife-supermarket"
   gem "mixlib-versioning"
   gem "artifactory"
-  # No rubygems release of this yet
-  gem "opscode-pushy-client", github: "chef/opscode-pushy-client"
+  # The opscode-pushy-client version is pinned by "rake dependencies", which grabs the current version from omnibus.
+  gem "opscode-pushy-client", github: "chef/opscode-pushy-client", branch: "1.3.4"
   gem "ffi-rzmq-core"
   gem "knife-push"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,17 +73,14 @@ GIT
       win32-service (~> 0.8.7)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (12.9.41)
-      fuzzyurl (~> 0.8.0)
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
 
 GIT
   remote: git://github.com/chef/opscode-pushy-client.git
-  revision: a24b26706ccbf2632494e60f277a03cdb566debd
+  revision: 8265cc209370ec23d4072d4d8038d8c1f43546da
+  branch: 1.3.4
   specs:
-    opscode-pushy-client (2.0.2)
-      chef (>= 12.5)
+    opscode-pushy-client (1.3.4)
+      chef (>= 12.0)
       ffi-rzmq
       ohai
       uuidtools
@@ -168,6 +165,10 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
+    chef-config (12.9.41)
+      fuzzyurl (~> 0.8.0)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
     chef-provisioning (1.7.0)
       cheffish (>= 1.3.1, < 3.0)
       inifile (>= 2.0.2)
@@ -648,7 +649,6 @@ GEM
     ruby-prof (0.15.9)
     ruby-progressbar (1.8.0)
     ruby-shadow (2.5.0)
-    ruby_dep (1.3.1)
     rubyntlm (0.6.0)
     rubyzip (1.2.0)
     rufus-lru (1.1.0)

--- a/spec/unit/tasks/helpers_spec.rb
+++ b/spec/unit/tasks/helpers_spec.rb
@@ -1,0 +1,75 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require_relative "../../../tasks/helpers"
+
+class RakeMock
+
+end
+
+describe "Rake 'dependencies' task" do
+  let(:rake_mock) { Class.new { include RakeDependenciesTaskHelpers }.new }
+  let(:product_name) { "chef" }
+  let(:gemfile_name) { "chef" }
+  let(:gemfile) {'gem "chef", github: "chef/chef", branch: "0.0.0"'}
+  let(:expected_version) { "0.0.1" }
+
+  before do
+    allow(rake_mock).to receive(:puts)
+    allow(rake_mock).to receive(:get_latest_version_for).with(product_name).and_return(expected_version)
+  end
+
+  describe "update_gemfile_from_stable" do
+    context "when gemfile does not contain the expected string" do
+      let(:gemfile) { "These are not the droids you are looking for." }
+
+      it "raises an error" do
+        expect { rake_mock.update_gemfile_from_stable(gemfile, product_name, gemfile_name) }.to raise_error(/Gemfile does not have a line of the form/)
+      end
+    end
+
+    context "when gemfile does contain the expected string" do
+      let(:prefix) { "" }
+      let(:expected_output) {"gem \"chef\", github: \"chef/chef\", branch: \"#{prefix}#{expected_version}\""}
+
+      context "and the version string does not have a prefix" do
+        it "updates the gemfile entry to the newer version" do
+          expect(rake_mock.update_gemfile_from_stable(gemfile, product_name, gemfile_name))
+            .to eq(expected_output)
+        end
+      end
+
+      context "and the version is the same" do
+        let(:expected_version) { "0.0.0" }
+        it "warns the user that the version is not being updated" do
+          expect(rake_mock).to receive(:puts).with(/version in Gemfile already at latest stable/)
+          expect(rake_mock.update_gemfile_from_stable(gemfile, product_name, gemfile_name))
+            .to eq(expected_output)
+        end
+      end
+
+      context "and a prefix is specified" do
+        let(:prefix) { "v" }
+        it "updates the gemfile entry to the newer version" do
+          expect(rake_mock.update_gemfile_from_stable(gemfile, product_name, gemfile_name, prefix))
+            .to eq(expected_output)
+        end
+      end
+    end
+  end
+end

--- a/tasks/helpers.rb
+++ b/tasks/helpers.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Putting this method in a module so it is easier to test
+module RakeDependenciesTaskHelpers
+  def update_gemfile_from_stable(gemfile, product_name, gemfile_name, version_prefix="")
+    version = get_latest_version_for(product_name)
+    version = "#{version_prefix}#{version}"
+    found = gemfile.sub!(/^(\s*gem "#{gemfile_name}", github: "chef\/#{gemfile_name}", branch: ")([^"]*)(")$/m) do
+      if $2 != "#{version}"
+        puts "Setting #{product_name} version in Gemfile to #{version} (was #{$2})"
+      else
+        puts "#{product_name} version in Gemfile already at latest stable (#{$2})"
+      end
+      "#{$1}#{version}#{$3}"
+    end
+    unless found
+      raise "Gemfile does not have a line of the form 'gem \"#{gemfile_name}\", github: \"chef/#{gemfile_name}\", branch: \"<version>\"', so we didn't update it to latest stable (#{version})."
+    end
+    gemfile
+  end
+
+  def get_latest_version_for(product_name, channel_name = :stable)
+    require 'mixlib/install'
+    puts "Getting latest '#{channel_name}' channel #{product_name} version ..."
+    options = {
+      channel: channel_name.to_sym,
+      product_version: :latest,
+      product_name: product_name,
+    }
+    Mixlib::Install.new(options).artifact_info.first.version
+  end
+end

--- a/version_policy.rb
+++ b/version_policy.rb
@@ -89,16 +89,17 @@ ACCEPTABLE_OUTDATED_GEMS = [
   "unicode-display_width",
   "varia_model",
   "httpclient",
-  # We have a task called update_current_chef which scans and pins to the
-  # latest released chef/chef-config but it pulls from the chef repo
-  # instead of from rubygems. Bundler currently considers any git source
-  # at the same version (or lower) than one available from rubygems as
+  # We have a task called update_stable_channel_gems which scans and pins to the
+  # latest released chef/chef-config/opscode-pushy-client but it pulls from the
+  # chef repo instead of from rubygems. Bundler currently considers any git
+  # source at the same version (or lower) than one available from rubygems as
   # outdated and hence fails the outdated gem test, confusing Julia bot.
-  #
-  # Therefore..  turn checks on both of them off. If and when the rake
-  # task for update_current_chef changes, this exclusion can be revisited.
+  
+  # Therefore..  turn checks on both of them off. If and when the rake task for
+  # update_stable_channel_gems changes, this exclusion can be revisited.
   "chef",
   "chef-config",
+  "opscode-pushy-client",
 ]
 
 #


### PR DESCRIPTION
To bring how we handle this dependency in line with other dependencies in the ChefDK

\cc @randomcamel @mwrock @PrajaktaPurohit 