### PR TITLE
Generate delivery config

### DIFF
--- a/lib/chef-dk/command/generate.rb
+++ b/lib/chef-dk/command/generate.rb
@@ -29,6 +29,7 @@ require 'chef-dk/command/generator_commands/template'
 require 'chef-dk/command/generator_commands/repo'
 require 'chef-dk/command/generator_commands/policyfile'
 require 'chef-dk/command/generator_commands/generator_generator'
+require 'chef-dk/command/generator_commands/build_cookbook'
 
 module ChefDK
   module Command
@@ -54,6 +55,7 @@ module ChefDK
       generator(:repo, :Repo, "Generate a Chef code repository")
       generator(:policyfile, :Policyfile, "Generate a Policyfile for use with the install/push commands")
       generator(:generator, :GeneratorGenerator, "Copy ChefDK's generator cookbook so you can customize it")
+      generator(:'build-cookbook', :BuildCookbook, "Generate a build cookbook for use with Delivery")
 
       def self.banner_headline
         <<-E

--- a/lib/chef-dk/command/generator_commands/build_cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/build_cookbook.rb
@@ -1,0 +1,110 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef-dk/command/generator_commands/base'
+
+module ChefDK
+  module Command
+    module GeneratorCommands
+
+      class BuildCookbook < Base
+
+        banner "Usage: chef generate build-cookbook NAME [options]"
+
+        attr_reader :errors
+
+        attr_reader :cookbook_name_or_path
+
+        options.merge!(SharedGeneratorOptions.options)
+
+        def initialize(params)
+          @params_valid = true
+          @cookbook_name = nil
+          super
+        end
+
+        def run
+          read_and_validate_params
+          if params_valid?
+            setup_context
+            chef_runner.converge
+            0
+          else
+            err(opt_parser)
+            1
+          end
+        rescue ChefDK::ChefRunnerError => e
+          err("ERROR: #{e}")
+          1
+        end
+
+        def setup_context
+          super
+          Generator.add_attr_to_context(:delivery_project_dir, delivery_project_dir)
+
+          Generator.add_attr_to_context(:build_cookbook_parent_is_cookbook, build_cookbook_parent_is_cookbook?)
+        end
+
+        def recipe
+          "build_cookbook"
+        end
+
+        def build_cookbook_parent_is_cookbook?
+          metadata_json_path = File.join(delivery_project_dir, "metadata.json")
+          metadata_rb_path = File.join(delivery_project_dir, "metadata.rb")
+
+          File.exist?(metadata_json_path) || File.exist?(metadata_rb_path)
+        end
+
+        def delivery_project_dir
+          project_dir = File.expand_path(cookbook_name_or_path, Dir.pwd)
+          # Detect if we were invoked with arguments like
+          #
+          #     chef generate build-cookbook project/.delivery/build-cookbook
+          #
+          # If so, normalize paths so we don't make a directory structure like
+          # `.delivery/.delivery/build-cookbook`.
+          #
+          # Note that we don't check the name of the build cookbook the user
+          # asked for and we hard-code to naming it "build-cookbook". We also
+          # don't catch the case that the user requested something like
+          # `project/.delivery/build-cookbook/extra-thing-that-shouldn't-be-here`
+          Pathname.new(project_dir).ascend do |dir|
+            if File.basename(dir) == ".delivery"
+              project_dir = File.dirname(dir)
+            end
+          end
+          project_dir
+        end
+
+        def read_and_validate_params
+          arguments = parse_options(params)
+          @cookbook_name_or_path = arguments[0]
+          unless @cookbook_name_or_path
+            @params_valid = false
+          end
+        end
+
+        def params_valid?
+          @params_valid
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -94,6 +94,8 @@ module ChefDK
           Generator.add_attr_to_context(:policy_local_cookbook, ".")
 
           Generator.add_attr_to_context(:enable_delivery, enable_delivery?)
