### PR TITLE
Updating the delivery local syntax test to use the new defaults introduced

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
@@ -18,7 +18,7 @@ lint = "chef exec cookstyle"
 # uploaded to Supermarket. We turn off any rules tagged "supermarket"
 # by default. If you plan to share this cookbook you should remove
 # '-t ~supermarket' below to enable supermarket rules.
-syntax = "chef exec foodcritic . --exclude spec -f any -t ~supermarket"
+syntax = "chef exec foodcritic . -t ~supermarket"
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -198,7 +198,7 @@ lint = "chef exec cookstyle"
 # uploaded to Supermarket. We turn off any rules tagged "supermarket"
 # by default. If you plan to share this cookbook you should remove
 # '-t ~supermarket' below to enable supermarket rules.
-syntax = "chef exec foodcritic . --exclude spec -f any -t ~supermarket"
+syntax = "chef exec foodcritic . -t ~supermarket"
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"


### PR DESCRIPTION
Depends on https://github.com/acrmp/foodcritic/pull/462

TODO:
- [ ] Test this with the new foodcritic updates

\cc @afiune @charlesjohnson @danielsdeleo @tylercloke 
