### PR TITLE
Disable foodcritic rules which check for issues_url and source_url in metadata.rb

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
@@ -9,12 +9,15 @@
 # By default these phases are configured for Cookbook Workflow only
 #
 # As this is still a prototype we are not modifying the current
-# config.json file and it will continue working as usual. 
+# config.json file and it will continue working as usual.
 
 [local_phases]
 unit = "rspec spec/"
 lint = "cookstyle"
-syntax = "foodcritic . --exclude spec -f any"
+# Foodcritic expects an `issues_url` and `source_url` in the metadata.rb
+# We turn this off by default because only cookbooks uploaded to the
+# Supermarket will have these added.
+syntax = "foodcritic . --exclude spec -f any -t \"~FC064\" -t \"~FC065\""
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"

--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -5,3 +5,11 @@ license '<%= license %>'
 description 'Installs/Configures <%= cookbook_name %>'
 long_description 'Installs/Configures <%= cookbook_name %>'
 version '0.1.0'
+
+# If you upload to Supermarket you should set this so your cookbook
+# gets a `View Issues` link
+# issues_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>/issues' if respond_to?(:issues_url)
+
+# If you upload to Supermarket you should set this so your cookbook
+# gets a `View Source` link
+# source_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>' if respond_to?(:source_url)

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -190,12 +190,15 @@ EOF
 # By default these phases are configured for Cookbook Workflow only
 #
 # As this is still a prototype we are not modifying the current
-# config.json file and it will continue working as usual. 
+# config.json file and it will continue working as usual.
 
 [local_phases]
 unit = "rspec spec/"
 lint = "cookstyle"
-syntax = "foodcritic . --exclude spec -f any"
+# Foodcritic expects an `issues_url` and `source_url` in the metadata.rb
+# We turn this off by default because only cookbooks uploaded to the
+# Supermarket will have these added.
+syntax = "foodcritic . --exclude spec -f any -t \\\"~FC064\\\" -t \\\"~FC065\\\""
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"
@@ -664,7 +667,7 @@ SPEC_HELPER
       let(:file) { File.join(tempdir, "new_cookbook", "metadata.rb") }
 
       include_examples "a generated file", :cookbook_name do
-        let(:line) { /name\s+'new_cookbook'/ }
+        let(:line) { /name\s+'new_cookbook'.+# issues_url.+# source_url/m }
       end
     end
 


### PR DESCRIPTION
They are only used by cookbooks uploaded to Supermarket so users need to opt into this. Put an example in metadata.rb

Just a note: Ideally, Supermarket would be the one to enforce these rules.

\cc @danielsdeleo @afiune @tylercloke 