+          Generator.add_attr_to_context(:delivery_project_dir, cookbook_full_path)
+          Generator.add_attr_to_context(:build_cookbook_parent_is_cookbook, true)
 
           Generator.add_attr_to_context(:use_berkshelf, berks_mode?)
         end

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -49,12 +49,21 @@ module ChefDK
           boolean:      true,
           default:      nil
 
+        option :delivery,
+          short:        "-d",
+          long:         "--delivery",
+          description:  "Generate cookbook with delivery integration",
+          boolean:      true,
+          default:      nil
+
+
         options.merge!(SharedGeneratorOptions.options)
 
         def initialize(params)
           @params_valid = true
           @cookbook_name = nil
           @berks_mode = true
+          @enable_delivery = false
           super
         end
 
@@ -83,6 +92,8 @@ module ChefDK
           Generator.add_attr_to_context(:policy_name, policy_name)
           Generator.add_attr_to_context(:policy_run_list, policy_run_list)
           Generator.add_attr_to_context(:policy_local_cookbook, ".")
+
+          Generator.add_attr_to_context(:enable_delivery, enable_delivery?)
 
           Generator.add_attr_to_context(:use_berkshelf, berks_mode?)
         end
@@ -119,6 +130,10 @@ module ChefDK
           @berks_mode
         end
 
+        def enable_delivery?
+          @enable_delivery
+        end
+
         def read_and_validate_params
           arguments = parse_options(params)
           @cookbook_name_or_path = arguments[0]
@@ -133,6 +148,10 @@ module ChefDK
 
           if config[:policy]
             @berks_mode = false
+          end
+
+          if config[:delivery]
+            @enable_delivery = true
           end
         end
 

--- a/lib/chef-dk/skeletons/code_generator/files/default/build-cookbook/.kitchen.yml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build-cookbook/.kitchen.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: vagrant
+  synced_folders:
+    - [<%= File.join(ENV['PWD'], '..', '..')%>, '/tmp/repo-data']
+
+provisioner:
+  name: chef_zero
+  encrypted_data_bag_secret_key_path: 'secrets/fakey-mcfakerton'
+  data_bags_path: './data_bags'
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-7.1
+
+suites:
+  - name: default
+    run_list:
+      - recipe[delivery_build::default]
+      - recipe[test]
+    attributes:

