### PR TITLE
Add a Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Description
+
+Briefly describe the issue
+
+# ChefDK Version
+
+Tell us which version of the ChefDK you are running. Run `chef --version` to display the version.
+
+# Platform Version
+
+Tell us which operating system distribution and version ChefDK is running on.
+
+# Replication Case
+
+Tell us what steps to take to replicate your problem. See [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve) for information on how to create a good replication case.
+
+# Stacktrace
+
+Please include the stacktrace.out output or link to a gist of it, if there is one.
+
+## NOTE: CHEFDK BUGS ONLY
+
+This issue tracker is for the code contained within this repo -- `chefdk`.
+
+- [Server issues](https://github.com/chef/chef-server/issues/new)
+- [Chef-client issues](https://github.com/chef/chef/issues/new)
+- Cookbook Issues (see the <https://github.com/chef-cookbooks> repos or search [Supermarket](https://supermarket.chef.io) or GitHub/Google)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,6 @@ Chef is built to last. We strive to ensure high quality throughout the Chef expe
   continuously on all the pull requests. We require the Travis runs to succeed on every pull
   request before being merged.
 
-In addition to this it would be nice to include the description of the problem you are solving
-  with your change. You can use [Chef Issue Template](#issuetemplate) in the description section
-  of the pull request.
 
 ### <a name="cr"></a> Chef Code Review Process
 
@@ -48,6 +45,7 @@ Once you a pull request, the **Chef Engineering Team** or **Chef Core Committers
 
 If you would like to learn about when your code will be available in a release of Chef, read more about
   [Chef Release Process](#release).
+
 
 ### Contributor License Agreement (CLA)
 Licensing is very important to open source projects. It helps ensure the
@@ -121,29 +119,6 @@ If you are familiar with Chef and know the component that is causing you a probl
 Otherwise you can file your issue in the [Chef project](https://github.com/chef/chef/issues)
   and we will make sure it gets filed against the appropriate project.
 
-In order to decrease the back and forth in issues, and to help us get to the bottom of them quickly
-  we use the below issue template. You can copy/paste this template into the issue you are opening and
-  edit it accordingly.
-
-<a name="issuetemplate"></a>
-```
-### Version:
-[Version of the project installed]
-
-### Environment: [Details about the environment such as the Operating System, cookbook details, etc...]
-
-### Scenario:
-[What you are trying to achieve and you can't?]
-
-### Steps to Reproduce:
-[If you are filing an issue what are the things we need to do in order to repro your problem?]
-
-### Expected Result:
-[What are you expecting to happen as the consequence of above reproduction steps?]
-
-### Actual Result:
-[What actually happens after the reproduction steps?]
-```
 
 ## <a name="release"></a> Chef Release Cycles
 


### PR DESCRIPTION
This is a much better way to do this vs. the copy / paste issue template
in the contributing doc

Signed-off-by: Tim Smith <tsmith@chef.io>