### PR TITLE
Remove CONTRIBUTING.md from gemspec

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.2'
 
-  gem.files = %w{Rakefile LICENSE README.md CONTRIBUTING.md warning.txt} +
+  gem.files = %w{Rakefile LICENSE README.md warning.txt} +
       %w{version_policy.rb omnibus_overrides.rb} +
       Dir.glob("Gemfile*") + # Includes Gemfile and locks
       Dir.glob("*.gemspec") +


### PR DESCRIPTION
### Description

We removed CONTRIBUTING.md, so we need to update the gemspec.

### Issues Resolved

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>