### PR TITLE
Pass environment to make distclean while building git

### DIFF
--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -48,7 +48,7 @@ build do
 
   # We do a distclean so we ensure that the autoconf files are not trying to be
   # clever.
-  make "distclean"
+  make "distclean", env: env
 
   # AIX needs /opt/freeware/bin only for patch
   if aix?


### PR DESCRIPTION
This fixes builds on Debian and Ubuntu that were failing for me while trying to build in Docker. Previous to this, the `make distclean` would fail, as `make` was not in the path:

```
[Software: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Building because `preparation' dirtied the cache
[NetFetcher: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Cleaning project directory `/var/cache/omnibus/src/git-custom-bindir'
[NetFetcher: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Extracting `/var/cache/omnibus/cache/git-2.8.2.tar.gz' to `/var/cache/omnibus/src/git-custom-bindir'
[Builder: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Starting build
[Builder: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Environment:
[Builder: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 |   PATH=""
[Builder: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | $ make distclean
[Builder: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Execute: `make distclean': 0.0163s
[Builder: git-custom-bindir] I | 2016-10-13T16:07:15+00:00 | Build git-custom-bindir: 0.0166s
bundler: failed to load command: omnibus (/usr/local/bundle/bin/omnibus)
Errno::ENOENT: No such file or directory - make
```
Full stack trace at https://gist.github.com/kevinreedy/1562dd299e0ad1b41b2f2fde10617858.

Signed-off-by: Kevin Reedy <kreedy@chef.io>