### PR TITLE
make cookbook generator output more concise

### DIFF
--- a/lib/chef-dk/command/generator_commands/base.rb
+++ b/lib/chef-dk/command/generator_commands/base.rb
@@ -18,6 +18,9 @@
 require 'chef-dk/configurable'
 require 'chef-dk/command/generator_commands'
 
+require 'chef-dk/command/generator_commands/chef_exts/recipe_dsl_ext'
+require 'chef-dk/command/generator_commands/chef_exts/generator_desc_resource'
+
 module ChefDK
   module Command
     module GeneratorCommands

--- a/lib/chef-dk/command/generator_commands/chef_exts/generator_desc_resource.rb
+++ b/lib/chef-dk/command/generator_commands/chef_exts/generator_desc_resource.rb
@@ -1,0 +1,85 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require 'chef/provider'
+
+module ChefDK
+  module ChefResource
+
+    # GeneratorDesc is similar to Chef's built-in log resource, but instead of
+    # sending output through the logger, it sends output through the output
+    # formatter, which avoids the extra formatting that the logger would add.
+    #
+    # As the name implies, it is used to describe the steps that the generator
+    # takes to create a cookbook.
+    class GeneratorDesc < Chef::Resource
+
+      resource_name(:generator_desc)
+
+      identity_attr(:message)
+
+      default_action(:write)
+
+      def initialize(name, run_context = nil)
+        super
+        @message = name
+      end
+
+      def message(arg = nil)
+        set_or_return(
+          :message,
+          arg,
+          :kind_of => String
+        )
+      end
+
+    end
+  end
+
+  module ChefProvider
+
+    # Chef log provider, allows logging to chef's logs from recipes
+    class GeneratorDesc < Chef::Provider
+
+      provides :generator_desc
+
+      def whyrun_supported?
+        true
+      end
+
+      # No concept of a 'current' resource for logs, this is a no-op
+      #
+      # === Return
+      # true:: Always return true
+      def load_current_resource
+        true
+      end
+
+      # Write the log to Chef's log
+      #
+      # === Return
+      # true:: Always return true
+      def action_write
+        run_context.events.subscribers.first.puts_line("- #{new_resource.message}")
+        new_resource.updated_by_last_action(true)
+      end
+
+    end
+
+  end
+end

--- a/lib/chef-dk/command/generator_commands/chef_exts/quieter_doc_formatter.rb
+++ b/lib/chef-dk/command/generator_commands/chef_exts/quieter_doc_formatter.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/formatters/doc'
+
+module ChefDK
+
+  # Subclass of Chef's standard 'doc' formatter that mutes messages that occur
+  # prior to convergence. This gives us cleaner output in general, but is
+  # especially noticeable when the standard formatter is disabled by the
+  # generator cookbook.
+  class QuieterDocFormatter < Chef::Formatters::Doc
+
+    cli_name(:chefdk_doc)
+
+    # Called when starting to collect gems from the cookbooks
+    def cookbook_gem_start(gems)
+    end
+
+    # Called when cookbook loading starts.
+    def library_load_start(file_count)
+    end
+  end
+end
+

--- a/lib/chef-dk/command/generator_commands/chef_exts/recipe_dsl_ext.rb
+++ b/lib/chef-dk/command/generator_commands/chef_exts/recipe_dsl_ext.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/dsl/recipe'
+
+module ChefDK
+
+  # Methods here are mixed in to the Chef recipe DSL to provide extra
+  # functionality for generator cookbooks.
+  module RecipeDSLExt
+
+    # Replaces the current formatter (by default this is the `doc` formatter)
+    # with the null formatter, thus suppressing normal Chef output.
+    def silence_chef_formatter
+      old = run_context.events.subscribers.first
+      out, err = old.output.out, old.output.err
+      run_context.events.subscribers.clear
+      null_formatter = Chef::Formatters.new(:null, out, err)
+      run_context.events.register(null_formatter)
+    end
+
+  end
+end
+
+Chef::DSL::Recipe.send(:include, ChefDK::RecipeDSLExt)
+

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -71,6 +71,7 @@ module ChefDK
           read_and_validate_params
           if params_valid?
             setup_context
