### PR TITLE
Putting the custom git binary folder at the end of the path

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -463,28 +463,39 @@ end
         end
       end
 
-      add_component "git" do |c|
-        c.base_dir = "gitbin"
-        c.smoke_test do
-      	  tmpdir do |cwd|
-            sh!("#{File.join(omnibus_root, "gitbin", "git")} config -l")
-      	    sh!("#{File.join(omnibus_root, "gitbin", "git")} clone https://github.com/chef/chef-provisioning", cwd: cwd)
+      if Chef::Platform.windows?
+        add_component "git" do |c|
+          c.base_dir = "embedded/bin"
+          c.smoke_test do
+        	  tmpdir do |cwd|
+              sh!("#{embedded_bin("git")} config -l")
+        	    sh!("#{embedded_bin("git")} clone https://github.com/chef/chef-provisioning", cwd: cwd)
+        	  end
+          end
+        end
+      else
+        add_component "git" do |c|
+          c.base_dir = "gitbin"
+          c.smoke_test do
+        	  tmpdir do |cwd|
+              sh!("#{File.join(omnibus_root, "gitbin", "git")} config -l")
+        	    sh!("#{File.join(omnibus_root, "gitbin", "git")} clone https://github.com/chef/chef-provisioning", cwd: cwd)
 
-      	    # # If /usr/bin/git is a symlink, fail the test.
-      	    # # Note that this test cannot go last because it does not return a
-      	    # # Mixlib::Shellout object in the windows case, which will break the tests.
-      	    unless Chef::Platform.windows?
+        	    # If /usr/bin/git is a symlink, fail the test.
+        	    # Note that this test cannot go last because it does not return a
+        	    # Mixlib::Shellout object in the windows case, which will break the tests.
               failure_str = "#{nix_platform_native_bin_dir}/git contains a symlink which might mean we accidentally overwrote system git via chefdk."
               result = sh("readlink #{nix_platform_native_bin_dir}/git")
               # if a symlink was found, test to see if it is in a chefdk install
               if result.status.exitstatus == 0
                raise failure_str if result.stdout =~ /chefdk/
               end
-      	    end
-      	    # <chef_dk>/bin/ should not contain a git binary.
-      	    failure_str = "`<chef_dk>/bin/git --help` should fail as git should be installed in gitbin"
-      	    fail_if_exit_zero("#{bin("git")} --help", failure_str)
-      	  end
+
+        	    # <chef_dk>/bin/ should not contain a git binary.
+        	    failure_str = "`<chef_dk>/bin/git --help` should fail as git should be installed in gitbin"
+        	    fail_if_exit_zero("#{bin("git")} --help", failure_str)
+        	  end
+          end
         end
       end
 

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -464,28 +464,27 @@ end
       end
 
       add_component "git" do |c|
-        c.base_dir = "embedded/bin"
+        c.base_dir = "gitbin"
         c.smoke_test do
-	  tmpdir do |cwd|
-            sh!("#{embedded_bin("git")} config -l")
-	    sh!("#{embedded_bin("git")} clone https://github.com/chef/chef-provisioning", cwd: cwd)
+      	  tmpdir do |cwd|
+            sh!("#{File.join(omnibus_root, "gitbin", "git")} config -l")
+      	    sh!("#{File.join(omnibus_root, "gitbin", "git")} clone https://github.com/chef/chef-provisioning", cwd: cwd)
 
-	    # # If /usr/bin/git is a symlink, fail the test.
-	    # # Note that this test cannot go last because it does not return a
-	    # # Mixlib::Shellout object in the windows case, which will break the tests.
-	    unless Chef::Platform.windows?
-             failure_str = "#{nix_platform_native_bin_dir}/git contains a symlink which might mean we accidentally overwrote system git via chefdk."
-             result = sh("readlink #{nix_platform_native_bin_dir}/git")
-             # if a symlink was found, test to see if it is in a chefdk install
-             if result.status.exitstatus == 0
+      	    # # If /usr/bin/git is a symlink, fail the test.
+      	    # # Note that this test cannot go last because it does not return a
+      	    # # Mixlib::Shellout object in the windows case, which will break the tests.
+      	    unless Chef::Platform.windows?
+              failure_str = "#{nix_platform_native_bin_dir}/git contains a symlink which might mean we accidentally overwrote system git via chefdk."
+              result = sh("readlink #{nix_platform_native_bin_dir}/git")
+              # if a symlink was found, test to see if it is in a chefdk install
+              if result.status.exitstatus == 0
                raise failure_str if result.stdout =~ /chefdk/
