### PR TITLE
Remove duplicate components from $PATH

### DIFF
--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -166,7 +166,7 @@ HELP
         # /dev/null to avoid Fish's helpful warnings about nonexistent
         # PATH elements.
         if var == 'PATH'
-          emit_shell_cmd(%Q(set -gx #{var} "#{val.split(':').join('" "')}" 2>/dev/null;))
+          emit_shell_cmd(%Q(set -gx #{var} "#{val.split(File::PATH_SEPARATOR).join('" "')}" 2>/dev/null;))
         else
           emit_shell_cmd(%Q(set -gx #{var} "#{val}";))
         end

--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -111,10 +111,10 @@ module ChefDK
       @omnibus_env ||=
         begin
           user_bin_dir = File.expand_path(File.join(Gem.user_dir, 'bin'))
-          path = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH'] ]
-          path << git_windows_bin_dir if Dir.exists?(git_windows_bin_dir)
+          paths = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir ] + ENV['PATH'].split(File::PATH_SEPARATOR)
+          paths << git_windows_bin_dir if Dir.exists?(git_windows_bin_dir)
           {
-            'PATH' => path.join(File::PATH_SEPARATOR),
+            'PATH' => paths.uniq.join(File::PATH_SEPARATOR),
             'GEM_ROOT' => Gem.default_dir,
             'GEM_HOME' => Gem.user_dir,
             'GEM_PATH' => Gem.path.join(File::PATH_SEPARATOR),

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -20,7 +20,10 @@ require 'chef-dk/command/shell_init'
 
 describe ChefDK::Command::ShellInit do
 
-  let(:expected_path) { [omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH']].join(File::PATH_SEPARATOR) }
+  let(:expected_path) do
+    paths = [omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir] + ENV['PATH'].split(File::PATH_SEPARATOR)
+    paths.uniq.join(File::PATH_SEPARATOR)
+  end
   let(:stdout_io) { StringIO.new }
   let(:stderr_io) { StringIO.new }
 
@@ -231,10 +234,10 @@ compdef _chef chef
   end
 
   context 'for fish' do
-    before do
-      stub_const('File::PATH_SEPARATOR', ':')
+    let(:expected_path) do
+      paths = [omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir] + ENV['PATH'].split(File::PATH_SEPARATOR)
+      paths.uniq.join('" "')
     end
-    let(:expected_path) { [omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH']].join(':').split(':').join('" "') }
     let(:expected_environment_commands) do
       <<-EOH
 set -gx PATH "#{expected_path}" 2>/dev/null;


### PR DESCRIPTION
This is to make sure we do not add duplicate components into $PATH, components of ChefDK will be kept in front of other components.  Without this, my $PATH will get ridiculous long after opened several tmux panes or windows (see below) or nested shell.  I understand I can fix on my end but why not make it better for all users.

![image](https://cloud.githubusercontent.com/assets/1407119/15380615/84ef1ae4-1daa-11e6-8bcf-85b832150437.png)