### PR TITLE
Removing the duplicated pushy Windows dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,18 +93,3 @@ end
 group(:linux, :bsd, :mac_os_x, :solaris) do
   gem "ruby-shadow", platform: :ruby
 end
-
-# TODO delete this when we figure out how to include the pushy windows dependencies
-# correctly
-platforms :mswin, :mingw do
-  gem "ffi"
-  gem "rdp-ruby-wmi"
-  gem "windows-api"
-  gem "windows-pr"
-  gem "win32-api"
-  gem "win32-dir"
-  gem "win32-event"
-  gem "win32-mutex"
-  gem "win32-process", "~> 0.8.2"
-  gem "win32-service"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     cleanroom (1.0.0)
     coderay (1.1.1)
     colorize (0.7.7)
-    compat_resource (12.10.1)
+    compat_resource (12.10.2)
     cookbook-omnifetch (0.2.2)
       minitar (~> 0.5.4)
     cookstyle (0.0.1)
@@ -202,6 +202,7 @@ GEM
     fauxhai (3.4.0)
       net-ssh
     ffi (1.9.10)
+    ffi (1.9.10-x86-mingw32)
     ffi-rzmq (2.0.4)
       ffi-rzmq-core (>= 1.0.1)
     ffi-rzmq-core (1.0.5)
@@ -394,6 +395,7 @@ GEM
     hashie (3.4.4)
     highline (1.7.8)
     hitimes (1.2.4)
+    hitimes (1.2.4-x86-mingw32)
     httpclient (2.7.2)
     i18n (0.7.0)
     inflecto (0.0.2)
@@ -469,6 +471,9 @@ GEM
       mixlib-versioning
     mixlib-log (1.6.0)
     mixlib-shellout (2.2.6)
+    mixlib-shellout (2.2.6-universal-mingw32)
+      win32-process (~> 0.8.2)
+      wmi-lite (~> 1.0)
     mixlib-versioning (1.1.0)
     molinillo (0.4.5)
     multi_json (1.12.1)
@@ -488,6 +493,8 @@ GEM
     net-telnet (0.1.1)
     nio4r (1.2.1)
     nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.7.2-x86-mingw32)
       mini_portile2 (~> 2.0.0.rc2)
     nori (2.6.0)
     notiffany (0.1.0)
@@ -603,6 +610,7 @@ GEM
     ruby-prof (0.15.9)
     ruby-progressbar (1.8.1)
     ruby-shadow (2.5.0)
+    ruby_dep (1.3.1)
     rubyntlm (0.6.0)
     rubyzip (1.2.0)
     rufus-lru (1.1.0)
@@ -664,6 +672,8 @@ GEM
     varia_model (0.4.1)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 4.0.0)
+    win32-process (0.8.3)
+      ffi (>= 1.0.0)
     winrm (1.8.1)
       builder (>= 2.1.2)
       gssapi (~> 1.2)
@@ -687,6 +697,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   appbundler!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -603,7 +603,6 @@ GEM
     ruby-prof (0.15.9)
     ruby-progressbar (1.8.1)
     ruby-shadow (2.5.0)
-    ruby_dep (1.3.1)
     rubyntlm (0.6.0)
     rubyzip (1.2.0)
     rufus-lru (1.1.0)
@@ -708,7 +707,6 @@ DEPENDENCIES
   dep-selector-libgecode
   dep_selector
   fauxhai
-  ffi
   ffi-rzmq-core
   foodcritic (>= 6.1.1)
   github_changelog_generator
@@ -734,7 +732,6 @@ DEPENDENCIES
   rake
   rb-readline
   rdoc
-  rdp-ruby-wmi
   rspec-core (~> 3.0)
   rspec-expectations (~> 3.0)
   rspec-mocks (~> 3.0)
@@ -742,17 +739,9 @@ DEPENDENCIES
   ruby-prof
   ruby-shadow
   test-kitchen
-  win32-api
-  win32-dir
-  win32-event
-  win32-mutex
-  win32-process (~> 0.8.2)
-  win32-service
-  windows-api
-  windows-pr
   winrm-elevated
   winrm-fs
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.12.4


### PR DESCRIPTION
We don't actually need to duplicate these.  See https://github.com/chef/opscode-pushy-client/pull/91#issuecomment-220693642 for more detail.

\cc @ksubrama @mwrock @PrajaktaPurohit 