### PR TITLE
Added option --for to build_cookbook generator to use branch other than master

### DIFF
--- a/lib/chef-dk/command/generator_commands/build_cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/build_cookbook.rb
@@ -29,6 +29,11 @@ module ChefDK
 
         attr_reader :cookbook_name_or_path
 
+        option :pipeline,
+          :long  => "--pipeline PIPELINE",
+          :description => "Use PIPELINE to set target branch to something other than master for the build_cookbook",
+          :default => "master"
+
         options.merge!(SharedGeneratorOptions.options)
 
         def initialize(params)
@@ -58,6 +63,12 @@ module ChefDK
 
           Generator.add_attr_to_context(:delivery_project_git_initialized, delivery_project_git_initialized?)
           Generator.add_attr_to_context(:build_cookbook_parent_is_cookbook, build_cookbook_parent_is_cookbook?)
+
+          Generator.add_attr_to_context(:pipeline, pipeline)
+        end
+
+        def pipeline
+          config[:pipeline]
         end
 
         def recipe
@@ -112,4 +123,3 @@ module ChefDK
     end
   end
 end
-

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -63,6 +63,11 @@ module ChefDK
           boolean:      true,
           default:      false
 
+        option :pipeline,
+          :long  => "--pipeline PIPELINE",
+          :description => "Use PIPELINE to set target branch to something other than master for the build_cookbook",
+          :default => "master"
+
         options.merge!(SharedGeneratorOptions.options)
 
         def initialize(params)
@@ -125,6 +130,11 @@ module ChefDK
           Generator.add_attr_to_context(:verbose, verbose?)
 
           Generator.add_attr_to_context(:use_berkshelf, berks_mode?)
+          Generator.add_attr_to_context(:pipeline, pipeline)
+        end
+
+        def pipeline
+          config[:pipeline]
         end
 
         def policy_name

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -1,6 +1,7 @@
 
 context = ChefDK::Generator.context
 delivery_project_dir = context.delivery_project_dir
+pipeline = context.pipeline
 dot_delivery_dir = File.join(delivery_project_dir, ".delivery")
 
 generator_desc("Ensuring delivery configuration")
@@ -156,8 +157,8 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     only_if "git status --porcelain |grep \".\""
   end
 
-  execute("git-return-to-master-branch") do
-    command("git checkout master")
+  execute("git-return-to-#{pipeline}-branch") do
+    command("git checkout #{pipeline}")
     cwd delivery_project_dir
   end
 
@@ -169,7 +170,7 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
   end
 
   execute("git-remove-delivery-config-branch") do
-    command("git branch -d add-delivery-configuration")
+    command("git branch -D add-delivery-configuration")
     cwd delivery_project_dir
   end
 end


### PR DESCRIPTION
Added option --for to build_cookbook generator to use branch other than master.
This will allow delivery-cli to use non-master pipelines in delivery init.