### PR TITLE
Keep static libraries deleted in jenkins builds

### DIFF
--- a/omnibus/config/software/chef-dk-complete.rb
+++ b/omnibus/config/software/chef-dk-complete.rb
@@ -32,5 +32,3 @@ dependency "rubygems-customization"
 dependency "shebang-cleanup"
 dependency "version-manifest"
 dependency "openssl-customization"
-
-dependency "clean-static-libs"


### PR DESCRIPTION
From what I can tell by looking at jenkins build logs, Windows is the only platform where actual files are deleted by this build delendency defined [here](https://github.com/chef/omnibus-software/blob/master/config/software/clean-static-libs.rb). The files deleted on Windows are:
```
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodedriver.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodeint.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodekernel.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodeminimodel.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodesearch.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodeset.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/dep-selector-libgecode-1.3.1/lib/dep-selector-libgecode/vendored-gecode/lib/libgecodesupport.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/libyajl2-1.2.0/ext/libyajl2/libyajldll.a
Deleting C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/libyajl2-1.2.0/lib/libyajl2/vendored-libyajl2/lib/libyajldll.a
```
The `ffi-yajl` gem depends on these libraries. So if a user attempts to install a different version of lib-yajl or a gem that depends on it, they will receive compilation errors blocking the install.