### PR TITLE
Fix up inspec generated content.

### DIFF
--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -100,7 +100,7 @@ module ChefDK
             msg("\nThere are several commands you can run to get started locally developing and testing your cookbook.")
             msg("Type `delivery local --help` to see a full list.")
             msg("\nWhy not start by writing a test? Tests for the default recipe are stored at:\n")
-            msg("test/recipes/default_spec.rb")
+            msg("test/recipes/default_test.rb")
             msg("\nIf you'd prefer to dive right in, the default recipe can be found at:")
             msg("\nrecipes/default.rb\n")
           end

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -100,7 +100,7 @@ module ChefDK
             msg("\nThere are several commands you can run to get started locally developing and testing your cookbook.")
             msg("Type `delivery local --help` to see a full list.")
             msg("\nWhy not start by writing a test? Tests for the default recipe are stored at:\n")
-            msg("test/integration/default/default_spec.rb")
+            msg("test/recipes/default_spec.rb")
             msg("\nIf you'd prefer to dive right in, the default recipe can be found at:")
             msg("\nrecipes/default.rb\n")
           end

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -21,8 +21,8 @@ directory "#{app_dir}/test/recipes" do
   recursive true
 end
 
-template "#{app_dir}/test/recipes/default_spec.rb" do
-  source 'inspec_default_spec.rb.erb'
+template "#{app_dir}/test/recipes/default_test.rb" do
+  source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -17,11 +17,11 @@ template "#{app_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{app_dir}/test/integration/default" do
+directory "#{app_dir}/test/recipes" do
   recursive true
 end
 
-template "#{app_dir}/test/integration/default/default_spec.rb" do
+template "#{app_dir}/test/recipes/default_spec.rb" do
   source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -55,11 +55,11 @@ template "#{cookbook_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{cookbook_dir}/test/integration/default" do
+directory "#{cookbook_dir}/test/recipes" do
   recursive true
 end
 
-template "#{cookbook_dir}/test/integration/default/default_spec.rb" do
+template "#{cookbook_dir}/test/recipes/default_spec.rb" do
   source 'inspec_default_spec.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -59,8 +59,8 @@ directory "#{cookbook_dir}/test/recipes" do
   recursive true
 end
 
-template "#{cookbook_dir}/test/recipes/default_spec.rb" do
-  source 'inspec_default_spec.rb.erb'
+template "#{cookbook_dir}/test/recipes/default_test.rb" do
+  source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -4,6 +4,7 @@ cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 recipe_path = File.join(cookbook_dir, "recipes", "#{context.new_file_basename}.rb")
 spec_helper_path = File.join(cookbook_dir, "spec", "spec_helper.rb")
 spec_path = File.join(cookbook_dir, "spec", "unit", "recipes", "#{context.new_file_basename}_spec.rb")
+inspec_path = File.join(cookbook_dir, "test", "recipes", "#{context.new_file_basename}.rb")
 
 # Chefspec
 directory "#{cookbook_dir}/spec/unit/recipes" do
@@ -20,8 +21,20 @@ template spec_path do
   action :create_if_missing
 end
 
+# Inspec
+directory "#{cookbook_dir}/test/recipes" do
+  recursive true
+end
+
+template inspec_path do
+  source 'inspec_default_spec.rb.erb'
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
 # Recipe
 template recipe_path do
   source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
 end
+

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -27,7 +27,7 @@ directory "#{cookbook_dir}/test/recipes" do
 end
 
 template inspec_path do
-  source 'inspec_default_spec.rb.erb'
+  source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_spec.rb.erb
@@ -1,7 +1,18 @@
-describe '<%= cookbook_name %>::default' do
-  # The Inspec reference, with examples and extensive documentation, can be
-  # found at https://docs.chef.io/inspec_reference.html
-  it 'does something' do
-    skip 'Replace this with meaningful tests'
+# # encoding: utf-8
+
+# Inspec test for recipe COOKBOOKNAME::RECIPENAME
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
   end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
@@ -1,6 +1,6 @@
 # # encoding: utf-8
 
-# Inspec test for recipe COOKBOOKNAME::RECIPENAME
+# Inspec test for recipe <%= cookbook_name %>::<%= recipe_name %>
 
 # The Inspec reference, with examples and extensive documentation, can be
 # found at https://docs.chef.io/inspec_reference.html

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -7,7 +7,6 @@ provisioner:
 
 verifier:
   name: inspec
-  format: doc
 
 platforms:
   - name: ubuntu-16.04

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -20,7 +20,6 @@ provisioner:
 
 verifier:
   name: inspec
-  format: doc
 
 platforms:
   - name: ubuntu-16.04

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -32,7 +32,7 @@ describe ChefDK::Command::GeneratorCommands::App do
       .kitchen.yml
       test
       test/recipes
-      test/recipes/default_spec.rb
+      test/recipes/default_test.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore
@@ -128,8 +128,8 @@ describe ChefDK::Command::GeneratorCommands::App do
         end
       end
 
