### PR TITLE
Removed call to write updated lockfile when pushing policy

### DIFF
--- a/lib/chef-dk/policyfile_services/push.rb
+++ b/lib/chef-dk/policyfile_services/push.rb
@@ -91,12 +91,6 @@ module ChefDK
         raise PolicyfilePushError.new("Failed to upload policy to policy group #{policy_group}", error)
       end
 
-      def write_updated_lockfile
-        with_file(policyfile_lock_expanded_path) do |f|
-          f.print(FFI_Yajl::Encoder.encode(policyfile_lock.to_lock, pretty: true ))
-        end
-      end
-
       def validate_lockfile
         return @policyfile_lock if @policyfile_lock
         @policyfile_lock = ChefDK::PolicyfileLock.new(storage_config).build_from_lock_data(policy_data)

--- a/lib/chef-dk/policyfile_services/push.rb
+++ b/lib/chef-dk/policyfile_services/push.rb
@@ -75,7 +75,6 @@ module ChefDK
         end
 
         validate_lockfile
-        write_updated_lockfile
         upload_policy
 
       end
@@ -111,4 +110,3 @@ module ChefDK
     end
   end
 end
-

--- a/spec/unit/policyfile_services/push_spec.rb
+++ b/spec/unit/policyfile_services/push_spec.rb
@@ -184,9 +184,9 @@ E
           push_service.uploader
         end
 
-        it "validates the lockfile, writes any updates, and uploads the cookbooks" do
+        it "validates the lockfile and uploads the cookbooks" do
           allow(File).to receive(:open).and_call_original
-          expect(File).to receive(:open).with(policyfile_lock_path, "wb+").and_yield(updated_lockfile_io)
+          expect(File).not_to receive(:open).with(policyfile_lock_path, "wb+")
           expect(uploader).to receive(:upload)
 
           push_service.run
@@ -202,9 +202,9 @@ E
           push_service.uploader
         end
 
-        it "validates the lockfile, writes any updates, and uploads the cookbooks" do
+        it "validates the lockfile and uploads the cookbooks" do
           allow(File).to receive(:open).and_call_original
-          expect(File).to receive(:open).with(policyfile_lock_path, "wb+").and_yield(updated_lockfile_io)
+          expect(File).not_to receive(:open).with(policyfile_lock_path, "wb+")
           expect(uploader).to receive(:upload)
 
           push_service.run
@@ -216,7 +216,7 @@ E
 
         before do
           allow(File).to receive(:open).and_call_original
-          expect(File).to receive(:open).with(policyfile_lock_path, "wb+").and_yield(updated_lockfile_io)
+          expect(File).not_to receive(:open).with(policyfile_lock_path, "wb+")
           expect(uploader).to receive(:upload).and_raise("an error")
         end
 


### PR DESCRIPTION
I wanted to try and fix #831 with this Pull Request. After the change, all RSpec tests passed. I also tested that this works by adding my fork as a dependency in the Gemfile of my cookbook. I was still able to run `chef install` and `chef update` successfully. I was also able to run `chef push` without it generating a new lock file so that multiple policy groups end up having the same policy revision.