### PR TITLE
Build Delivery CLI on Windows using msys2 build toolchain

### DIFF
--- a/ci/verify-chefdk.bat
+++ b/ci/verify-chefdk.bat
@@ -10,5 +10,12 @@ SET TMP=%TMP%\cheftest
 RMDIR /S /Q %TEMP%
 MKDIR %TEMP%
 
+REM ; Ensure the calling environment (disapproval look Bundler) does not
+REM ; infect our Ruby environment created by the `chef` cli.
+FOR %%E IN (_ORIGINAL_GEM_PATH, BUNDLE_BIN_PATH, BUNDLE_GEMFILE, GEM_HOME, GEM_PATH, GEM_ROOT, RUBYLIB, RUBYOPT, RUBY_ENGINE, RUBY_ROOT, RUBY_VERSION) DO SET %%E=
+
+REM ; Ensure the msys2 build dlls are not on the path
+SET PATH=C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\opscode\chefdk\bin
+
 REM ; Run this last so the correct exit code is propagated
 chef verify

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -451,16 +451,14 @@ end
         end
       end
 
-      unless Chef::Platform.windows?
-        add_component "delivery-cli" do |c|
-          # We'll want to come back and revisit getting unit tests added -
-          # currently running the tests depends on cargo , which is not included
-          # in our package.
-          c.base_dir = "bin"
-          c.smoke_test do
-            tmpdir do |cwd|
-              sh!("delivery setup --user=shipit --server=delivery.shipit.io --ent=chef --org=squirrels", cwd: cwd)
-            end
+      add_component "delivery-cli" do |c|
+        # We'll want to come back and revisit getting unit tests added -
+        # currently running the tests depends on cargo , which is not included
+        # in our package.
+        c.base_dir = "bin"
+        c.smoke_test do
+          tmpdir do |cwd|
+            sh!("delivery setup --user=shipit --server=delivery.shipit.io --ent=chef --org=squirrels", cwd: cwd)
           end
         end
       end

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -21,6 +21,11 @@ provisioner:
   attributes:
     vagrant:
       this_key_exists_so_we_have_a_vagrant_key: true
+    omnibus:
+      build_user:          vagrant
+      build_user_group:    vagrant
+      build_user_password: vagrant
+      install_dir: /opt/chefdk
 
 platforms:
   - name: centos-6.7
@@ -63,6 +68,13 @@ platforms:
   # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
   # will load the 32-bit version of the MinGW toolchain.
   - name: windows-2012r2-standard-i386
+    provisioner:
+      attributes:
+        omnibus:
+          build_user:          vagrant
+          build_user_group:    Administrators
+          build_user_password: vagrant
+          install_dir: /opscode/chefdk
     driver:
       box: chef/windows-server-2012r2-standard # private
       synced_folders:
@@ -72,16 +84,7 @@ platforms:
       # at `C:\vagrant\code\chef-dk`
       - ['../..', '/vagrant/code']
 
-attribute_defaults: &attribute_defaults
-  build_user:          vagrant
-  build_user_group:    vagrant
-  build_user_password: vagrant
-
 suites:
   - name: chefdk
-    attributes:
-      omnibus:
-        <<: *attribute_defaults
-        install_dir: /opt/chefdk
     run_list:
       - omnibus::default

--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -2,9 +2,6 @@ source 'https://supermarket.chef.io'
 
 cookbook 'omnibus'
 
-# Uncomment to use the latest version of the Omnibus cookbook from GitHub
-# cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'
-
 group :integration do
   cookbook 'apt',      '~> 2.3'
   cookbook 'freebsd',  '~> 0.1'

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 2f04eff7dbec575cb2985d846dacd02a422cd36f
+  revision: e09de191b0d95acdf7d1d4ee74ab55f7b6847131
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: a36e70caedceadfcf0d85e2adef44ba0218a60a6
+  revision: 2a597277f1a5e13901d116ef852611fe88f6b76b
   specs:
     omnibus (5.4.0)
       aws-sdk (~> 2)
@@ -37,13 +37,13 @@ GEM
   specs:
     addressable (2.4.0)
     artifactory (2.3.2)
-    awesome_print (1.6.1)
-    aws-sdk (2.3.9)
-      aws-sdk-resources (= 2.3.9)
-    aws-sdk-core (2.3.9)
+    awesome_print (1.7.0)
+    aws-sdk (2.3.12)
+      aws-sdk-resources (= 2.3.12)
+    aws-sdk-core (2.3.12)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.9)
-      aws-sdk-core (= 2.3.9)
+    aws-sdk-resources (2.3.12)
+      aws-sdk-core (= 2.3.12)
     berkshelf (4.3.3)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -79,13 +79,12 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.10.24)
+    chef-config (12.11.18)
       fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-sugar (3.3.0)
     cleanroom (1.0.0)
-    diff-lcs (1.2.5)
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -116,11 +115,8 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     minitar (0.5.4)
-    mixlib-authentication (1.4.0)
+    mixlib-authentication (1.4.1)
       mixlib-log
-      rspec-core (~> 3.2)
-      rspec-expectations (~> 3.2)
-      rspec-mocks (~> 3.2)
     mixlib-cli (1.6.0)
     mixlib-config (2.2.1)
     mixlib-install (1.0.12)
@@ -176,15 +172,6 @@ GEM
       retryable (~> 2.0)
       semverse (~> 1.1)
       varia_model (~> 0.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
     ruby-progressbar (1.8.1)
     rubyntlm (0.6.0)
     rubyzip (1.2.0)
@@ -197,7 +184,7 @@ GEM
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
     systemu (2.6.5)
-    test-kitchen (1.9.0)
+    test-kitchen (1.9.1)
       mixlib-install (~> 1.0, >= 1.0.4)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)

--- a/omnibus/config/software/chef-dk-complete.rb
+++ b/omnibus/config/software/chef-dk-complete.rb
@@ -2,12 +2,10 @@ name "chef-dk-complete"
 
 license :project_license
 
-unless windows?
-  # For the Delivery build nodes
-  dependency "delivery-cli"
-  # This is a build-time dependency, so we won't leave it behind:
-  dependency "rust-uninstall"
-end
+# For the Delivery build nodes
+dependency "delivery-cli"
+# This is a build-time dependency, so we won't leave it behind:
+dependency "rust-uninstall"
 
 # Leave for last so system git is used for most of the build.
 if windows?

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -56,6 +56,7 @@ describe ChefDK::Command::Verify do
       "knife-supermarket",
       "opscode-pushy-client",
       "git",
+      "delivery-cli",
     ]
   end
 
@@ -65,9 +66,6 @@ describe ChefDK::Command::Verify do
 
   it "defines berks, tk, chef and chef-dk components by default" do
     expected_components = default_components
-    unless Chef::Platform.windows?
-      expected_components << "delivery-cli"
-    end
     expect(command_instance.components).not_to be_empty
     expect(command_instance.components.map(&:name)).to match_array(expected_components)
   end


### PR DESCRIPTION
\cc @danielsdeleo @tylercloke @mwrock @ksubrama 

- [x] Run `rake dependencies:update_omnibus_gemfile_lock` after https://github.com/chef/omnibus-software/pull/680 is merged