### PR TITLE
guard against branch already existing when creating a build cookbook

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -115,6 +115,8 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
   execute("git-create-feature-branch") do
     command("git checkout -t -b add-delivery-configuration")
     cwd delivery_project_dir
+    
+    not_if "git branch |grep \"add-delivery-configuration\""
   end
 
   execute("git-add-delivery-config-json") do


### PR DESCRIPTION
- added a not_if guard to the generator to avoid attempting to create the branch if it already exists
