### PR TITLE
Create cookbooks with exemplary git history

### DIFF
--- a/lib/chef-dk/command/generator_commands/build_cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/build_cookbook.rb
@@ -56,6 +56,7 @@ module ChefDK
           super
           Generator.add_attr_to_context(:delivery_project_dir, delivery_project_dir)
 
+          Generator.add_attr_to_context(:delivery_project_git_initialized, delivery_project_git_initialized?)
           Generator.add_attr_to_context(:build_cookbook_parent_is_cookbook, build_cookbook_parent_is_cookbook?)
         end
 
@@ -89,6 +90,10 @@ module ChefDK
             end
           end
           project_dir
+        end
+
+        def delivery_project_git_initialized?
+          File.exist?(File.join(delivery_project_dir, ".git"))
         end
 
         def read_and_validate_params

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -72,6 +72,8 @@ module ChefDK
           if params_valid?
             setup_context
             chef_runner.converge
+            msg("")
+            msg("Your cookbook is ready. Type `cd #{cookbook_name_or_path}` to start working.")
             0
           else
             err(opt_parser)

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -96,6 +96,7 @@ module ChefDK
           Generator.add_attr_to_context(:enable_delivery, enable_delivery?)
           Generator.add_attr_to_context(:delivery_project_dir, cookbook_full_path)
           Generator.add_attr_to_context(:build_cookbook_parent_is_cookbook, true)
+          Generator.add_attr_to_context(:delivery_project_git_initialized, have_git? && !cookbook_path_in_git_repo?)
 
           Generator.add_attr_to_context(:use_berkshelf, berks_mode?)
         end

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -110,14 +110,14 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command("git add .delivery/config.json")
     cwd delivery_project_dir
 
-    only_if "git status --porcelain |grep '.'"
+    only_if "git status --porcelain |grep \".\""
   end
 
   execute("git-commit-delivery-config") do
-    command("git commit -m 'Add generated delivery configuration'")
+    command("git commit -m \"Add generated delivery configuration\"")
     cwd delivery_project_dir
 
-    only_if "git status --porcelain |grep '.'"
+    only_if "git status --porcelain |grep \".\""
   end
 
 
@@ -125,14 +125,14 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command("git add .delivery")
     cwd delivery_project_dir
 
-    only_if "git status --porcelain |grep '.'"
+    only_if "git status --porcelain |grep \".\""
   end
 
   execute("git-commit-delivery-build-cookbook") do
-    command("git commit -m 'Add generated delivery build cookbook'")
+    command("git commit -m \"Add generated delivery build cookbook\"")
     cwd delivery_project_dir
 
-    only_if "git status --porcelain |grep '.'"
+    only_if "git status --porcelain |grep \".\""
   end
 
   execute("git-return-to-master-branch") do

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -124,7 +124,7 @@ if context.have_git
     end
 
     execute("git-commit-new-files") do
-      command("git commit -m 'Add generated cookbook content'")
+      command("git commit -m \"Add generated cookbook content\"")
       cwd cookbook_dir
     end
   end

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -103,16 +103,30 @@ end
 
 # git
 if context.have_git
-  if !context.skip_git_init
+  unless context.skip_git_init
 
     execute("initialize-git") do
       command("git init .")
       cwd cookbook_dir
     end
+
   end
 
   cookbook_file "#{cookbook_dir}/.gitignore" do
     source "gitignore"
+  end
+
+  unless context.skip_git_init
+
+    execute("git-add-new-files") do
+      command("git add .")
+      cwd cookbook_dir
+    end
+
+    execute("git-commit-new-files") do
+      command("git commit -m 'Add generated cookbook content'")
+      cwd cookbook_dir
+    end
   end
 end
 

--- a/spec/shared/custom_generator_cookbook.rb
+++ b/spec/shared/custom_generator_cookbook.rb
@@ -16,7 +16,13 @@ shared_examples_for "custom generator cookbook" do
 
     let(:argv) { [generator_arg, "--generator-cookbook", generator_cookbook_path] }
 
-    subject(:code_generator) { described_class.new(argv) }
+    let(:stdout_io) { StringIO.new }
+
+    subject(:code_generator) do
+      described_class.new(argv).tap do |gen|
+        allow(gen).to receive(:stdout).and_return(stdout_io)
+      end
+    end
 
     before do
       reset_tempdir

