### PR TITLE
Basic integration between ChefDK and DCO

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "diff-lcs", "~> 1.0"
   gem.add_dependency "paint", "~> 1.0"
   gem.add_dependency "chef-provisioning", "~> 2.0"
+  gem.add_dependency "dco", "~> 1.0"
 
   gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "rake"

--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -17,6 +17,9 @@
 
 
 ChefDK.commands do |c|
+  c.builtin "dco", :DcoForwarder, require_path: "chef-dk/command/dco",
+    desc: "Manage Developer Certificate of Origin workflow"
+
   c.builtin "exec", :Exec, require_path: "chef-dk/command/exec",
     desc: "Runs the command in context of the embedded ruby"
 

--- a/lib/chef-dk/command/dco.rb
+++ b/lib/chef-dk/command/dco.rb
@@ -1,0 +1,41 @@
+#
+# Copyright 2016, Noah Kantrowitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'dco'
+
+require 'chef-dk/command/base'
+
+
+module ChefDK
+  module Command
+    # Forwards all commands to dco.
+    class DcoForwarder < ChefDK::Command::Base
+      banner "Usage: chef dco DCO_COMMANDS_AND_OPTIONS"
+
+      def run(params)
+        Dco::CLI.start(params)
+      end
+
+      def needs_help?(*args)
+        false
+      end
+
+      def needs_version?(*args)
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This won't actually work until I release the 1.0 of the gem (probably tomorrow, waiting for confirmation from peoples that it meets our legal requirements), but opening now for discussion. I would like to include this gem with ChefDK to help contributors to Chef itself more easily navigate DCO. We could just include it as its own executable and leave things at that, which I would be totally cool with, but this seemed like a nice touch. It exposes the same commands via a `chef dco` subcommand, making it feel a bit more like Chef is giving you tools to do DCO-y things.

You can find more info about my `dco` command over in its [readme](https://github.com/coderanger/dco). What say we all?