--- a/lib/chef-dk/skeletons/code_generator/files/default/build-cookbook/README.md
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build-cookbook/README.md
@@ -1,0 +1,146 @@
+# build-cookbook
+
+A build cookbook for running the parent project through Chef Delivery
+
+This build cookbook should be customized to suit the needs of the parent project. Using this cookbook can be done outside of Chef Delivery, too. If the parent project is a Chef cookbook, we've detected that and "wrapped" [delivery-truck](https://github.com/chef-cookbooks/delivery-truck). That means it is a dependency, and each of its pipeline phase recipes is included in the appropriate phase recipes in this cookbook. If the parent project is not a cookbook, it's left as an exercise to the reader to customize the recipes as needed for each phase in the pipeline.
+
+## .delivery/config.json
+
+In the parent directory to this build-cookbook, the `config.json` can be modified as necessary. For example, phases can be skipped, publishing information can be added, and so on. Refer to customer support or the Chef Delivery documentation for assistance on what options are available for this configuration.
+
+## Test Kitchen - Local Verify Testing
+
+This cookbook also has a `.kitchen.yml` which can be used to create local build nodes with Test Kitchen to perform the verification phases, `unit`, `syntax`, and `lint`. When running `kitchen converge`, the instances will be set up like Chef Delivery "build nodes" with the [delivery_build cookbook](https://github.com/chef-cookbooks/delivery_build). The reason for this is to make sure that the same exact kind of nodes are used by this build cookbook are run on the local workstation as would run Delivery. It will run `delivery job verify PHASE` for the parent project.
+
+Modify the `.kitchen.yml` if necessary to change the platforms or other configuration to run the verify phases. After making changes in the parent project, `cd` into this directory (`.delivery/build-cookbook`), and run:
+
+```
+kitchen test
+```
+
+## Recipes
+
+Each of the recipes in this build-cookbook are run in the named phase during the Chef Delivery pipeline. The `unit`, `syntax`, and `lint` recipes are additionally run when using Test Kitchen for local testing as noted in the above section.
+
+## Making Changes - Cookbook Example
+
+When making changes in the parent project (that which lives in `../..` from this directory), or in the recipes in this build cookbook, there is a bespoke workflow for Chef Delivery. As an example, we'll discuss a Chef Cookbook as the parent.
+
+First, create a new branch for the changes.
+
+```
+git checkout -b testing-build-cookbook
+```
+
+Next, increment the version in the metadata.rb. This should be in the *parent*, not in this, the build-cookbook. If this is not done, the verify phase will fail.
+
+```
+% git diff
+<SNIP>
+-version '0.1.0'
++version '0.1.1'
+```
+
+The change we'll use for an example is to install the `zsh` package. Write a failing ChefSpec in the cookbook project's `spec/unit/recipes/default_spec.rb`.
+
+```ruby
+require 'spec_helper'
+
+describe 'godzilla::default' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'installs zsh' do
+      expect(chef_run).to install_package('zsh')
+    end
+  end
+end
+```
+
+Commit the local changes as work in progress. The `delivery job` expects to use a clean git repository.
+
+```
+git add ../..
+git commit -m 'WIP: Testing changes'
+```
+
+From *this* directory (`.delivery/build-cookbook`, relative to the parent cookbook project), run
+
+```
+cd .delivery/build-cookbook
+kitchen converge
+```
+
+This will take some time at first, because the VMs need to be created, Chef installed, the Delivery CLI installed, etc. Later runs will be faster until they are destroyed. It will also fail on the first VM, as expected, because we wrote the test first. Now edit the parent cookbook project's default recipe to install `zsh`.
+
+```
+cd ../../
+$EDITOR/recipes/default.rb
+```
+
+It should look like this:
+
+```
+package 'zsh'
+```
+
+Create another commit.
+
+```
+git add .
+git commit -m 'WIP: Install zsh in default recipe'
+```
+
+Now rerun kitchen from the build-cookbook.
+
+```
+cd .delivery/build-cookbook
+kitchen converge
+```
+
+This will take awhile because it will now pass on the first VM, and then create the second VM. We should have warned you this was a good time for a coffee break.
+
+```
+Recipe: test::default
+
+- execute HOME=/home/vagrant delivery job verify unit --server localhost --ent test --org kitchen
+  * execute[HOME=/home/vagrant delivery job verify lint --server localhost --ent test --org kitchen] action run
+    - execute HOME=/home/vagrant delivery job verify lint --server localhost --ent test --org kitchen
+
+    - execute HOME=/home/vagrant delivery job verify syntax --server localhost --ent test --org kitchen
+
+Running handlers:
+Running handlers complete
+Chef Client finished, 3/32 resources updated in 54.665445968 seconds
+Finished converging <default-centos-71> (1m26.83s).
+```
+
+Victory is ours! Our verify phase passed on the build nodes.
+
+We are ready to run this through our Delivery pipeline. Simply run `delivery review` on the local system from the parent project, and it will open a browser window up to the change we just added.
+
+```
+cd ../..
+delivery review
+```
+
+## FAQ
+
+### Why don't I just run rspec, foodcritic/rubocop, knife cookbook test on my local system?
+
+An objection to the Test Kitchen approach is that it is much faster to run the unit, lint, and syntax commands for the project on the local system. That is totally true, and also totally valid. Do that for the really fast feedback loop. However, the dance we do with Test Kitchen brings a much higher degree of confidence in the changes we're making, that everything will run on the build nodes in Chef Delivery. We strongly encourage this approach before actually pushing the changes to Delivery.
+
+### Why do I have to make a commit every time?
+
+When running `delivery job`, it expects to merge the commit for the changeset against the clean master branch. If we don't save our progress by making a commit, our local changes aren't run through `delivery job` in the Test Kitchen build instances. We can always perform an interactive rebase, and modify the original changeset message in Delivery with `delivery review --edit`. The latter won't modify the git commits, only the changeset in Delivery.
+
+### What do I do next?
+
+Make changes in the cookbook project as required for organizational goals and needs. Modify the `build-cookbook` as necessary for the pipeline phases that the cookbook should go through.
+
+### What if I get stuck?
+
+Contact Chef Support, or your Chef Customer Success team and they will help you get unstuck.

--- a/lib/chef-dk/skeletons/code_generator/files/default/build-cookbook/test-fixture-recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build-cookbook/test-fixture-recipe.rb
@@ -1,0 +1,7 @@
+%w(unit lint syntax).each do |phase|
+  # TODO: This works on Linux/Unix. Not Windows.
+  execute "HOME=/home/vagrant delivery job verify #{phase} --server localhost --ent test --org kitchen" do
+    cwd '/tmp/repo-data'
+    user 'vagrant'
+  end
+end

--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "build_cookbook": {
+    "name": "build-cookbook",
+    "path": ".delivery/build-cookbook"
+  },
+  "skip_phases": [],
+  "build_nodes": {},
+  "dependencies": []
+}

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -1,0 +1,10 @@
+
+context = ChefDK::Generator.context
+cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
+dot_delivery_dir = File.join(cookbook_dir, ".delivery")
+
+directory dot_delivery_dir
+
+cookbook_file File.join(dot_delivery_dir, "config.json") do
+  source "delivery-config.json"
+end

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -1,10 +1,88 @@
 
 context = ChefDK::Generator.context
-cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
-dot_delivery_dir = File.join(cookbook_dir, ".delivery")
+delivery_project_dir = context.delivery_project_dir
+dot_delivery_dir = File.join(delivery_project_dir, ".delivery")
 
 directory dot_delivery_dir
 
 cookbook_file File.join(dot_delivery_dir, "config.json") do
   source "delivery-config.json"
 end
+
+build_cookbook_dir = File.join(dot_delivery_dir, "build-cookbook")
+
+# cookbook root dir
+directory build_cookbook_dir
+
+# metadata.rb
+template "#{build_cookbook_dir}/metadata.rb" do
+  source "build-cookbook/metadata.rb.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
+# README
+cookbook_file "#{build_cookbook_dir}/README.md" do
+  source "build-cookbook/README.md"
+  action :create_if_missing
+end
+
+# LICENSE
+template "#{build_cookbook_dir}/LICENSE" do
+  source "LICENSE.#{context.license}.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
+# chefignore
+cookbook_file "#{build_cookbook_dir}/chefignore"
+
+# Berksfile
+template "#{build_cookbook_dir}/Berksfile" do
+  source "build-cookbook/Berksfile.erb"
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
+# Recipes
+directory "#{build_cookbook_dir}/recipes"
+
+%w(default deploy functional lint provision publish quality security smoke syntax unit).each do |phase|
+  template "#{build_cookbook_dir}/recipes/#{phase}.rb" do
+    source 'build-cookbook/recipe.rb.erb'
+    helpers(ChefDK::Generator::TemplateHelper)
+    variables phase: phase
+    action :create_if_missing
+  end
+end
+
+# Test Kitchen build node
+cookbook_file "#{build_cookbook_dir}/.kitchen.yml" do
+  source "build-cookbook/.kitchen.yml"
+end
+
+directory "#{build_cookbook_dir}/data_bags/keys" do
+  recursive true
+end
+
+file "#{build_cookbook_dir}/data_bags/keys/delivery_builder_keys.json" do
+  content '{"id": "delivery_builder_keys"}'
+end
+
+directory "#{build_cookbook_dir}/secrets"
+
+file "#{build_cookbook_dir}/secrets/fakey-mcfakerton"
+
+directory "#{build_cookbook_dir}/test/fixtures/cookbooks/test/recipes" do
+  recursive true
+end
+
+file "#{build_cookbook_dir}/test/fixtures/cookbooks/test/metadata.rb" do
+  content %(name 'test'
+version '0.1.0')
+end
+
+cookbook_file "#{build_cookbook_dir}/test/fixtures/cookbooks/test/recipes/default.rb" do
+  source "build-cookbook/test-fixture-recipe.rb"
+end
+

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -115,3 +115,9 @@ if context.have_git
     source "gitignore"
   end
 end
