### PR TITLE
Prompt user when generating cookbooks with hyphens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group(:omnibus_package) do
   gem "chefspec"
   gem "fauxhai"
   gem "foodcritic", ">= 6.1.1"
+  gem "highline", "~> 1.6", ">= 1.6.9"
   gem "inspec", ">= 0.17.1"
   gem "kitchen-ec2"
   gem "kitchen-dokken"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ PATH
       cookbook-omnifetch (~> 0.2, >= 0.2.2)
       diff-lcs (~> 1.0)
       ffi-yajl (>= 1.0, < 3.0)
+      highline (~> 1.6, >= 1.6.9)
       minitar (~> 0.5.4)
       mixlib-cli (~> 1.7)
       mixlib-shellout (~> 2.0)
@@ -780,6 +781,7 @@ DEPENDENCIES
   ffi-rzmq-core
   foodcritic (>= 6.1.1)
   guard
+  highline (~> 1.6, >= 1.6.9)
   inspec (>= 0.17.1)
   kitchen-dokken
   kitchen-ec2

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -56,6 +56,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "chef-provisioning", "~> 1.2"
 
+  gem.add_dependency "highline", "~> 1.6", ">= 1.6.9"
+
   gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "rake"
 


### PR DESCRIPTION
Cookbook names with hyphens can lead to problems especially when dealing with custom resources. We want to discourage this behavior by informing the user that hyphenated cookbook name are not recommended and prompts them to proceed rather than failing fast. Additionally, the user can override the prompt by adding the `-y` or `--yes` argument when generating the cookbook.