### PR TITLE
`chef --version` should print the Delivery CLI version

### DIFF
--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -97,12 +97,12 @@ BANNER
     def show_version
       msg("Chef Development Kit Version: #{ChefDK::VERSION}")
 
-      ["chef-client", "berks", "kitchen"].each do |component|
+      ["chef-client", "delivery", "berks", "kitchen"].each do |component|
         result = Bundler.with_clean_env { shell_out("#{component} --version") }
         if result.exitstatus != 0
           msg("#{component} version: ERROR")
         else
-          version = result.stdout.scan(/[\d+\.]+\S+/).join
+          version = result.stdout.scan(/(?:master\s)?[\d+\.\(\)]+\S+/).join("\s")
           msg("#{component} version: #{version}")
         end
       end


### PR DESCRIPTION
The change properly handles the two different version string formats a `delivery --version` command can return:

```
$ delivery --version
delivery master (454c3f37819ed508a49c971f38e42267ce8a47de)

$ delivery --version
delivery 0.0.15 (454c3f37819ed508a49c971f38e42267ce8a47de)
```

The updated ChefDK version output looks like:

```
$ chef --version
Chef Development Kit Version: 0.14.25
chef-client version: 12.10.24
delivery version: master (454c3f37819ed508a49c971f38e42267ce8a47de)
berks version: 4.3.3
kitchen version: 1.8.0
```

/cc @charlesjohnson @tyler-ball @ksubrama 