### PR TITLE
Add error message for invalid license settings

### DIFF
--- a/lib/chef-dk/generator.rb
+++ b/lib/chef-dk/generator.rb
@@ -72,7 +72,7 @@ module ChefDK
       # preamble to a file. Optionally specify a comment to prepend to each line.
       def license_description(comment=nil)
         case license
-        when 'all_rights'
+        when 'all_rights', 'none'
           result = "Copyright (c) #{year} #{copyright_holder}, All Rights Reserved."
         when 'apachev2'
           result = <<-EOH
@@ -149,6 +149,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 EOH
+        else
+          raise ArgumentError, "Invalid generator.license setting: #{license}.  See available licenses at https://docs.chef.io/ctl_chef.html#chef-generate-cookbook"
         end
         if comment
           # Ensure there's no trailing whitespace


### PR DESCRIPTION
This allows someone setting an invalid license parameter on the generator to receive a more meaningful error and give a location to find valid values.

I didn't find a good reference for the generator settings and when entering none based on the config.rb talk it causes an undefined method error due to result not having a value.

The alternative approach I think of with this would be to have `none` behave the same as all_rights, but that might require deprecation notices and wouldn't handle other invalid cases someone may try to use.

referenced docs: 
https://docs.chef.io/config_rb.html  (shows none albeit for a different setting)
https://docs.chef.io/ctl_chef.html#chef-generate-cookbook  (shows all_rights as the default)

Command output before:

```
C:\Users\slarson\cookbooks                                                                                                              
λ chef generate cookbook dt_test                                                                                                        
Generating cookbook dt_test                                                                                                             
- Ensuring correct cookbook file content                                                                                                

================================================================================                                                        
Error executing action `create_if_missing` on resource 'template[C:/Users/slarson/cookbooks/dt_test/spec/unit/recipes/default_spec.rb]' 
================================================================================                                                        

Chef::Mixin::Template::TemplateError                                                                                                    
------------------------------------                                                                                                    
undefined method `gsub' for nil:NilClass                                                                                                

Resource Declaration:                                                                                                                   
---------------------                                                                                                                   
# In C:\Users\slarson\.chef\dt_generator\recipes\cookbook.rb                                                          

 84: template "#{cookbook_dir}/spec/unit/recipes/default_spec.rb" do
 85:   source "recipe_spec.rb.erb"
 86:   helpers(ChefDK::Generator::TemplateHelper)                                                                                       
 87:   action :create_if_missing
 88: end                                                                                           
 89: 

Compiled Resource:                                                                                                       
------------------                                                                                                                      
# Declared in C:\Users\slarson\.chef\dt_generator\recipes\cookbook.rb:84:in `from_file'

template("C:/Users/slarson/cookbooks/dt_test/spec/unit/recipes/default_spec.rb") do
  action [:create_if_missing]                   
  retries 0                                                                                                   
  retry_delay 2
  default_guard_interpreter :default
  source "recipe_spec.rb.erb"
  helper_modules [ChefDK::Generator::TemplateHelper]
  declared_type :template                                                                  
  cookbook_name :dt_generator
  recipe_name "cookbook"
  path "C:/Users/slarson/cookbooks/dt_test/spec/unit/recipes/default_spec.rb"
end                     

Template Context:
-----------------  
on line #5
  3: # Spec:: default
  4: # 
  5: <%= license_description('#') %>
  6: 
  7: require 'spec_helper'

Platform: 
--------- 
i386-mingw32

