### PR TITLE
Actually remove bundler git/path-sourced gem files

### DIFF
--- a/omnibus/config/software/chef-dk-cleanup.rb
+++ b/omnibus/config/software/chef-dk-cleanup.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2016 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-name "chef-dk-remove-docs"
+name "chef-dk-cleanup"
 
 license :project_license
 
@@ -23,6 +23,14 @@ build do
   require_relative "../../files/chef-dk/build-chef-dk"
   extend BuildChefDK
 
+  # Clear the now-unnecessary git caches, cached gems, and git-checked-out gems
+  block "Delete bundler git cache and git installs" do
+    gemdir = shellout!("#{gem_bin} environment gemdir", env: env).stdout.chomp
+    remove_directory "#{gemdir}/cache"
+    remove_directory "#{gemdir}/bundler"
+  end
+
+  # Clean up docs
   delete "#{install_dir}/embedded/docs"
   delete "#{install_dir}/embedded/share/man"
   delete "#{install_dir}/embedded/share/doc"

--- a/omnibus/config/software/chef-dk-complete.rb
+++ b/omnibus/config/software/chef-dk-complete.rb
@@ -27,7 +27,7 @@ if windows?
   dependency "ruby-windows-devkit"
 end
 
-dependency "chef-dk-remove-docs"
+dependency "chef-dk-cleanup"
 dependency "rubygems-customization"
 dependency "shebang-cleanup"
 dependency "version-manifest"

--- a/omnibus/files/chef-dk/build-chef-dk.rb
+++ b/omnibus/files/chef-dk/build-chef-dk.rb
@@ -128,12 +128,5 @@ module BuildChefDK
 
     # Freeze the location's Gemfile.lock.
     create_bundle_config(shared_gemfile, frozen: true)
-
-    # Clear the now-unnecessary git caches, cached gems, and git-checked-out gems
-    block "Delete bundler git cache and git installs" do
-      gemdir = shellout!("#{gem_bin} environment gemdir", env: env).stdout.chomp
-      remove_file "#{gemdir}/cache"
-      remove_file "#{gemdir}/bundler"
-    end
   end
 end


### PR DESCRIPTION
We currently clean up bundler's `git`-based gem directory in the `chef-dk` software definition. However, the `chef-dk-appbundler` software definition runs afterward and can put things back in there. To fix this, we now clean bundler's directories after chef-dk-appbundler, in a separate step. We merged this with the chef-remove-docs step.