### PR TITLE
Fix recipe in code_generator skeleton

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -130,6 +130,6 @@ end
 
 if context.enable_delivery
 
-  include_recipe "code_generator::build_cookbook"
+  include_recipe "::build_cookbook"
 
 end


### PR DESCRIPTION
Do not hard code the cookbook name. Instead use no-name so that
end-users can generate a generator that is not `code_generator`