### PR TITLE
[UW-65] Remove & make the `-d` flag the default behavior

### DIFF
--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -52,9 +52,9 @@ module ChefDK
         option :delivery,
           short:        "-d",
           long:         "--delivery",
-          description:  "Generate cookbook with delivery integration",
+          description:  "This option has no effect and exists only for compatibility with past releases",
           boolean:      true,
-          default:      nil
+          default:      true
 
         option :verbose,
           short:        "-V",
@@ -69,7 +69,7 @@ module ChefDK
           @params_valid = true
           @cookbook_name = nil
           @berks_mode = true
-          @enable_delivery = false
+          @enable_delivery = true
           @verbose = false
           super
         end
@@ -198,10 +198,6 @@ module ChefDK
 
           if config[:policy]
             @berks_mode = false
-          end
-
-          if config[:delivery]
-            @enable_delivery = true
           end
 
           if config[:verbose]

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -140,6 +140,113 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       end
     end
 
+    context "by default configure for delivery" do
+
+      let(:dot_delivery) { File.join(tempdir, "new_cookbook", ".delivery") }
+
+      before do
+        Dir.chdir(tempdir) do
+          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+          expect(cookbook_generator.run).to eq(0)
+        end
+      end
+
+      describe ".delivery/config.json" do
+
+        let(:file) { File.join(tempdir, "new_cookbook", ".delivery", "config.json") }
+
+        let(:expected_content) do
+          <<-CONFIG_DOT_JSON
+{
+  "version": "2",
+  "build_cookbook": {
+    "name": "build-cookbook",
+    "path": ".delivery/build-cookbook"
+  },
+  "skip_phases": [],
+  "build_nodes": {},
+  "dependencies": []
+}
+  CONFIG_DOT_JSON
+        end
+
+        it "configures delivery to use a local build cookbook" do
+          expect(IO.read(file)).to eq(expected_content)
+        end
+
+      end
+
+      describe "build cookbook recipes" do
+
+        let(:file) do
+          File.join(dot_delivery, "build-cookbook", "recipes", "publish.rb")
+        end
+
+        let(:expected_content) do
+          <<-CONFIG_DOT_JSON
+#
+# Cookbook Name:: build-cookbook
+# Recipe:: publish
+#
+# Copyright (c) 2016 The Authors, All Rights Reserved.
+include_recipe 'delivery-truck::publish'
+  CONFIG_DOT_JSON
+        end
+
+        it "delegates functionality to delivery-truck" do
+          expect(IO.read(file)).to include(expected_content)
+        end
+
+      end
+
+      describe "build cookbook Berksfile" do
+
+        let(:file) do
+          File.join(dot_delivery, "build-cookbook", "Berksfile")
+        end
+
+        let(:expected_content) do
+          <<-CONFIG_DOT_JSON
+source 'https://supermarket.chef.io'
+
+metadata
+
+cookbook 'delivery-truck',
+  git: 'https://github.com/chef-cookbooks/delivery-truck.git',
+  branch: 'master'
+
+# This is so we know where to get delivery-truck's dependency
+cookbook 'delivery-sugar',
+  git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
+  branch: 'master'
+
+group :delivery do
+  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
+  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
+  cookbook 'test', path: './test/fixtures/cookbooks/test'
+end
+  CONFIG_DOT_JSON
+        end
+
+        it "sets the sources for delivery library cookbooks to github" do
+         expect(IO.read(file)).to include(expected_content)
+        end
+
+      end
+    end
+
+    context "when passed delivery option" do
+
+      let(:argv) { %w[new_cookbook --delivery] }
+
+      it 'still works with no action' do
+        Dir.chdir(tempdir) do
+          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
+          expect(cookbook_generator.run).to eq(0)
+        end
+      end
+    end
+
     context "when given the verbose flag" do
 
       let(:argv) { %w[ new_cookbook --verbose ] }
@@ -185,6 +292,11 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 Generating cookbook new_cookbook
 - Ensuring correct cookbook file content
 - Committing cookbook files to git
+- Ensuring delivery configuration
+- Ensuring correct delivery build cookbook content
+- Adding delivery configuration to feature branch
+- Adding build cookbook to feature branch
+- Merging delivery content feature branch to master
 
 Your cookbook is ready. Type `cd new_cookbook` to start working.
 OUTPUT