-             end
-	    end
-
-	    # <chef_dk>/bin/ should not contain a git binary.
-	    failure_str = "`<chef_dk>/bin/git --help` should fail as git should be installed in embedded/bin"
-	    fail_if_exit_zero(bin("git --help"), failure_str)
-	  end
+              end
+      	    end
+      	    # <chef_dk>/bin/ should not contain a git binary.
+      	    failure_str = "`<chef_dk>/bin/git --help` should fail as git should be installed in gitbin"
+      	    fail_if_exit_zero("#{bin("git")} --help", failure_str)
+      	  end
         end
       end
 

--- a/lib/chef-dk/helpers.rb
+++ b/lib/chef-dk/helpers.rb
@@ -98,6 +98,15 @@ module ChefDK
       File.join(usr_bin_prefix, command)
     end
 
+    # Unix users do not want git on their path if they already have it installed.
+    # Because we put `embedded/bin` on the path we must move the git binaries
+    # somewhere else that we can append to the end of the path.
+    # This is only a temporary solution - see https://github.com/chef/chef-dk/issues/854
+    # for a better proposed solution.
+    def git_bin_dir
+      @git_bin_dir ||= File.expand_path(File.join(omnibus_root, "gitbin"))
+    end
+
     # In our Windows ChefDK omnibus package we include Git For Windows, which
     # has a bunch of helpful unix utilties (like ssh, scp, etc.) bundled with it
     def git_windows_bin_dir
@@ -112,6 +121,7 @@ module ChefDK
         begin
           user_bin_dir = File.expand_path(File.join(Gem.user_dir, 'bin'))
           path = [ omnibus_bin_dir, user_bin_dir, omnibus_embedded_bin_dir, ENV['PATH'] ]
+          path << git_bin_dir if Dir.exists?(git_bin_dir)
           path << git_windows_bin_dir if Dir.exists?(git_windows_bin_dir)
           {
             'PATH' => path.join(File::PATH_SEPARATOR),

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "gitbin"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git"
 
 # pedump pessimistically pins multipart-post to a version from 2013 which makes
 # bundler very unhappy. Remove this when upstream has merged zed-0xff/pedump#6 .

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "gitbin"
 
 # pedump pessimistically pins multipart-post to a version from 2013 which makes
 # bundler very unhappy. Remove this when upstream has merged zed-0xff/pedump#6 .

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 1a54d651c10f271d8cbf51ac3378747468e998e6
-  branch: gitbin
+  revision: d6c10d3f94e368bc358b1ca0f1520642372910fd
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 32324e19b76f75d06c6e3c7333a8865c9b5767c3
+  revision: 1a54d651c10f271d8cbf51ac3378747468e998e6
+  branch: gitbin
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
@@ -38,12 +39,12 @@ GEM
     addressable (2.4.0)
     artifactory (2.3.2)
     awesome_print (1.7.0)
-    aws-sdk (2.3.15)
-      aws-sdk-resources (= 2.3.15)
-    aws-sdk-core (2.3.15)
+    aws-sdk (2.3.16)
+      aws-sdk-resources (= 2.3.16)
+    aws-sdk-core (2.3.16)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.15)
-      aws-sdk-core (= 2.3.15)
+    aws-sdk-resources (2.3.16)
+      aws-sdk-core (= 2.3.16)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -121,7 +122,7 @@ GEM
       mixlib-log
     mixlib-cli (1.6.0)
     mixlib-config (2.2.1)
-    mixlib-install (1.0.13)
+    mixlib-install (1.1.0)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -186,7 +187,7 @@ GEM
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
     systemu (2.6.5)
-    test-kitchen (1.10.0)
+    test-kitchen (1.10.2)
       mixlib-install (~> 1.0, >= 1.0.4)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)