+
+if context.enable_delivery
+
+  include_recipe "code_generator::build_cookbook"
+
+end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/build-cookbook/Berksfile.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build-cookbook/Berksfile.erb
@@ -1,0 +1,20 @@
+source 'https://supermarket.chef.io'
+
+metadata
+<% if build_cookbook_parent_is_cookbook -%>
+
+cookbook 'delivery-truck',
+  git: 'https://github.com/chef-cookbooks/delivery-truck.git',
+  branch: 'master'
+
+# This is so we know where to get delivery-truck's dependency
+cookbook 'delivery-sugar',
+  git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
+  branch: 'master'
+<% end -%>
+
+group :delivery do
+  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
+  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
+  cookbook 'test', path: './test/fixtures/cookbooks/test'
+end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/build-cookbook/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build-cookbook/metadata.rb.erb
@@ -1,0 +1,9 @@
+name 'build-cookbook'
+maintainer '<%= copyright_holder %>'
+maintainer_email '<%= email %>'
+license '<%= license %>'
+version '0.1.0'
+<% if build_cookbook_parent_is_cookbook -%>
+
+depends 'delivery-truck'
+<% end -%>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/build-cookbook/recipe.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build-cookbook/recipe.rb.erb
@@ -1,0 +1,8 @@
+#
+# Cookbook Name:: build-cookbook
+# Recipe:: <%= @phase %>
+#
+<%= license_description('#') %>
+<% if build_cookbook_parent_is_cookbook -%>
+include_recipe 'delivery-truck::<%= @phase %>'
+<% end -%>

