### PR TITLE
Add Dockerfile to Chef-DK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.3.1
+MAINTAINER Kevin Reedy <kreedy@chef.io>
+
+RUN apt-get update && apt-get install -y fakeroot
+
+ADD . /opt/chefdk-build
+
+WORKDIR /opt/chefdk-build/omnibus
+RUN bundle install --without development
+RUN git config --global user.email "nobody@chef.io" && git config --global user.name "Chef"
+RUN bundle exec omnibus build chefdk && bundle exec omnibus clean chefdk
+
+WORKDIR /root
+RUN echo 'eval "$(/opt/chefdk/bin/chef shell-init bash)"' >> /root/.bashrc
+CMD /bin/bash


### PR DESCRIPTION
Add a Dockerfile to Chef-DK to promote better use of Chef in Docker-based pipelines and allow for testing newer (or older) versions of Chef-DK without having to install to your system.

Note: `git config` is required for the omnibus build. I'm happy to update this to better values, though I don't believe these values actually persist anywhere in the image.

Output of a docker build using this Dockerfile:
```
kreedy@Kevins-iMac:~/Projects/kevinreedy/chef-dk$ git log --pretty=oneline | head -n 3
ab09aeb9b8022d039a4d4b00d3f368c19be18e0e Add Dockerfile
ca00f402aef82b6d67a00962b15e8e6186474179 Bump version of chef-dk to 0.17.3 by Chef Versioner.
e0372f5e005facb303439fe30d2c0dc0d31d88bb Merge pull request #942 from chef/afiune/FLOW-444/consume-delivery-truck-from-supermarket
kreedy@Kevins-iMac:~/Projects/kevinreedy/chef-dk$ docker build --no-cache -t tmpdk . && docker run -it --rm tmpdk

[snip]

Successfully built 8d9c25245738
root@99a61a52f561:~# which chef
/opt/chefdk/bin/chef
root@99a61a52f561:~# chef --version
Chef Development Kit Version: 0.17.3
chef-client version: 12.12.15
delivery version: master (f68e5c5804cd7d8a76c69b926fbb261e1070751b)
berks version: 4.3.5
kitchen version: 1.10.2
```