### PR TITLE
Re-enable and fix acceptance test

### DIFF
--- a/acceptance/Gemfile.lock
+++ b/acceptance/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/chef/chef-acceptance.git
-  revision: 4abda84e2fadd0452b77a8a88d4fd534843ced55
+  revision: 47e931cec100dce8efae4369a5b03443eaf2b733
   specs:
     chef-acceptance (0.2.0)
       mixlib-shellout (~> 2.0)

--- a/ci/verify-chefdk.sh
+++ b/ci/verify-chefdk.sh
@@ -33,15 +33,19 @@ if [ "x$ACCEPTANCE" != "x" ]; then
   for GEM_NAME in chef chef-dk
   do
 
+    # copy acceptance suites into workspace
+    SUITE_PATH=$WORKSPACE/acceptance-$GEM_NAME
+    mkdir -p $SUITE_PATH
+    cp -R /opt/chefdk/embedded/lib/ruby/gems/*/gems/$GEM_NAME-[0-9]*/acceptance/. $SUITE_PATH
+    sudo chown -R $USER:$USER $SUITE_PATH
+
+    cd $SUITE_PATH
+
     case "$GEM_NAME" in
      chef) SUITE_NAMES="top-cookbooks" ;;
         *) SUITE_NAMES="" ;;
     esac
 
-    # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
-    # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
-    # saves us from having to add a `sudo` to any of the `bundle` commands.
-    env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile /opt/chefdk/embedded/lib/ruby/gems/*/gems/$GEM_NAME-[0-9]*/acceptance/Gemfile
     env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
     env KITCHEN_CHEF_PRODUCT=chefdk KITCHEN_CHEF_WIN_ARCHITECTURE=i386 PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test $SUITE_NAMES --force-destroy --data-path $WORKSPACE/chef-acceptance-data/$GEM_NAME
   done

--- a/ci/verify-chefdk.sh
+++ b/ci/verify-chefdk.sh
@@ -26,27 +26,25 @@ done
 # ACCEPTANCE environment variable will be set on acceptance testers.
 # If is it set; we run the acceptance tests, otherwise run rspec tests.
 if [ "x$ACCEPTANCE" != "x" ]; then
-  # export PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:$PATH
+  export PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:$PATH
 
-  # set -e
+  set -e
 
-  # for GEM_NAME in chef chef-dk
-  # do
+  for GEM_NAME in chef chef-dk
+  do
 
-  #   case "$GEM_NAME" in
-  #    chef) SUITE_NAMES="top-cookbooks" ;;
-  #       *) SUITE_NAMES="" ;;
-  #   esac
+    case "$GEM_NAME" in
+     chef) SUITE_NAMES="top-cookbooks" ;;
+        *) SUITE_NAMES="" ;;
+    esac
 
-  #   # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
-  #   # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
-  #   # saves us from having to add a `sudo` to any of the `bundle` commands.
-  #   env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile /opt/chefdk/embedded/lib/ruby/gems/*/gems/$GEM_NAME-[0-9]*/acceptance/Gemfile
-  #   env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
-  #   env KITCHEN_CHEF_PRODUCT=chefdk KITCHEN_CHEF_WIN_ARCHITECTURE=i386 PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test $SUITE_NAMES --force-destroy --data-path $WORKSPACE/chef-acceptance-data/$GEM_NAME
-  # done
-
-  exit 0
+    # Force `$WORKSPACE/.bundle/config` to be created so bundler doesn't
+    # attempt to create the file up in the `$CHEF_GEM/acceptance/`. This
+    # saves us from having to add a `sudo` to any of the `bundle` commands.
+    env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle config --local gemfile /opt/chefdk/embedded/lib/ruby/gems/*/gems/$GEM_NAME-[0-9]*/acceptance/Gemfile
+    env PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID bundle install --deployment
+    env KITCHEN_CHEF_PRODUCT=chefdk KITCHEN_CHEF_WIN_ARCHITECTURE=i386 PATH=$PATH AWS_SSH_KEY_ID=$AWS_SSH_KEY_ID KITCHEN_DRIVER=ec2 KITCHEN_CHEF_CHANNEL=unstable bundle exec chef-acceptance test $SUITE_NAMES --force-destroy --data-path $WORKSPACE/chef-acceptance-data/$GEM_NAME
+  done
 else
   export PATH=/opt/chefdk/bin:$PATH
 


### PR DESCRIPTION
All chef-acceptance logs and generated data is now properly archived with the job:
http://manhattan.ci.chef.co/job/chef-test/6/architecture=x86_64,platform=acceptance,project=chef,role=tester/artifact/chef-acceptance-data/

These changes were tested in the following ad hoc build:
http://manhattan.ci.chef.co/job/chefdk-test/183/architecture=x86_64,platform=acceptance,project=chefdk,role=tester/console

/cc @chef/engineering-services @adamedx @btm @mwrock @PrajaktaPurohit @ksubrama 