### PR TITLE
Add .kitchen.yml to find generated inspec tests.

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -16,4 +16,7 @@ suites:
   - name: default
     run_list:
       - recipe[<%= cookbook_name %>::default]
+    verifier:
+      inspec_tests:
+        - test/recipes
     attributes:

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -27,4 +27,7 @@ platforms:
 
 suites:
   - name: default
+    verifier:
+      inspec_tests:
+        - test/recipes
     attributes:

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -565,6 +565,9 @@ platforms:
 
 suites:
   - name: default
+    verifier:
+      inspec_tests:
+        - test/recipes
     attributes:
 KITCHEN_YML
         end
@@ -635,6 +638,9 @@ suites:
   - name: default
     run_list:
       - recipe[new_cookbook::default]
+    verifier:
+      inspec_tests:
+        - test/recipes
     attributes:
 KITCHEN_YML
         end


### PR DESCRIPTION
(We will likely change the location in the future to avoid this
directive, but for now want the current location to work.)