+            msg("Generating cookbook #{cookbook_name}")
             chef_runner.converge
             msg("")
             msg("Your cookbook is ready. Type `cd #{cookbook_name_or_path}` to start working.")

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -3,11 +3,15 @@ context = ChefDK::Generator.context
 delivery_project_dir = context.delivery_project_dir
 dot_delivery_dir = File.join(delivery_project_dir, ".delivery")
 
+generator_desc("Ensuring delivery configuration")
+
 directory dot_delivery_dir
 
 cookbook_file File.join(dot_delivery_dir, "config.json") do
   source "delivery-config.json"
 end
+
+generator_desc("Ensuring correct delivery build cookbook content")
 
 build_cookbook_dir = File.join(dot_delivery_dir, "build-cookbook")
 
@@ -101,6 +105,8 @@ end
 #
 if context.have_git && context.delivery_project_git_initialized && !context.skip_git_init
 
+  generator_desc("Adding delivery configuration to feature branch")
+
   execute("git-create-feature-branch") do
     command("git checkout -t -b add-delivery-configuration")
     cwd delivery_project_dir
@@ -120,6 +126,7 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     only_if "git status --porcelain |grep \".\""
   end
 
+  generator_desc("Adding build cookbook to feature branch")
 
   execute("git-add-delivery-build-cookbook-files") do
     command("git add .delivery")
@@ -139,6 +146,8 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command("git checkout master")
     cwd delivery_project_dir
   end
+
+  generator_desc("Merging delivery content feature branch to master")
 
   execute("git-merge-delivery-config-branch") do
     command("git merge --no-ff add-delivery-configuration")

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -2,6 +2,10 @@
 context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 
+silence_chef_formatter
+
+generator_desc("Ensuring correct cookbook file content")
+
 # cookbook root dir
 directory cookbook_dir
 
@@ -104,6 +108,8 @@ end
 # git
 if context.have_git
   unless context.skip_git_init
+
+    generator_desc("Committing cookbook files to git")
 
     execute("initialize-git") do
       command("git init .")

--- a/spec/unit/chef_runner_spec.rb
+++ b/spec/unit/chef_runner_spec.rb
@@ -54,14 +54,16 @@ describe ChefDK::ChefRunner do
   end
 
   it "configures a formatter for the chef run" do
-    expect(chef_runner.formatter).to be_a(Chef::EventDispatch::Dispatcher)
+    expect(chef_runner.event_dispatcher).to be_a(Chef::EventDispatch::Dispatcher)
 
-    # TODO: Once https://github.com/chef/chef/pull/3340 is merged/released,
-    # just use `formatter.subscribers`
-    subscribers = chef_runner.formatter.instance_variable_get(:@subscribers)
+    subscribers = chef_runner.event_dispatcher.subscribers
 
     expect(subscribers.size).to eq(1)
-    expect(subscribers.first).to be_a(Chef::Formatters::Doc)
+    expect(subscribers.first).to be_a(ChefDK::QuieterDocFormatter)
+  end
+
+  it "extends the recipe DSL with ChefDK's extensions" do
+    expect(Chef::DSL::Recipe.included_modules).to include(ChefDK::RecipeDSLExt)
   end
 
   it "detects the platform with ohai" do