-      describe "test/recipes/default_spec.rb" do
-        let(:file) { File.join(tempdir, "new_app", "test", "recipes", "default_spec.rb") }
+      describe "test/recipes/default_test.rb" do
+        let(:file) { File.join(tempdir, "new_app", "test", "recipes", "default_test.rb") }
 
         include_examples "a generated file", :cookbook_name do
           let(:line) { "describe port" }

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -31,9 +31,8 @@ describe ChefDK::Command::GeneratorCommands::App do
       .gitignore
       .kitchen.yml
       test
-      test/integration
-      test/integration/default
-      test/integration/default/default_spec.rb
+      test/recipes
+      test/recipes/default_spec.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore
@@ -129,11 +128,11 @@ describe ChefDK::Command::GeneratorCommands::App do
         end
       end
 
-      describe "test/integration/default/default_spec.rb" do
-        let(:file) { File.join(tempdir, "new_app", "test", "integration", "default", "default_spec.rb") }
+      describe "test/recipes/default_spec.rb" do
+        let(:file) { File.join(tempdir, "new_app", "test", "recipes", "default_spec.rb") }
 
         include_examples "a generated file", :cookbook_name do
-          let(:line) { "describe 'new_app::default' do" }
+          let(:line) { "describe port" }
         end
       end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -35,7 +35,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       .kitchen.yml
       test
       test/recipes
-      test/recipes/default_spec.rb
+      test/recipes/default_test.rb
       Berksfile
       chefignore
       metadata.rb
@@ -65,7 +65,7 @@ Type `delivery local --help` to see a full list.
 
 Why not start by writing a test? Tests for the default recipe are stored at:
 
-test/recipes/default_spec.rb
+test/recipes/default_test.rb
 
 If you'd prefer to dive right in, the default recipe can be found at:
 
@@ -463,8 +463,8 @@ OUTPUT
 
         end
 
-        describe "test/recipes/default_spec.rb" do
-          let(:file) { File.join(tempdir, "new_cookbook", "test", "recipes", "default_spec.rb") }
+        describe "test/recipes/default_test.rb" do
+          let(:file) { File.join(tempdir, "new_cookbook", "test", "recipes", "default_test.rb") }
 
           include_examples "a generated file", :cookbook_name do
             let(:line) { "describe port" }

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -34,9 +34,8 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       .gitignore
       .kitchen.yml
       test
-      test/integration
-      test/integration/default
-      test/integration/default/default_spec.rb
+      test/recipes
+      test/recipes/default_spec.rb
       Berksfile
       chefignore
       metadata.rb
@@ -66,7 +65,7 @@ Type `delivery local --help` to see a full list.
 
 Why not start by writing a test? Tests for the default recipe are stored at:
 
-test/integration/default/default_spec.rb
+test/recipes/default_spec.rb
 
 If you'd prefer to dive right in, the default recipe can be found at:
 
@@ -464,11 +463,11 @@ OUTPUT
 
         end
 
-        describe "test/integration/default/default_spec.rb" do
-          let(:file) { File.join(tempdir, "new_cookbook", "test", "integration", "default", "default_spec.rb") }
+        describe "test/recipes/default_spec.rb" do
+          let(:file) { File.join(tempdir, "new_cookbook", "test", "recipes", "default_spec.rb") }
 
           include_examples "a generated file", :cookbook_name do
-            let(:line) { "describe 'new_cookbook::default' do" }
+            let(:line) { "describe port" }
           end
         end
       end
@@ -565,7 +564,6 @@ provisioner:
 
 verifier:
   name: inspec
-  format: doc
 
 platforms:
   - name: ubuntu-16.04
@@ -634,7 +632,6 @@ provisioner:
 
 verifier:
   name: inspec
-  format: doc
 
 platforms:
   - name: ubuntu-16.04
@@ -683,7 +680,7 @@ SPEC_HELPER
       let(:file) { File.join(tempdir, "new_cookbook", "spec", "unit", "recipes", "default_spec.rb") }
 
       include_examples "a generated file", :cookbook_name do
-        let(:line) { "describe \'new_cookbook::default\' do" }
+        let(:line) { "describe 'new_cookbook::default' do" }
       end
     end
 

--- a/spec/unit/command/generator_commands/recipe_spec.rb
+++ b/spec/unit/command/generator_commands/recipe_spec.rb
@@ -26,7 +26,9 @@ describe ChefDK::Command::GeneratorCommands::Recipe do
     let(:generator_name) { "recipe" }
     let(:generated_files) { [ "recipes/new_recipe.rb",
                               "spec/spec_helper.rb",
-                              "spec/unit/recipes/new_recipe_spec.rb" ] }
+                              "spec/unit/recipes/new_recipe_spec.rb",
+                              "test/recipes/new_recipe.rb"
+                            ] }
     let(:new_file_name) { "new_recipe" }
 
   end


### PR DESCRIPTION
+ mv test/integration/default/default_spec.rb -> test/recipes/default_test.rb.
+ Update the default inspec test to support windows and nix.
+ Remove doc inspec format from .kitchen.yml.
+ Have `chef generate recipe <path> <recipe_name>` make a test/recipes/<recipe_name>.rb file with the updated default inspec test content.