### PR TITLE
Generated .kitchen.yml defaults Inspec to doc format output

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -9,6 +9,7 @@ provisioner:
 # default verifier)
 # verifier:
 #   name: inspec
+#   format: doc
 
 platforms:
   - name: ubuntu-14.04

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -22,6 +22,7 @@ provisioner:
 # default verifier)
 # verifier:
 #   name: inspec
+#   format: doc
 
 platforms:
   - name: ubuntu-14.04

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -280,6 +280,7 @@ provisioner:
 # default verifier)
 # verifier:
 #   name: inspec
+#   format: doc
 
 platforms:
   - name: ubuntu-14.04
@@ -350,6 +351,7 @@ provisioner:
 # default verifier)
 # verifier:
 #   name: inspec
+#   format: doc
 
 platforms:
   - name: ubuntu-14.04


### PR DESCRIPTION
By default, Inspec returns output in rspec's terse progress format. This PR updates the cookbook generator so that the commented Inspec verifier block now defaults instead to rspec's more verbose documentation format.

This will provide the informative test output that people are used to seeing from Serverspec.
