### PR TITLE
Update deps and lock activesupport <5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2016 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,9 @@ group(:omnibus_package) do
   # Until listen supports Ruby 2.0 and 2.1
   gem "listen", "< 3.1.0"
   gem "mixlib-install"
+
+  # until dk runs on ruby 2.2.2+
+  gem "activesupport", "< 5.0"
 
   # For Delivery build node
   gem "chef-sugar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,10 @@ GIT
       win32-service (~> 0.8.7)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
+    chef-config (12.11.18)
+      fuzzyurl (~> 0.8.0)
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
 
 GIT
   remote: git://github.com/chef/opscode-pushy-client.git
@@ -120,12 +124,12 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.3.18)
-      aws-sdk-resources (= 2.3.18)
-    aws-sdk-core (2.3.18)
+    aws-sdk (2.3.19)
+      aws-sdk-resources (= 2.3.19)
+    aws-sdk-core (2.3.19)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.18)
-      aws-sdk-core (= 2.3.18)
+    aws-sdk-resources (2.3.19)
+      aws-sdk-core (= 2.3.19)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -168,10 +172,6 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.11.18)
-      fuzzyurl (~> 0.8.0)
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
     chef-provisioning (1.8.0)
       cheffish (>= 1.3.1, < 3.0)
       inifile (>= 2.0.2)
@@ -199,11 +199,11 @@ GEM
       chef-provisioning
     chef-sugar (3.3.0)
     chef-vault (2.9.0)
-    chef-zero (4.6.2)
+    chef-zero (4.7.0)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
       mixlib-log (~> 1.3)
-      rack
+      rack (< 2)
       uuidtools (~> 2.1)
     cheffish (2.0.4)
       chef-zero (~> 4.3)
@@ -215,6 +215,7 @@ GEM
     cleanroom (1.0.0)
     coderay (1.1.1)
     compat_resource (12.10.6)
+    concurrent-ruby (1.0.2)
     cookbook-omnifetch (0.2.3)
       minitar (~> 0.5.4)
     cookstyle (0.0.1)
@@ -533,7 +534,7 @@ GEM
       shellany (~> 0.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.17.0)
+    ohai (8.17.1)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -654,7 +655,7 @@ GEM
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
-    specinfra (2.59.3)
+    specinfra (2.59.4)
       net-scp
       net-ssh (>= 2.7, < 4.0)
       net-telnet
@@ -748,6 +749,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  activesupport (< 5.0)
   appbundler!
   artifactory
   berkshelf


### PR DESCRIPTION
activesupport 5 requires Ruby 2.2.2 or later. Until chefdk runs on 2.2.X
we need to stick with the 4.X release. This also bumps the deps to bring
in the latest chef-zero and ohai releases.

Signed-off-by: Tim Smith <tsmith@chef.io>