### PR TITLE
Change generator default verifier to Inspec

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/serverspec_spec_helper.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/serverspec_spec_helper.rb
@@ -1,8 +1,0 @@
-require 'serverspec'
-
-if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
-  set :backend, :exec
-else
-  set :backend, :cmd
-  set :os, family: 'windows'
-end

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -21,10 +21,6 @@ directory "#{app_dir}/test/integration/default" do
   recursive true
 end
 
-directory "#{app_dir}/test/integration" do
-  recursive true
-end
-
 template "#{app_dir}/test/integration/default/default_spec.rb" do
   source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -10,27 +10,23 @@ directory app_dir
 
 # Top level files
 
-# TK
+# Test Kitchen
 template "#{app_dir}/.kitchen.yml" do
   source 'kitchen.yml.erb'
   helpers(ChefDK::Generator::TemplateHelper)
 end
 
-directory "#{app_dir}/test/integration/default/serverspec" do
+# Inspec
+directory "#{app_dir}/test/integration/default" do
   recursive true
 end
 
-directory "#{app_dir}/test/integration/helpers/serverspec" do
+directory "#{app_dir}/test/integration" do
   recursive true
 end
 
-cookbook_file "#{app_dir}/test/integration/helpers/serverspec/spec_helper.rb" do
-  source 'serverspec_spec_helper.rb'
-  action :create_if_missing
-end
-
-template "#{app_dir}/test/integration/default/serverspec/default_spec.rb" do
-  source 'serverspec_default_spec.rb.erb'
+template "#{app_dir}/test/integration/default/default_spec.rb" do
+  source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -37,7 +37,7 @@ else
 end
 
 
-# TK & Serverspec
+# Test Kitchen
 template "#{cookbook_dir}/.kitchen.yml" do
 
   if context.use_berkshelf
@@ -50,21 +50,13 @@ template "#{cookbook_dir}/.kitchen.yml" do
   action :create_if_missing
 end
 
-directory "#{cookbook_dir}/test/integration/default/serverspec" do
+# Inspec
+directory "#{cookbook_dir}/test/integration/default" do
   recursive true
 end
 
-directory "#{cookbook_dir}/test/integration/helpers/serverspec" do
-  recursive true
-end
-
-cookbook_file "#{cookbook_dir}/test/integration/helpers/serverspec/spec_helper.rb" do
-  source 'serverspec_spec_helper.rb'
-  action :create_if_missing
-end
-
-template "#{cookbook_dir}/test/integration/default/serverspec/default_spec.rb" do
-  source 'serverspec_default_spec.rb.erb'
+template "#{cookbook_dir}/test/integration/default/default_spec.rb" do
+  source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_spec.rb.erb
@@ -1,0 +1,7 @@
+describe '<%= cookbook_name %>::default' do
+  # The Inspec reference, with examples and extensive documentation, can be 
+  # found at https://docs.chef.io/inspec_reference.html
+  it 'does something' do
+    skip 'Replace this with meaningful tests'
+  end
+end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -5,11 +5,9 @@ driver:
 provisioner:
   name: chef_zero
 
-# Uncomment the following verifier to leverage Inspec instead of Busser (the
-# default verifier)
-# verifier:
-#   name: inspec
-#   format: doc
+verifier:
+  name: inspec
+  format: doc
 
 platforms:
   - name: ubuntu-16.04

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -18,11 +18,9 @@ provisioner:
 
 #  require_chef_omnibus: 12.8.1
 
-# Uncomment the following verifier to leverage Inspec instead of Busser (the
-# default verifier)
-# verifier:
-#   name: inspec
-#   format: doc
+verifier:
+  name: inspec
+  format: doc
 
 platforms:
   - name: ubuntu-16.04

--- a/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/serverspec_default_spec.rb.erb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-
-describe '<%= cookbook_name %>::default' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
-  end
-end

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -33,9 +33,7 @@ describe ChefDK::Command::GeneratorCommands::App do
       test
       test/integration
       test/integration/default
-      test/integration/default/serverspec
-      test/integration/default/serverspec/default_spec.rb
-      test/integration/helpers/serverspec/spec_helper.rb
+      test/integration/default/default_spec.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore
@@ -131,8 +129,8 @@ describe ChefDK::Command::GeneratorCommands::App do
         end
       end
 
-      describe "test/integration/default/serverspec/default_spec.rb" do
-        let(:file) { File.join(tempdir, "new_app", "test", "integration", "default", "serverspec", "default_spec.rb") }
+      describe "test/integration/default/default_spec.rb" do
+        let(:file) { File.join(tempdir, "new_app", "test", "integration", "default", "default_spec.rb") }
 
         include_examples "a generated file", :cookbook_name do
           let(:line) { "describe 'new_app::default' do" }

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -33,9 +33,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       test
       test/integration
       test/integration/default
-      test/integration/default/serverspec
-      test/integration/default/serverspec/default_spec.rb
-      test/integration/helpers/serverspec/spec_helper.rb
+      test/integration/default/default_spec.rb
       Berksfile
       chefignore
       metadata.rb
@@ -177,8 +175,8 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
           expect(IO.read(file)).to eq(expected_kitchen_yml_content)
         end
 
-        describe "test/integration/default/serverspec/default_spec.rb" do
-          let(:file) { File.join(tempdir, "new_cookbook", "test", "integration", "default", "serverspec", "default_spec.rb") }
+        describe "test/integration/default/default_spec.rb" do
+          let(:file) { File.join(tempdir, "new_cookbook", "test", "integration", "default", "default_spec.rb") }
 
           include_examples "a generated file", :cookbook_name do
             let(:line) { "describe 'new_cookbook::default' do" }
@@ -276,11 +274,9 @@ provisioner:
 
 #  require_chef_omnibus: 12.8.1
 
-# Uncomment the following verifier to leverage Inspec instead of Busser (the
-# default verifier)
-# verifier:
-#   name: inspec
-#   format: doc
+verifier:
+  name: inspec
+  format: doc
 
 platforms:
   - name: ubuntu-16.04
@@ -347,11 +343,9 @@ driver:
 provisioner:
   name: chef_zero
 
-# Uncomment the following verifier to leverage Inspec instead of Busser (the
-# default verifier)
-# verifier:
-#   name: inspec
-#   format: doc
+verifier:
+  name: inspec
+  format: doc
 
 platforms:
   - name: ubuntu-16.04


### PR DESCRIPTION
Do not merge until 0.15.x ships.

Changes the cookbook generator so that the default verifier is now Inspec.
- Updates generated .kitchen.yml
- Generates Inspec-style test folder structure in cookbook skeleton
- default_spec.rb now refers to Inspec documentation, no longer includes spec_helper.rb
- No longer generates serverspec/spec_helper.rb
- Resolves #834