### PR TITLE
Add verbose flag for `generate cookbook`

### DIFF
--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -56,6 +56,12 @@ module ChefDK
           boolean:      true,
           default:      nil
 
+        option :verbose,
+          short:        "-V",
+          long:         "--verbose",
+          description:  "Show detailed output from the generator",
+          boolean:      true,
+          default:      false
 
         options.merge!(SharedGeneratorOptions.options)
 
@@ -64,6 +70,7 @@ module ChefDK
           @cookbook_name = nil
           @berks_mode = true
           @enable_delivery = false
+          @verbose = false
           super
         end
 
@@ -109,6 +116,8 @@ module ChefDK
           Generator.add_attr_to_context(:build_cookbook_parent_is_cookbook, true)
           Generator.add_attr_to_context(:delivery_project_git_initialized, have_git? && !cookbook_path_in_git_repo?)
 
+          Generator.add_attr_to_context(:verbose, verbose?)
+
           Generator.add_attr_to_context(:use_berkshelf, berks_mode?)
         end
 
@@ -146,6 +155,10 @@ module ChefDK
 
         def enable_delivery?
           @enable_delivery
+        end
+
+        def verbose?
+          @verbose
         end
 
         def have_delivery_config?
@@ -190,6 +203,12 @@ module ChefDK
           if config[:delivery]
             @enable_delivery = true
           end
+
+          if config[:verbose]
+            @verbose = true
+          end
+
+          true
         end
 
         def params_valid?

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -2,7 +2,7 @@
 context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 
-silence_chef_formatter
+silence_chef_formatter unless context.verbose
 
 generator_desc("Ensuring correct cookbook file content")
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -126,6 +126,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       expect(generator_context.cookbook_root).to eq(Dir.pwd)
       expect(generator_context.cookbook_name).to eq("new_cookbook")
       expect(generator_context.recipe_name).to eq("default")
+      expect(generator_context.verbose).to be(false)
     end
 
     it "creates a new cookbook" do
@@ -139,6 +140,32 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       end
     end
 
+    context "when given the verbose flag" do
+
+      let(:argv) { %w[ new_cookbook --verbose ] }
+
+      it "configures the generator context with verbose mode enabled" do
+        cookbook_generator.read_and_validate_params
+        cookbook_generator.setup_context
+        expect(generator_context.verbose).to be(true)
+      end
+
+      it "emits verbose output" do
+        Dir.chdir(tempdir) do
+          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+          expect(cookbook_generator.run).to eq(0)
+        end
+
+        # The normal chef formatter puts a heading for each recipe like this.
+        # Full output is large and subject to change with minor changes in the
+        # generator cookbook, so we just look for this line
+        expected_line = "Recipe: code_generator::cookbook"
+
+        actual = stdout_io.string
+
+        expect(actual).to include(expected_line)
+      end
+    end
 
     context "when no delivery CLI configuration is present" do
 


### PR DESCRIPTION
Adds `-V` / `--verbose` option to turn doc formatter output back on for `chef generate cookbook`. I picked `-V` because it's consistent with `knife`.