@@ -232,6 +344,11 @@ OUTPUT
 Generating cookbook new_cookbook
 - Ensuring correct cookbook file content
 - Committing cookbook files to git
+- Ensuring delivery configuration
+- Ensuring correct delivery build cookbook content
+- Adding delivery configuration to feature branch
+- Adding build cookbook to feature branch
+- Merging delivery content feature branch to master
 
 Your cookbook is ready. To setup the pipeline, type `cd new_cookbook`, then run `delivery init`
 OUTPUT
@@ -485,119 +602,6 @@ SPEC_HELPER
 
       end
 
-    end
-
-    context "when configured for delivery" do
-
-      let(:argv) { %w[new_cookbook --delivery] }
-
-      let(:dot_delivery) { File.join(tempdir, "new_cookbook", ".delivery") }
-
-      before do
-        Dir.chdir(tempdir) do
-          allow(cookbook_generator.chef_runner).to receive(:stdout).and_return(stdout_io)
-          expect(cookbook_generator.run).to eq(0)
-        end
-      end
-
-      it "emits concise output" do
-        expected = <<-OUTPUT
-Generating cookbook new_cookbook
-- Ensuring correct cookbook file content
-- Committing cookbook files to git
-- Ensuring delivery configuration
-- Ensuring correct delivery build cookbook content
-- Adding delivery configuration to feature branch
-- Adding build cookbook to feature branch
-- Merging delivery content feature branch to master
-
-Your cookbook is ready. Type `cd new_cookbook` to start working.
-OUTPUT
-
-        actual = stdout_io.string
-
-        # the formatter will add escape sequences to turn off any colors
-        actual.gsub!("\e[0m", "")
-        expect(actual).to eq(expected)
-      end
-
-      describe ".delivery/config.json" do
-
-        let(:file) { File.join(tempdir, "new_cookbook", ".delivery", "config.json") }
-
-        let(:expected_content) do
-          <<-CONFIG_DOT_JSON
-{
-  "version": "2",
-  "build_cookbook": {
-    "name": "build-cookbook",
-    "path": ".delivery/build-cookbook"
-  },
-  "skip_phases": [],
-  "build_nodes": {},
-  "dependencies": []
-}
-CONFIG_DOT_JSON
-        end
-
-        it "configures delivery to use a local build cookbook" do
-          expect(IO.read(file)).to eq(expected_content)
-        end
-
-      end
-
-      describe "build cookbook recipes" do
-
-        let(:file) do
-          File.join(dot_delivery, "build-cookbook", "recipes", "publish.rb")
-        end
-
-        let(:expected_content) do
-          <<-CONFIG_DOT_JSON
-include_recipe 'delivery-truck::publish'
-CONFIG_DOT_JSON
-        end
-
-        it "delegates functionality to delivery-truck" do
-          expect(IO.read(file)).to include(expected_content)
-        end
-
-      end
-
-      describe "build cookbook Berksfile" do
-
-        let(:file) do
-          File.join(dot_delivery, "build-cookbook", "Berksfile")
-        end
-
-        let(:expected_content) do
-          <<-CONFIG_DOT_JSON
-source 'https://supermarket.chef.io'
-
-metadata
-
-cookbook 'delivery-truck',
-  git: 'https://github.com/chef-cookbooks/delivery-truck.git',
-  branch: 'master'
-
-# This is so we know where to get delivery-truck's dependency
-cookbook 'delivery-sugar',
-  git: 'https://github.com/chef-cookbooks/delivery-sugar.git',
-  branch: 'master'
-
-group :delivery do
-  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
-  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
-  cookbook 'test', path: './test/fixtures/cookbooks/test'
-end
-CONFIG_DOT_JSON
-        end
-
-        it "sets the sources for delivery library cookbooks to github" do
-          expect(IO.read(file)).to include(expected_content)
-        end
-
-      end
     end
 
     describe "metadata.rb" do


### PR DESCRIPTION
It is time to remove the flag `-d` from `chef generate cookbook`command, not it will be the default behavior.

cc/ @tyler-ball @danielsdeleo @tylercloke 