### PR TITLE
Remove default folder in template generator

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/template.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/template.rb
@@ -10,7 +10,7 @@ unless File.extname(template_filename) == ".erb"
   template_filename = "#{template_filename}.erb"
 end
 
-template_path = File.join(cookbook_dir, "templates", "default", template_filename)
+template_path = File.join(cookbook_dir, "templates", template_filename)
 
 directory template_dir do
   recursive true

--- a/spec/unit/command/generator_commands/template_spec.rb
+++ b/spec/unit/command/generator_commands/template_spec.rb
@@ -24,7 +24,7 @@ describe ChefDK::Command::GeneratorCommands::Template do
   include_examples "a file generator" do
 
     let(:generator_name) { "template" }
-    let(:generated_files) { [ "templates/default/new_template.txt.erb" ] }
+    let(:generated_files) { [ "templates/new_template.txt.erb" ] }
     let(:new_file_name) { "new_template.txt" }
 
   end


### PR DESCRIPTION
Removes the default folder from the template generator.

Resolves #183.

Signed-off-by: Charles Johnson <charles@chef.io>