### PR TITLE
Adding release notes about the lack of Delivery CLI in 0.14 Windows packages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,9 +4,9 @@
 
 We're adding some additional tools to the ChefDK to make it easier for cookbook developers using Delivery. The tools are:
 
-* Delivery CLI
+* [Delivery CLI](https://github.com/chef/delivery-cli)
 * Git
-* Push Jobs client
+* [Push Jobs client](https://github.com/chef/opscode-pushy-client)
 * The following gems:
   * [Chef Sugar](https://github.com/sethvargo/chef-sugar)
   * [Knife Supermarket](https://github.com/chef/knife-supermarket)
@@ -18,6 +18,11 @@ bundled `git` executable on the path automatically. However, Windows
 users commonly request that we include `git`. If you wish to use the
 `git` executable bundled with ChefDK, launch ChefDK via the desktop icon
 on Windows or run `chef shell-init` on other platforms.
+
+There is one exception to the above list: the Delivery CLI is included
+in the OSX and Linux releases of ChefDK but not the Windows releases.
+Later releases of the ChefDK will include Delivery-CLI on all supported
+platforms.
 
 ## `cookstyle` added to ChefDK
 
@@ -42,4 +47,3 @@ If you have any suggestions for changes to the default ruleset in
 `cookstyle`, please [create a pull request](https://github.com/chef/cookstyle).
 
 For more information about `cookstyle`, [see the README on github](https://github.com/chef/cookstyle).
-


### PR DESCRIPTION
\cc @btm @mwrock @PrajaktaPurohit @randomcamel 