### PR TITLE
Fix RuboCop on generated build cookbooks

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/test-fixture-recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/test-fixture-recipe.rb
@@ -1,6 +1,7 @@
 %w(unit lint syntax).each do |phase|
+  args = "--server localhost --ent test --org kitchen"
   # TODO: This works on Linux/Unix. Not Windows.
-  execute "HOME=/home/vagrant delivery job verify #{phase} --server localhost --ent test --org kitchen" do
+  execute "HOME=/home/vagrant delivery job verify #{phase} #{args}" do
     cwd '/tmp/repo-data'
     user 'vagrant'
   end

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -87,8 +87,7 @@ directory "#{build_cookbook_dir}/test/fixtures/cookbooks/test/recipes" do
 end
 
 file "#{build_cookbook_dir}/test/fixtures/cookbooks/test/metadata.rb" do
-  content %(name 'test'
-version '0.1.0')
+  content %(name 'test'\nversion '0.1.0'\n)
 end
 
 cookbook_file "#{build_cookbook_dir}/test/fixtures/cookbooks/test/recipes/default.rb" do


### PR DESCRIPTION
This adds a final newline to `metadata.rb` and refactors
`test-fixture-recipe.rb` to be less that 80 columns.

Without this `chef exec rubocop .delivery` will show complaints on a 
generated `build_cookbook`
