### PR TITLE
Update cookbook generator to create project.toml

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
@@ -1,0 +1,21 @@
+# Delivery Prototype for Local Phases Execution
+#
+# The purpose of this file is to prototype a new way to execute
+# phases locally on your workstation. The delivery-cli will read
+# this file and execute the command(s) that are configured for
+# each phase. You can customize them by just modifying the phase
+# key on this file.
+#
+# By default these phases are configured for Cookbook Workflow only
+#
+# As this is still a prototype we are not modifying the current
+# config.json file and it will continue working as usual. 
+
+[local_phases]
+unit = "rspec spec/"
+lint = "cookstyle"
+syntax = "foodcritic . --exclude spec -f any"
+provision = "chef exec kitchen create"
+deploy = "chef exec kitchen converge"
+smoke = "chef exec kitchen verify"
+cleanup = "chef exec kitchen destroy"

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -11,6 +11,11 @@ cookbook_file File.join(dot_delivery_dir, "config.json") do
   source "delivery-config.json"
 end
 
+# Adding a new prototype file for delivery-cli local commands
+cookbook_file File.join(dot_delivery_dir, "project.toml") do
+  source "delivery-project.toml"
+end
+
 generator_desc("Ensuring correct delivery build cookbook content")
 
 build_cookbook_dir = File.join(dot_delivery_dir, "build_cookbook")
@@ -114,6 +119,15 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
 
   execute("git-add-delivery-config-json") do
     command("git add .delivery/config.json")
+    cwd delivery_project_dir
+
+    only_if "git status --porcelain |grep \".\""
+  end
+
+  # Adding the new prototype file to the feature branch
+  # so it gets checked in with the delivery config commit
+  execute("git-add-delivery-project-toml") do
+    command("git add .delivery/project.toml")
     cwd delivery_project_dir
 
     only_if "git status --porcelain |grep \".\""

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -174,6 +174,42 @@ EOF
         end
       end
 
+      describe ".delivery/project.toml" do
+
+        let(:file) { File.join(tempdir, "new_cookbook", ".delivery", "project.toml") }
+
+        let(:expected_content) do
+          <<-PROJECT_DOT_TOML
+# Delivery Prototype for Local Phases Execution
+#
+# The purpose of this file is to prototype a new way to execute
+# phases locally on your workstation. The delivery-cli will read
+# this file and execute the command(s) that are configured for
+# each phase. You can customize them by just modifying the phase
+# key on this file.
+#
+# By default these phases are configured for Cookbook Workflow only
+#
+# As this is still a prototype we are not modifying the current
+# config.json file and it will continue working as usual. 
+
+[local_phases]
+unit = "rspec spec/"
+lint = "cookstyle"
+syntax = "foodcritic . --exclude spec -f any"
+provision = "chef exec kitchen create"
+deploy = "chef exec kitchen converge"
+smoke = "chef exec kitchen verify"
+cleanup = "chef exec kitchen destroy"
+  PROJECT_DOT_TOML
+        end
+
+        it "exists with default config for Cookbook Workflow" do
+          expect(IO.read(file)).to eq(expected_content)
+        end
+
+      end
+
       describe ".delivery/config.json" do
 
         let(:file) { File.join(tempdir, "new_cookbook", ".delivery", "config.json") }


### PR DESCRIPTION
Now `chef generate cookbook` creates a `.delivery/project.toml` file
that is a prototype for our newest `delivery local [phase]` command
(comming up) that will do the execution of configurable local phases
on your workstation.