### PR TITLE
Install fewer gems when bumping chef-dk.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,12 @@ gem "chef-dk", path: "."
 
 group(:omnibus_package, :development, :test) do
   gem "pry"
+  gem "rake"
+  gem "rdoc"
+  gem "yard"
+  gem "dep_selector"
+  gem "guard"
+  gem "ruby-prof"
 end
 
 # All software we recognize needs to stay at the latest possible version. But
@@ -84,14 +90,6 @@ group(:omnibus_package) do
   gem "cookstyle"
   gem "winrm-fs"
   gem "winrm-elevated"
-
-  # bundled or development dependencies we want to ship
-  gem "dep_selector"
-  gem "guard"
-  gem "ruby-prof"
-  gem "rake"
-  gem "rdoc"
-  gem "yard"
 end
 
 # Everything except AIX and Windows

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -57,6 +57,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "chef-provisioning", "~> 1.2"
 
   gem.add_development_dependency "github_changelog_generator"
+  gem.add_development_dependency "rake"
 
   %w(rspec-core rspec-expectations rspec-mocks).each do |dev_gem|
     gem.add_development_dependency dev_gem, "~> 3.0"

--- a/ci/bundle_install.sh
+++ b/ci/bundle_install.sh
@@ -4,5 +4,6 @@ set -evx
 
 gem environment
 bundler_version=$(grep bundler omnibus_overrides.rb | cut -d'"' -f2)
-gem install bundler -v $bundler_version --user-install
+gem install bundler -v $bundler_version --user-install --conservative
+export BUNDLE_WITHOUT=omnibus_package:test:aix:bsd:linux:mac_os_x:solaris:windows:default
 bundle _${bundler_version}_ install


### PR DESCRIPTION
Removes dependencies on many native gems (reliability)
Doesn't install bundle unless it has to (speed)