### PR TITLE
Adding the Git for Windows tools to the path if they are present

### DIFF
--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -89,4 +89,23 @@ describe ChefDK::Helpers do
     end
 
   end
+
+  describe "omnibus_env" do
+    let(:git_partial_path) { File.join("embedded", "git", "usr", "bin") }
+    before do
+      allow(helpers).to receive(:omnibus_expand_path) {|*paths| File.expand_path(File.join(paths)) }
+      allow(Dir).to receive(:exists?).with(/#{git_partial_path}/).and_return false
+    end
+
+    it "does not include the git tools in the path" do
+      expect(helpers.omnibus_env['PATH']).to_not match(/#{git_partial_path}/)
+    end
+
+    context "when the git tools directory exists" do
+      it "includes them in the path" do
+        expect(Dir).to receive(:exists?).with(/#{git_partial_path}/).and_return true
+        expect(helpers.omnibus_env['PATH']).to match(/#{git_partial_path}/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This includes helpful unix tools like ssh, scp, etc. Once a Windows users has ran our custom desktop shortcut or `chef shell-init powershell` then they will have access to these tools. I put it at the end of the path because some of these tools are already bundled into the ChefDK.

@tpetchel @randomcamel @btm @schisamo @ksubrama @PrajaktaPurohit 