ERROR: Chef failed to converge:
Chef::Mixin::Template::TemplateError (undefined method `gsub' for nil:NilClass) on line #5:

  3: # Spec:: default
  4: #                                                                                                                                  
  5: <%= license_description('#') %>                                                                                                    
  6:                                                                                                                                    
  7: require 'spec_helper'                                                                                                              

  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/generator.rb:155:in `license_description'             
  (erubis):5:in `block in evaluate'                                                                                                     
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:74:in `instance_eval'                        
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:74:in `evaluate'                             
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/mixin/template.rb:161:in `_render_templat
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/mixin/template.rb:147:in `render_template
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/template/content.rb:53:in `file_
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/file_content_management/content_base.rb:4
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:462:in `tempfile'       
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:339:in`do_generate_cont
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:150:in`action_create'  
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:162:in`action_create_if
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider.rb:145:in `run_action'          
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource.rb:591:in `run_action'          
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:69:in `run_action'             
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:97:in `block (2 levels) in conv
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:97:in `each'                   
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:97:in `block in converge'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/resource_list.rb:94:ie_each_resource'                                                                                                   
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:tor_block'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:ndex'                                                                                                                                   
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/resource_list.rb:92:isource'
  C:/opscode/chefdk/embedded/lib/ruby/2.1.0/forwardable.rb:183:in `execute_each_resource'                                               
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:96:in `converge'               
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/chef_runner.rb:43:in `converge'                       
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/command/generator_commands/cookbook.rb:82:in`run'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/command/generate.rb:88:in `run'                       
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/command/base.rb:58:in`run_with_default_options'      
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/cli.rb:73:in `run'                                    
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/bin/chef:25:in `<top (required)>'                                 
  C:/opscode/chefdk/bin/chef:85:in `load'                                                                                               
  C:/opscode/chefdk/bin/chef:85:in `<main>'                                                                                             


Caused by: (Chef::Mixin::Template::TemplateError) undefined method `gsub' for nil:NilClass                                              
```

Output after:

```
C:\Users\slarson\cookbooks                                                                                                                                                           
λ rm -rf dt_test\                                                                                                                                                                    

C:\Users\slarson\cookbooks                                                                                                                                                           
λ chef generate cookbook dt_test                                                                                                                                                     
Generating cookbook dt_test                                                                                                                                                          
- Ensuring correct cookbook file content                                                                                                                                             

================================================================================                                                                                                     
Error executing action `create_if_missing` on resource 'template[C:/Users/slarson/cookbooks/dt_test/spec/unit/recipes/default_spec.rb]'                                              
================================================================================                                                                                                     

Chef::Mixin::Template::TemplateError                                                                                                                                                 
------------------------------------                                                                                                                                                 
Invalid generator.license setting: none.  See available licenses at https://docs.chef.io/ctl_chef.html#chef-generate-cookbook                                                        

Resource Declaration:                                                                                                                                                                
---------------------                                                                                                                                                                
# In C:\Users\slarson\.chef\dt_generator\recipes\cookbook.rb                                                                                                                         

 84: template "#{cookbook_dir}/spec/unit/recipes/default_spec.rb" do                                                                                                                 
 85:   source "recipe_spec.rb.erb"                                                                                                                                                   
 86:   helpers(ChefDK::Generator::TemplateHelper)                                                                                                                                    
 87:   action :create_if_missing                                                                                                                                                     
 88: end                                                                                                                                                                             
 89:                                                                                                                                                                                 

Compiled Resource:                                                                                                                                                                   
------------------                                                                                                                                                                   
# Declared in C:\Users\slarson\.chef\dt_generator\recipes\cookbook.rb:84:in `from_file'                                                                                              

template("C:/Users/slarson/cookbooks/dt_test/spec/unit/recipes/default_spec.rb") do                                                                                                  
  action [:create_if_missing]                                                                                                                                                        
  retries 0                                                                                                                                                                          
  retry_delay 2                                                                                                                                                                      
  default_guard_interpreter :default                                                                                                                                                 
  source "recipe_spec.rb.erb"                                                                                                                                                        
  helper_modules [ChefDK::Generator::TemplateHelper]                                                                                                                                 
  declared_type :template                                                                                                                                                            
  cookbook_name :dt_generator                                                                                                                                                        
  recipe_name "cookbook"                                                                                                                                                             
  path "C:/Users/slarson/cookbooks/dt_test/spec/unit/recipes/default_spec.rb"                                                                                                        
end                                                                                                                                                                                  

Template Context:                                                                                                                                                                    
-----------------                                                                                                                                                                    
on line #5                                                                                                                                                                           
  3: # Spec:: default                                                                                                                                                                
  4: #                                                                                                                                                                               
  5: <%= license_description('#') %>                                                                                                                                                 
  6:                                                                                                                                                                                 
  7: require 'spec_helper'                                                                                                                                                           

Platform:                                                                                                                                                                            
---------                                                                                                                                                                            
i386-mingw32                                                                                                                                                                         

ERROR: Chef failed to converge:                                                                                                                                                      

Chef::Mixin::Template::TemplateError (Invalid generator.license setting: none.  See available licenses at https://docs.chef.io/ctl_chef.html#chef-generate-cookbook) on line #5:     

  3: # Spec:: default                                                                                                                                                                
  4: #                                                                                                                                                                               
  5: <%= license_description('#') %>                                                                                                                                                 
  6:                                                                                                                                                                                 
  7: require 'spec_helper'                                                                                                                                                           

  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/generator.rb:153:in `license_description'                                                          
  (erubis):5:in `block in evaluate'                                                                                                                                                  
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:74:in `instance_eval'                                                                     
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:74:in `evaluate'                                                                          
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/mixin/template.rb:161:in `_render_template'                                           
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/mixin/template.rb:147:in `render_template'                                            
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/template/content.rb:53:in `file_for_provider'                                
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/file_content_management/content_base.rb:40:in `tempfile'                              
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:462:in`tempfile'                                                    
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:339:in`do_generate_content'                                         
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:150:in`action_create'                                               
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider/file.rb:162:in`action_create_if_missing'                                    
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/provider.rb:145:in`run_action'                                                       
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource.rb:591:in`run_action'                                             
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:69:in`run_action'                                               
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:97:in `block (2 levels) in converge'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:97:in `each'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:97:in `block in converge'                                                   
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/resource_list.rb:94:in `block in execute_each_resource'           
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'                                
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'                 
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'                                 
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'                             
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'                      
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/resource_collection/resource_list.rb:92:in `execute_each_resource'                    
  C:/opscode/chefdk/embedded/lib/ruby/2.1.0/forwardable.rb:183:in `execute_each_resource'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-12.12.15-universal-mingw32/lib/chef/runner.rb:96:in `converge'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/chef_runner.rb:43:in `converge'
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/command/generator_commands/cookbook.rb:82:in`run'                                                 
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/command/generate.rb:88:in`run'                                                                    
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/command/base.rb:58:in`run_with_default_options'                                                   
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/lib/chef-dk/cli.rb:73:in`run'                                                                                 
  C:/opscode/chefdk/embedded/lib/ruby/gems/2.1.0/gems/chef-dk-0.16.28/bin/chef:25:in `<top(required)>'                                                                              
  C:/opscode/chefdk/bin/chef:85:in `load'                                                                                                                                            
  C:/opscode/chefdk/bin/chef:85:in `<main>'                                                                                                                                          


Caused by: (Chef::Mixin::Template::TemplateError) Invalid generator.license setting: none.  See available licenses at https://docs.chef.io/ctl_chef.html#chef-generate-cookbook
```
