### PR TITLE
clean up leftover test cruft

### DIFF
--- a/ci/verify-chefdk.sh
+++ b/ci/verify-chefdk.sh
@@ -2,6 +2,9 @@
 
 set -evx
 
+# Cleanning up some cruft from previous tests
+sudo find /tmp -name 'chef-dk*' | sudo xargs rm -rf
+
 # Set up a custom tmpdir, and clean it up before and after the tests
 TMPDIR="${TMPDIR:-/tmp}/cheftest"
 export TMPDIR


### PR DESCRIPTION
I'm piping from find because there were so many items.

I have run this through an ad hoc build which has wiped the cruft off all existing testers.