--- a/spec/unit/command/generator_commands/build_cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/build_cookbook_spec.rb
@@ -1,0 +1,309 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'shared/custom_generator_cookbook'
+require 'chef-dk/command/generator_commands/build_cookbook'
+
+describe ChefDK::Command::GeneratorCommands::BuildCookbook do
+
+  let(:argv) { %w[delivery_project] }
+
+  let(:stdout_io) { StringIO.new }
+  let(:stderr_io) { StringIO.new }
+
+  let(:expected_cookbook_file_relpaths) do
+    %w[
+      .kitchen.yml
+      data_bags
+      data_bags/keys
+      data_bags/keys/delivery_builder_keys.json
+      test
+      test/fixtures
+      test/fixtures/cookbooks
+      test/fixtures/cookbooks/test
+      test/fixtures/cookbooks/test/metadata.rb
+      test/fixtures/cookbooks/test/recipes
+      test/fixtures/cookbooks/test/recipes/default.rb
+      Berksfile
+      chefignore
+      metadata.rb
+      README.md
+      LICENSE
+      recipes
+      recipes/default.rb
+      recipes/deploy.rb
+      recipes/functional.rb
+      recipes/lint.rb
+      recipes/provision.rb
+      recipes/publish.rb
+      recipes/quality.rb
+      recipes/security.rb
+      recipes/smoke.rb
+      recipes/syntax.rb
+      recipes/unit.rb
+      secrets
+      secrets/fakey-mcfakerton
+    ]
+  end
+
+  let(:expected_cookbook_files) do
+    expected_cookbook_file_relpaths.map do |relpath|
+      File.join(tempdir, "delivery_project", ".delivery", "build-cookbook", relpath)
+    end
+  end
+
+  subject(:cookbook_generator) do
+    described_class.new(argv)
+  end
+
+  def generator_context
+    ChefDK::Generator.context
+  end
+
+  before do
+    ChefDK::Generator.reset
+  end
+
+  it "configures the chef runner" do
+    expect(cookbook_generator.chef_runner).to be_a(ChefDK::ChefRunner)
+    expect(cookbook_generator.chef_runner.cookbook_path).to eq(File.expand_path('lib/chef-dk/skeletons', project_root))
+  end
+
+  context "when given invalid/incomplete arguments" do
+
+    let(:expected_help_message) do
+      "Usage: chef generate build-cookbook NAME [options]\n"
+    end
+
+
+    def with_argv(argv)
+      generator = described_class.new(argv)
+      allow(generator).to receive(:stdout).and_return(stdout_io)
+      allow(generator).to receive(:stderr).and_return(stderr_io)
+      generator
+    end
+
+    it "prints usage when args are empty" do
+      with_argv([]).run
+      expect(stderr_io.string).to include(expected_help_message)
+    end
+
+  end
+
+  context "when given the name of the delivery project" do
+
+    let(:argv) { %w[delivery_project] }
+
+    let(:project_dir) { File.join(tempdir, "delivery_project") }
+
+    before do
+      reset_tempdir
+      Dir.mkdir(project_dir)
+    end
+
+    it "configures the generator context" do
+      cookbook_generator.read_and_validate_params
+      cookbook_generator.setup_context
+      expect(generator_context.delivery_project_dir).to eq(File.join(Dir.pwd, "delivery_project"))
+    end
+
+    it "creates a build cookbook" do
+      Dir.chdir(tempdir) do
+        allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+        cookbook_generator.run
+      end
+      generated_files = Dir.glob("#{tempdir}/delivery_project/**/*", File::FNM_DOTMATCH)
+      expected_cookbook_files.each do |expected_file|
+        expect(generated_files).to include(expected_file)
+      end
+    end
+
+    shared_examples_for "a generated file" do |context_var|
+      before do
+        Dir.chdir(tempdir) do
+          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+          cookbook_generator.run
+        end
+      end
+
+      it "should contain #{context_var} from the generator context" do
+        expect(File.read(file)).to include(line)
+      end
+    end
+
+    # This shared example group requires a let binding for
+    # `expected_kitchen_yml_content`
+    shared_examples_for "kitchen_yml_and_integration_tests" do
+
+      describe "Generating Test Kitchen and integration testing files" do
+
+        before do
+          Dir.chdir(tempdir) do
+            allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+            cookbook_generator.run
+          end
+        end
+
+        let(:file) { File.join(tempdir, "delivery_project", ".delivery", "build-cookbook", ".kitchen.yml") }
+
+        it "creates a .kitchen.yml with the expected content" do
+          expect(IO.read(file)).to eq(expected_kitchen_yml_content)
+        end
+
+      end
+    end
+
+    context "when the delivery project is a cookbook" do
+
+      let(:parent_metadata_rb) { File.join(tempdir, "delivery_project", "metadata.rb") }
+
+      before do
+        FileUtils.touch(parent_metadata_rb)
+      end
+
+      it "detects that the parent project is a cookbook" do
+        Dir.chdir(tempdir) do
+          cookbook_generator.read_and_validate_params
+          cookbook_generator.setup_context
+          expect(generator_context.build_cookbook_parent_is_cookbook).to eq(true)
+        end
+      end
+
+      describe "metadata.rb" do
+        let(:file) { File.join(tempdir, "delivery_project", ".delivery", "build-cookbook", "metadata.rb") }
+
+        include_examples "a generated file", :cookbook_name do
+          let(:line) do
+            <<-METADATA
+name 'build-cookbook'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+version '0.1.0'
+
+depends 'delivery-truck'
+METADATA
+          end
+        end
+      end
+
+      describe "delivery phase recipes" do
+
+        before do
+          Dir.chdir(tempdir) do
+            allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+            cookbook_generator.run
+          end
+        end
+
+        it "generates phase recipes which include the corresponding delivery truck recipe" do
+          %w[
+            deploy.rb
+            functional.rb
+            lint.rb
+            provision.rb
+            publish.rb
+            quality.rb
+            security.rb
+            smoke.rb
+            syntax.rb
+            unit.rb
+          ].each do |phase_recipe|
+            recipe_file = File.join(tempdir, "delivery_project", ".delivery", "build-cookbook", "recipes", phase_recipe)
+            phase = File.basename(phase_recipe, ".rb")
+            expected_content = %Q[include_recipe 'delivery-truck::#{phase}']
+            expect(IO.read(recipe_file)).to include(expected_content)
+          end
+        end
+
+      end
+
+    end
+
+    context "when the delivery project is not a cookbook" do
+
+      it "detects that the parent project is not a cookbook" do
+        cookbook_generator.read_and_validate_params
+        cookbook_generator.setup_context
+        expect(generator_context.build_cookbook_parent_is_cookbook).to eq(false)
+      end
+
+      describe "metadata.rb" do
+        let(:file) { File.join(tempdir, "delivery_project", ".delivery", "build-cookbook", "metadata.rb") }
+
+        include_examples "a generated file", :cookbook_name do
+          let(:line) do
+            <<-METADATA
+name 'build-cookbook'
+maintainer 'The Authors'
+maintainer_email 'you@example.com'
+license 'all_rights'
+version '0.1.0'
+METADATA
+          end
+        end
+      end
+
+      describe "delivery phase recipes" do
+
+        before do
+          Dir.chdir(tempdir) do
+            allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+            cookbook_generator.run
+          end
+        end
+
+        it "generates phase recipes that are empty" do
+          %w[
+            deploy.rb
+            functional.rb
+            lint.rb
+            provision.rb
+            publish.rb
+            quality.rb
+            security.rb
+            smoke.rb
+            syntax.rb
+            unit.rb
+          ].each do |phase_recipe|
+            recipe_file = File.join(tempdir, "delivery_project", ".delivery", "build-cookbook", "recipes", phase_recipe)
+            expect(IO.read(recipe_file)).to_not include("include_recipe")
+          end
+        end
+
+      end
+
+    end
+  end
+
+  context "when given a path including the .delivery directory" do
+    let(:argv) { [ File.join(tempdir, "delivery_project", ".delivery", "build-cookbook") ] }
+
+    before do
+      reset_tempdir
+    end
+
+    it "correctly sets the delivery project dir to the parent of the .delivery dir" do
+      cookbook_generator.read_and_validate_params
+      cookbook_generator.setup_context
+      expect(generator_context.delivery_project_dir).to eq(File.join(tempdir, "delivery_project"))
+    end
+
+  end
+
+end

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -380,6 +380,43 @@ SPEC_HELPER
 
     end
 
