### PR TITLE
Update naming of Windows instance to include `*-i386`

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -60,7 +60,9 @@ platforms:
   - name: macosx-10.11
     driver:
       box: chef/macosx-10.11 # private
-  - name: windows-2012r2-standard
+  # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
+  # will load the 32-bit version of the MinGW toolchain.
+  - name: windows-2012r2-standard-i386
     driver:
       box: chef/windows-server-2012r2-standard # private
       synced_folders:

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -108,7 +108,7 @@ Please note the mounted code directory is also at `C:\home\vagrant\chef-dk\omnib
 as opposed to `C:\Users\vagrant\chef-dk\omnibus`.
 
 ```shell
-$ bundle exec kitchen login chefdk-windows-81-professional
+$ bundle exec kitchen login chefdk-windows-2012r2-standard-i386
 Last login: Sat Sep 13 10:19:04 2014 from 172.16.27.1
 Microsoft Windows [Version 6.3.9600]
 (c) 2013 Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
This ensures the Omnibus build is executed in 32-bit mode which matches how we currently build ChefDK in our pipeline.

/cc @tyler-ball @ksubrama

Now that we released the updated omnibus cookbook to supermarket.chef.io this is the only change we need to ensure people are executing local/dev Omnibus builds in 32-bit mode on Windows.