### PR TITLE
Fix mixlib-cli dependency to match https://github.com/chef/chef/pull/5045

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ PATH
       diff-lcs (~> 1.0)
       ffi-yajl (>= 1.0, < 3.0)
       minitar (~> 0.5.4)
-      mixlib-cli (~> 1.5, < 1.7)
+      mixlib-cli (~> 1.7)
       mixlib-shellout (~> 2.0)
       paint (~> 1.0)
       solve (~> 2.0, >= 2.0.1)
@@ -491,7 +491,7 @@ GEM
       mixlib-log
     mixlib-authentication (1.4.1)
       mixlib-log
-    mixlib-cli (1.6.0)
+    mixlib-cli (1.7.0)
     mixlib-config (2.2.1)
     mixlib-install (1.1.0)
       artifactory

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "mixlib-cli", "~> 1.5", "< 1.7"
+  gem.add_dependency "mixlib-cli", "~> 1.7"
   gem.add_dependency "mixlib-shellout", "~> 2.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
 


### PR DESCRIPTION
I think this should be safe, the 1.7 pin was in response to a similar pin on Chef (I think at least)

/cc @mwrock