+    context "when configured for delivery" do
+
+      let(:argv) { %w[new_cookbook --delivery] }
+
+      describe ".delivery/config.json" do
+
+        let(:file) { File.join(tempdir, "new_cookbook", ".delivery", "config.json") }
+
+        let(:expected_content) do
+          <<-CONFIG_DOT_JSON
+{
+  "version": "2",
+  "build_cookbook": {
+    "name": "build-cookbook",
+    "path": ".delivery/build-cookbook"
+  },
+  "skip_phases": [],
+  "build_nodes": {},
+  "dependencies": []
+}
+CONFIG_DOT_JSON
+        end
+
+        before do
+          Dir.chdir(tempdir) do
+            allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+            cookbook_generator.run
+          end
+        end
+
+        it "configures delivery to use a local build cookbook" do
+          expect(IO.read(file)).to eq(expected_content)
+        end
+
+      end
+    end
+
     describe "metadata.rb" do
       let(:file) { File.join(tempdir, "new_cookbook", "metadata.rb") }
 


### PR DESCRIPTION
* Add new option `-d`/`--delivery` to `chef generate cookbook`, which will create a `.delivery/config.json` and build cookbook in the generated cookbook.
* Add new generator subcommand, `chef generate build-cookbook`, which creates the `.delivery` content as above, but outside the context of generating a new cookbook. This includes the same auto-detection logic as [pcb](https://github.com/chef-cookbooks/pcb) to determine if the project is a cookbook or not, and modify the generated content accordingly. Therefore, it can potentially replace the pcb cookbook's role in `delivery init`.

For both use cases, I compared the generated files to those created by `delivery init -l`, and confirmed there are no substantive differences.