### PR TITLE
execute("git-add-delivery-project-toml")

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -122,7 +122,14 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command("git add .delivery/config.json")
     cwd delivery_project_dir
 
-    only_if "git status --porcelain |grep \".\""
+    only_if (
+	    case [:os_family]
+	    when 'linux'
+	      "git status --porcelain |grep \".\""
+	    when 'windows'
+  	    "git status --porcelain | find \".\""
+	    end
+	  )
   end
 
   # Adding the new prototype file to the feature branch


### PR DESCRIPTION
Hello,

The grep command does not exist on windows platform which causes the `chef generate cookbook` command to hang.  Breaking the operation generates the following error:
`Missing Windows Admin Privileges
--------------------------------
chef-client doesn't have administrator privileges. This can be a possible reason for the resource failure.`

Tracing the command `git status --porcelain |grep "."` will generate `'grep' is not recognized as an internal or external command, operable program or batch file.`

Added a case statement to handle differences between os_family and to use the `find` command for window platforms

-Derek