--- a/spec/unit/command/generator_commands/chef_exts/generator_desc_resource_spec.rb
+++ b/spec/unit/command/generator_commands/chef_exts/generator_desc_resource_spec.rb
@@ -1,0 +1,97 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'stringio'
+
+require 'chef/run_context'
+require 'chef/cookbook/cookbook_collection'
+require 'chef/node'
+require 'chef/event_dispatch/dispatcher'
+require 'chef/formatters/base'
+
+require 'ohai/system'
+
+require 'chef-dk/command/generator_commands/chef_exts/generator_desc_resource'
+
+describe ChefDK::ChefResource::GeneratorDesc do
+
+  let(:node) { Chef::Node.new }
+
+  let(:stdout) { StringIO.new }
+
+  let(:stderr) { StringIO.new }
+
+  let(:null_formatter) do
+    Chef::Formatters.new(:null, stdout, stderr)
+  end
+
+  let(:events) do
+    Chef::EventDispatch::Dispatcher.new.tap do |d|
+      d.register(null_formatter)
+    end
+  end
+
+  let(:cookbook_collection) { Chef::CookbookCollection.new }
+
+  let(:run_context) do
+    Chef::RunContext.new(node, cookbook_collection, events)
+  end
+
+  let(:message) { "this part of the cookbook does a thing" }
+
+  let(:resource) do
+    described_class.new(message, run_context)
+  end
+
+  describe "resource" do
+
+    it "has the message it was created with" do
+      expect(resource.message).to eq(message)
+    end
+
+    it "defaults to action :write" do
+      expect(resource.action).to eq( [ :write ] )
+    end
+
+    it "is identified by the message property" do
+      expect(resource.identity).to eq(message)
+    end
+
+  end
+
+  describe "provider" do
+
+    let(:provider) do
+      ChefDK::ChefProvider::GeneratorDesc.new(resource, run_context)
+    end
+
+    it "supports why run" do
+      expect(provider.whyrun_supported?).to be(true)
+    end
+
+    it "does nothing for load current resource" do
+      expect(provider.load_current_resource).to be(true)
+    end
+
+    it "writes the message to the formatter" do
+      provider.action_write
+      expect(stdout.string).to include(message)
+    end
+  end
+
+end

--- a/spec/unit/command/generator_commands/chef_exts/recipe_dsl_ext_spec.rb
+++ b/spec/unit/command/generator_commands/chef_exts/recipe_dsl_ext_spec.rb
@@ -36,6 +36,8 @@ require 'chef-dk/command/generator_commands/chef_exts/quieter_doc_formatter'
 
 describe ChefDK::RecipeDSLExt do
 
+  before(:all) { Chef.reset! }
+
   let(:stdout) { StringIO.new }
 
   let(:stderr) { StringIO.new }
@@ -67,7 +69,12 @@ describe ChefDK::RecipeDSLExt do
     end
   end
 
-  let(:cookbook_name) { "example" }
+  # In some circumstances (not totally clear about what), compat resource gets
+  # loaded and it does some weird stuff to `Chef::Recipe.new` which can fail if
+  # you pass in a cookbook name that is bogus and not-falsey. Using `nil` for
+  # the cookbook name works around that.
+  # https://github.com/chef-cookbooks/compat_resource/blob/3d948a5a9cabccddc7cf5e48dfea796a6b557a44/files/lib/chef_compat/monkeypatches/chef/recipe.rb#L8-L15
+  let(:cookbook_name) { nil }
 
   let(:recipe_name) { "example" }
 

--- a/spec/unit/command/generator_commands/chef_exts/recipe_dsl_ext_spec.rb
+++ b/spec/unit/command/generator_commands/chef_exts/recipe_dsl_ext_spec.rb
@@ -1,0 +1,104 @@
+#
+# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'stringio'
+
+require 'chef/config'
+require 'chef/recipe'
+require 'chef/run_context'
+require 'chef/event_dispatch/dispatcher'
+require 'chef/policy_builder'
+require 'chef/formatters/doc'
+require 'chef/cookbook/file_vendor'
+require 'chef/cookbook/file_system_file_vendor'
+require 'chef/cookbook/cookbook_collection'
+require 'chef/cookbook_loader'
+
+require 'ohai/system'
+
+require 'chef-dk/command/generator_commands/chef_exts/recipe_dsl_ext'
+require 'chef-dk/command/generator_commands/chef_exts/quieter_doc_formatter'
+
+describe ChefDK::RecipeDSLExt do
+
+  let(:stdout) { StringIO.new }
+
+  let(:stderr) { StringIO.new }
+
+  let(:doc_formatter) do
+    Chef::Formatters.new(:chefdk_doc, stdout, stderr)
+  end
+
+  let(:event_dispatcher) do
+    Chef::EventDispatch::Dispatcher.new.tap do |d|
+      d.register(doc_formatter)
+    end
+  end
+
+  let(:run_list) { [ ] }
+
+  let(:ohai) do
+    Ohai::System.new.tap do |o|
+      o.all_plugins(["platform", "platform_version"])
+    end
+  end
+
+  let(:policy_builder) do
+    Chef::PolicyBuilder::Dynamic.new("chef-dk", ohai.data, {}, nil, event_dispatcher).tap do |b|
+      b.load_node
+      b.build_node
+      b.node.run_list(*run_list)
+      b.expand_run_list
+    end
+  end
+
+  let(:cookbook_name) { "example" }
+
+  let(:recipe_name) { "example" }
+
+  let(:run_context) { policy_builder.setup_run_context }
+
+  let(:recipe) { Chef::Recipe.new(cookbook_name, recipe_name, run_context) }
+
+  before do
+    Chef::Config.solo_legacy_mode = true
+    Chef::Config.color = true
+    Chef::Config.diff_disabled = true
+    Chef::Config.use_policyfile = false
+  end
+
+  describe "silence_chef_formatter" do
+
+    before do
+      recipe.silence_chef_formatter
+    end
+
+    let(:formatter) { run_context.events.subscribers.first }
+
+    it "replaces the default formatter with a null formatter" do
+      expect(formatter).to be_a(Chef::Formatters::NullFormatter)
+    end
+
+    it "passes stdout and stderr from the default formatter to the new one" do
+      expect(formatter.output.out).to be(stdout)
+      expect(formatter.output.err).to be(stderr)
+    end
+
+  end
+
+end

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -141,6 +141,27 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       end
     end
 