--- a/omnibus/config/software/chef-dk-complete.rb
+++ b/omnibus/config/software/chef-dk-complete.rb
@@ -11,7 +11,7 @@ dependency "rust-uninstall"
 if windows?
   dependency "git-windows"
 else
-  dependency "git"
+  dependency "git-custom-bindir"
 end
 
 dependency "chef-dk"

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -1,0 +1,125 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOTE - This is a straight copy of the git.rb definition in omnibus-software
+# EXCEPT we specify a custom bindir when running make. We do this because
+# we only want to include the Git binaries at the end of a user's path
+# when they run `chef shell-init`. This is a temporary solution until we
+# shave the yak of moving ruby into /opt/chefdk/bin and putting
+# /opt/chefdk/embedded/bin at the end of the user's path.
+# TODO - when deleting this, also delete omnibus/config/templates/git-custom-bindir
+
+name "git-custom-bindir"
+default_version "2.8.2"
+
+license "LGPL-2.1"
+license_file "LGPL-2.1"
+
+dependency "curl"
+dependency "zlib"
+dependency "openssl"
+dependency "pcre"
+dependency "libiconv"
+dependency "expat"
+
+relative_path "git-#{version}"
+
+version "2.8.2" do
+  source md5: "3022d8ebf64b35b9704d5adf54b256f9"
+end
+
+source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  # We do a distclean so we ensure that the autoconf files are not trying to be
+  # clever.
+  make "distclean"
+
+  # AIX needs /opt/freeware/bin only for patch
+  if aix?
+    patch_env = env.dup
+    patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
+
+    # But only needs the below for 1.9.5
+    if version == "1.9.5"
+      patch source: "aix-strcmp-in-dirc.patch", plevel: 1, env: patch_env
+    end
+  end
+
+  config_hash = {
+    # Universal options
+    NO_GETTEXT: "YesPlease",
+    NEEDS_LIBICONV: "YesPlease",
+    NO_INSTALL_HARDLINKS: "YesPlease",
+    NO_PERL: "YesPlease",
+    NO_PYTHON: "YesPlease",
+    NO_TCLTK: "YesPlease",
+  }
+
+  if freebsd?
+    config_hash["CHARSET_LIB"] = "-lcharset"
+    config_hash["FREAD_READS_DIRECTORIES"] = "UnfortunatelyYes"
+    config_hash["HAVE_CLOCK_GETTIME"] = "YesPlease"
+    config_hash["HAVE_CLOCK_MONOTONIC"] = "YesPlease"
+    config_hash["HAVE_GETDELIM"] = "YesPlease"
+    config_hash["HAVE_PATHS_H"] = "YesPlease"
+    config_hash["HAVE_STRINGS_H"] = "YesPlease"
+    config_hash["PTHREAD_LIBS"] = "-pthread"
+    config_hash["USE_ST_TIMESPEC"] = "YesPlease"
+    config_hash["HAVE_BSD_SYSCTL"] = "YesPlease"
+    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
+  elsif solaris?
+    env["CC"] = "gcc"
+    env["SHELL_PATH"] = "#{install_dir}/embedded/bin/bash"
+    config_hash["NEEDS_SOCKET"] = "YesPlease"
+    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
+  elsif aix?
+    env["CC"] = "xlc_r"
+    env["INSTALL"] = "/opt/freeware/bin/install"
+    # xlc doesn't understand the '-Wl,-rpath' syntax at all so... we don't enable
+    # the NO_R_TO_GCC_LINKER flag. This means that it will try to use the
+    # old style -R for libraries and as a result, xlc will ignore it. In this case, we
+    # we want that to happen because we explicitly set the libpath with the correct
+    # command line argument in omnibus itself.
+  else
+    # Linux things!
+    config_hash["HAVE_PATHS_H"] = "YesPlease"
+    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
+  end
+
+  erb source: "config.mak.erb",
+      dest: "#{project_dir}/config.mak",
+      mode: 0755,
+      vars: {
+               cc: env["CC"],
+               ld: env["LD"],
+               cflags: env["CFLAGS"],
+               cppflags: env["CPPFLAGS"],
+               install: env["INSTALL"],
+               install_dir: install_dir,
+               ldflags: env["LDFLAGS"],
+               shell_path: env["SHELL_PATH"],
+               config_hash: config_hash,
+             }
+
+  # NOTE - If you run ./configure the environment variables set above will not be
+  # used and only the command line args will be used. The issue with this is you
+  # cannot specify everything on the command line that you can with the env vars.
+  make "prefix=#{install_dir}/embedded bindir=#{install_dir}/gitbin -j #{workers}", env: env
+  make "prefix=#{install_dir}/embedded bindir=#{install_dir}/gitbin install", env: env
+end

