### PR TITLE
Add policyfile stuff to chefignore

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -82,6 +82,11 @@ Berksfile.lock
 cookbooks/*
 tmp
 
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
 # Cookbooks #
 #############
 CONTRIBUTING*


### PR DESCRIPTION
Resolves an issue where the Policyfile.lock.json is included as an input
to a cookbook's identifier hash so changes to informational-only
information (such as git commits) causes the `revision_id` to be
updated.

Addresses one of the issues in https://github.com/chef/chef-dk/pull/880