+    it "emits concise output" do
+      Dir.chdir(tempdir) do
+        allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+        expect(cookbook_generator.run).to eq(0)
+      end
+
+      expected = <<-OUTPUT
+Generating cookbook new_cookbook
+- Ensuring correct cookbook file content
+- Committing cookbook files to git
+
+Your cookbook is ready. Type `cd new_cookbook` to start working.
+OUTPUT
+
+      actual = stdout_io.string
+
+      # the formatter will add escape sequences to turn off any colors
+      actual.gsub!("\e[0m", "")
+      expect(actual).to eq(expected)
+    end
+
     shared_examples_for "a generated file" do |context_var|
       before do
         Dir.chdir(tempdir) do
@@ -399,6 +420,27 @@ SPEC_HELPER
           allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
           expect(cookbook_generator.run).to eq(0)
         end
+      end
+
+      it "emits concise output" do
+        expected = <<-OUTPUT
+Generating cookbook new_cookbook
+- Ensuring correct cookbook file content
+- Committing cookbook files to git
+- Ensuring delivery configuration
+- Ensuring correct delivery build cookbook content
+- Adding delivery configuration to feature branch
+- Adding build cookbook to feature branch
+- Merging delivery content feature branch to master
+
+Your cookbook is ready. Type `cd new_cookbook` to start working.
+OUTPUT
+
+        actual = stdout_io.string
+
+        # the formatter will add escape sequences to turn off any colors
+        actual.gsub!("\e[0m", "")
+        expect(actual).to eq(expected)
       end
 
       describe ".delivery/config.json" do


### PR DESCRIPTION
Output of `chef generate cookbook` looks like this:

```
shell$ chef generate cookbook foo -d     
Generating cookbook foo
- Ensuring correct cookbook file content
- Committing cookbook files to git
- Ensuring delivery configuration
- Ensuring correct delivery build cookbook content
- Adding delivery configuration to feature branch
- Adding build cookbook to feature branch
- Merging delivery content feature branch to master

Your cookbook is ready. Type `cd foo` to start working.
```

## Implementation:

* Add a `silence_chef_formatter` method to the recipe DSL, which works by changing the formatter to the `null` formatter. This makes the concise output mode opt-in. The intention is to not change the output for users with existing custom generator cookbooks unless/until they modify their cookbooks to have descriptions.
* Add a `generator_desc` HWRP. It's basically like the log resource in core, but sends the message via the formatter so it doesn't extra stuff to the message.
* Use a slightly modified version of the doc formatter by default. The modified version suppresses `Installing Cookbook Gems:` and `Compiling Cookbooks...` messages that otherwise would get printed before the generator cookbook had the chance to change the formatter.
* Only the cookbook generator is changed at this time. We will probably change the others in the future, but didn't want to increase the scope of this work beyond just the cookbook generator.