--- a/omnibus/config/templates/git-custom-bindir/config.mak.erb
+++ b/omnibus/config/templates/git-custom-bindir/config.mak.erb
@@ -1,0 +1,31 @@
+<%- if cc -%>
+CC=<%= cc %>
+<%-  end -%>
+<%- if ld -%>
+LD=<%= ld %>
+<%-  end -%>
+<%- if cflags -%>
+CFLAGS=<%= cflags %>
+<%-  end -%>
+<%- if cppflags -%>
+CPPFLAGS=<%= cppflags %>
+<%-  end -%>
+<%- if ldflags -%>
+LDFLAGS=<%= ldflags %>
+<%-  end -%>
+<%- if install -%>
+INSTALL=<%= install %>
+<%-  end -%>
+<%- if shell_path -%>
+SHELL_PATH=<%= shell_path %>
+<%-  end -%>
+CURLDIR=<%= install_dir %>/embedded
+EXPATDIR=<%= install_dir %>/embedded
+ICONVDIR=<%= install_dir %>/embedded
+LIBPCREDIR=<%= install_dir %>/embedded
+OPENSSLDIR=<%= install_dir %>/embedded
+ZLIB_PATH=<%= install_dir %>/embedded
+
+<%- config_hash.each_pair do |k, v| -%>
+<%= k.to_s %>=<%= v %>
+<%- end -%>

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -91,20 +91,29 @@ describe ChefDK::Helpers do
   end
 
   describe "omnibus_env" do
-    let(:git_partial_path) { File.join("embedded", "git", "usr", "bin") }
+    let(:git_tools_path) { File.join("embedded", "git", "usr", "bin") }
+    let(:custom_gitbin_path) { File.join("gitbin") }
     before do
       allow(helpers).to receive(:omnibus_expand_path) {|*paths| File.expand_path(File.join(paths)) }
-      allow(Dir).to receive(:exists?).with(/#{git_partial_path}/).and_return false
+      allow(Dir).to receive(:exists?).with(/#{custom_gitbin_path}/).and_return false
+      allow(Dir).to receive(:exists?).with(/#{git_tools_path}/).and_return false
     end
 
     it "does not include the git tools in the path" do
-      expect(helpers.omnibus_env['PATH']).to_not match(/#{git_partial_path}/)
+      expect(helpers.omnibus_env['PATH']).to_not match(/#{git_tools_path}/)
+    end
+
+    context "when the custom gitbin directory exists" do
+      it "includes them in the path" do
+        expect(Dir).to receive(:exists?).with(/#{custom_gitbin_path}/).and_return true
+        expect(helpers.omnibus_env['PATH']).to match(/#{custom_gitbin_path}$/)
+      end
     end
 
     context "when the git tools directory exists" do
       it "includes them in the path" do
-        expect(Dir).to receive(:exists?).with(/#{git_partial_path}/).and_return true
-        expect(helpers.omnibus_env['PATH']).to match(/#{git_partial_path}/)
+        expect(Dir).to receive(:exists?).with(/#{git_tools_path}/).and_return true
+        expect(helpers.omnibus_env['PATH']).to match(/#{git_tools_path}$/)
       end
     end
   end


### PR DESCRIPTION
 So we do not overwrite user's Git

\cc @danielsdeleo @tylercloke @charlesjohnson @afiune 

Fixes https://github.com/chef/chef-dk/issues/854

I realize this is the OPPOSITE of the solution we want, but I want to do this for now and then address the real fix when we have time to in July/August.