### PR TITLE
WIP - Add rubocop to /opt/chefdk/bin

### DIFF
--- a/omnibus/config/software/chef-dk-appbundle.rb
+++ b/omnibus/config/software/chef-dk-appbundle.rb
@@ -18,6 +18,7 @@ build do
   appbundle_gem "test-kitchen"
   appbundle_gem "opscode-pushy-client"
   appbundle_gem "cookstyle"
+  appbundle_gem "rubocop"
 
   # These are not appbundled, but need to have their Gemfiles locked down so that their tests will run
 


### PR DESCRIPTION
http://manhattan.ci.chef.co/job/chefdk-trigger-ad_hoc/314/downstreambuildview/

Fails with:
```
[Builder: chef-dk-appbundle] I | 2016-05-20T00:43:58+00:00 |   PKG_CONFIG_PATH="/opt/chefdk/embedded/lib/pkgconfig"
[Builder: chef-dk-appbundle] I | 2016-05-20T00:43:58+00:00 | $ /opt/chefdk/embedded/bin/bundle show rubocop
                          D | 2016-05-20T00:44:02+00:00 | /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rubocop-0.39.0
[Builder: chef-dk-appbundle] I | 2016-05-20T00:44:02+00:00 | Lock down the rubocop gem: 4.2931s
[Builder: chef-dk-appbundle] I | 2016-05-20T00:44:02+00:00 | Build chef-dk-appbundle: 325.0774s
/home/jenkins/workspace/chefdk-build/architecture/x86_64/platform/ubuntu-12.04/project/chefdk/role/builder/omnibus/files/chef-dk-appbundle/build-chef-dk-appbundle.rb:36:in `read': No such file or directory @ rb_sysopen - /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rubocop-0.39.0/Gemfile (Errno::ENOENT)
	from /home/jenkins/workspace/chefdk-build/architecture/x86_64/platform/ubuntu-12.04/project/chefdk/role/builder/omnibus/files/chef-dk-appbundle/build-chef-dk-appbundle.rb:36:in `block in lockdown_gem'
```
```
➜  chef-dk git:(praj/FLOW-369/include_rubocop) ls /Users/prajaktapurohit/.chefdk/gem/ruby/2.1.0/gems/rubocop-0.39.0/
LICENSE.txt  README.md    assets/      bin/         config/      lib/         spec/
```
To Do:
- [ ] Open a PR for rubocop to include gemfile and gemspec in its gem package