### PR TITLE
fix bundle tasks on windows

### DIFF
--- a/tasks/bundle_util.rb
+++ b/tasks/bundle_util.rb
@@ -43,6 +43,7 @@ module BundleUtil
     cwd = File.expand_path(cwd || ".", project_root)
     Bundler.with_clean_env do
       Dir.chdir(cwd) do
+        default_platforms = platforms.join(" ") + " ruby"
         gemfile ||= "Gemfile"
         gemfile = File.expand_path(gemfile, cwd)
         raise "No platform #{platform} (supported: #{PLATFORMS.keys.join(", ")})" if platform && !PLATFORMS[platform]
@@ -52,11 +53,13 @@ module BundleUtil
           if File.exist?("#{gemfile}.lock")
             puts "Deleting #{gemfile}.lock ..."
             File.delete("#{gemfile}.lock")
+            default_platforms = "ruby"
           end
         end
 
         # Run the bundle command
-        ruby_platforms = platform ? PLATFORMS[platform].join(" ") : "ruby"
+        default_platforms = File.exist?("#{gemfile}.lock") ? Gem.platforms.join(" ") : "ruby"
+        ruby_platforms = platform ? PLATFORMS[platform].join(" ") : default_platforms
         cmd = Shellwords.join([Gem.ruby, "-S", bundle_platform, ruby_platforms, *args])
         puts "#{prefix}#{Shellwords.join(["bundle", *args])}#{platform ? " for #{platform} platform" : ""}:"
         with_gemfile(gemfile) do


### PR DESCRIPTION
I've been noticung that `rake bundle:install` and `rake bundle:update` have not been working on windows where I do my development. These usually result in:
```
Your Gemfile.lock is corrupt. The following gem is missing from the DEPENDENCIES
section: 'win32-api'
bundle config --local frozen 1:
BUNDLE_GEMFILE=C:/dev/chef-dk/Gemfile
> C:/opscode/chefdk/embedded/bin/ruby.exe -S C:/dev/chef-dk/tasks/bin/bundle-platform ruby config --local frozen 1
bundle-platform set Gem.platforms to ["ruby"] (was ["ruby", "x86-mingw32"])
You are replacing the current local value of frozen, which is currently nil
rake aborted!
C:/dev/chef-dk/tasks/bin/bundle-platform failed: exit code pid 42572 exit 20
```

This PR seems to fix the issue and I have confirmed that it produces a Gemfile.lock identical to one generated on a linux machine.