--- a/spec/shared/setup_git_committer_config.rb
+++ b/spec/shared/setup_git_committer_config.rb
@@ -1,0 +1,54 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "mixlib/shellout"
+
+RSpec.shared_context("setup_git_committer_config") do
+
+  def _have_git_config_key?(key)
+    cmd = Mixlib::ShellOut.new("git config --global #{key}", returns: [0,1])
+    cmd.run_command
+    cmd.error!
+    cmd.status.success?
+  end
+
+  def _git_config(subcommand_args)
+    cmd = Mixlib::ShellOut.new("git config --global #{subcommand_args}")
+    cmd.run_command
+    cmd.error!
+    cmd
+  end
+
+  before(:all) do
+    unless _have_git_config_key?("user.name")
+      _git_config("user.name \"chefdk_rspec_user\"")
+    end
+    unless _have_git_config_key?("user.email")
+      _git_config("user.email \"chefdk_rspec_user@example.com\"")
+    end
+  end
+
+  after(:all) do
+    if _git_config("user.name").stdout.include?("chefdk_rspec_user")
+      _git_config("--unset user.name")
+    end
+    if _git_config("user.email").stdout.include?("chefdk_rspec_user")
+      _git_config("--unset user.email")
+    end
+  end
+
+end

--- a/spec/unit/command/generator_commands/build_cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/build_cookbook_spec.rb
@@ -17,10 +17,13 @@
 
 require 'spec_helper'
 require 'shared/custom_generator_cookbook'
+require 'shared/setup_git_committer_config'
 require 'chef-dk/command/generator_commands/build_cookbook'
 require 'mixlib/shellout'
 
 describe ChefDK::Command::GeneratorCommands::BuildCookbook do
+
+  include_context("setup_git_committer_config")
 
   let(:argv) { %w[delivery_project] }
 
@@ -307,7 +310,7 @@ METADATA
 
         git!("init .")
         git!("add .")
-        git!("commit -m 'initial commit'")
+        git!("commit -m \"initial commit\"")
 
         Dir.chdir(tempdir) do
           allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -59,6 +59,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
   subject(:cookbook_generator) do
     g = described_class.new(argv)
     allow(g).to receive(:cookbook_path_in_git_repo?).and_return(false)
+    allow(g).to receive(:stdout).and_return(stdout_io)
     g
   end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -17,9 +17,12 @@
 
 require 'spec_helper'
 require 'shared/custom_generator_cookbook'
+require 'shared/setup_git_committer_config'
 require 'chef-dk/command/generator_commands/cookbook'
 
 describe ChefDK::Command::GeneratorCommands::Cookbook do
+
+  include_context("setup_git_committer_config")
 
   let(:argv) { %w[new_cookbook] }
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -129,7 +129,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
     it "creates a new cookbook" do
       Dir.chdir(tempdir) do
         allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-        cookbook_generator.run
+        expect(cookbook_generator.run).to eq(0)
       end
       generated_files = Dir.glob("#{tempdir}/new_cookbook/**/*", File::FNM_DOTMATCH)
       expected_cookbook_files.each do |expected_file|
@@ -141,7 +141,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       before do
         Dir.chdir(tempdir) do
           allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-          cookbook_generator.run
+          expect(cookbook_generator.run).to eq(0)
         end
       end
 
@@ -164,17 +164,21 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
       describe "Generating Test Kitchen and integration testing files" do
 
-        before do
-          Dir.chdir(tempdir) do
-            allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-            cookbook_generator.run
+        describe "generating kitchen config" do
+
+          before do
+            Dir.chdir(tempdir) do
+              allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+              expect(cookbook_generator.run).to eq(0)
+            end
           end
-        end
 
-        let(:file) { File.join(tempdir, "new_cookbook", ".kitchen.yml") }
+          let(:file) { File.join(tempdir, "new_cookbook", ".kitchen.yml") }
 
-        it "creates a .kitchen.yml with the expected content" do
-          expect(IO.read(file)).to eq(expected_kitchen_yml_content)
+          it "creates a .kitchen.yml with the expected content" do
+            expect(IO.read(file)).to eq(expected_kitchen_yml_content)
+          end
+
         end
 
         describe "test/integration/default/serverspec/default_spec.rb" do
@@ -196,7 +200,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
         before do
           Dir.chdir(tempdir) do
             allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-            cookbook_generator.run
+            expect(cookbook_generator.run).to eq(0)
           end
         end
 
@@ -242,7 +246,7 @@ POLICYFILE_RB
         before do
           Dir.chdir(tempdir) do
             allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-            cookbook_generator.run
+            expect(cookbook_generator.run).to eq(0)
           end
         end
 
@@ -326,7 +330,7 @@ POLICYFILE_RB
         before do
           Dir.chdir(tempdir) do
             allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-            cookbook_generator.run
+            expect(cookbook_generator.run).to eq(0)
           end
         end
 
@@ -389,7 +393,7 @@ SPEC_HELPER
       before do
         Dir.chdir(tempdir) do
           allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-          cookbook_generator.run
+          expect(cookbook_generator.run).to eq(0)
         end
       end
 


### PR DESCRIPTION
* `chef generate cookbook` (default mode) will commit files to master when it detects that you want it to initialize a new git repo
* `chef generate cookbook -d` (delivery mode) will make one commit for `.delivery/config.json`, and another commit for the build cookbook. These commits are done in a feature branch which is merged (with `--no-ff` to force a merge commit) and then cleaned up.
* After `chef generate cookbook` the user now sees a message telling them to `cd` into the cookbook's directory to get started.