### PR TITLE
Check for other git path extensions besides ‘.exe’

### DIFF
--- a/lib/chef-dk/command/generator_commands/base.rb
+++ b/lib/chef-dk/command/generator_commands/base.rb
@@ -85,7 +85,13 @@ module ChefDK
         def have_git?
           path = ENV["PATH"] || ""
           paths = path.split(File::PATH_SEPARATOR)
-          paths.any? {|bin_path| File.exist?(File.join(bin_path, "git#{RbConfig::CONFIG['EXEEXT']}"))}
+          exts = [RbConfig::CONFIG['EXEEXT']]
+          exts.concat(ENV["PATHEXT"].split(";")) unless ENV["PATHEXT"].nil?
+          paths.any? do |bin_path|
+            exts.any? do |ext|
+              File.exist?(File.join(bin_path, "git#{ext}"))
+            end
+          end
         end
 
         private

--- a/spec/unit/command/generator_commands/base_spec.rb
+++ b/spec/unit/command/generator_commands/base_spec.rb
@@ -133,4 +133,49 @@ describe ChefDK::Command::GeneratorCommands::Base do
       end
     end
   end
+
+  describe '#have_git?' do
+    let(:cmd) { described_class.new([]) }
+    let(:path) { 'bin_path' }
+
+    before do
+      allow(File).to receive(:exist?)
+      allow(ENV).to receive(:[]).with('PATH').and_return(path)
+      allow(ENV).to receive(:[]).with('PATHEXT').and_return(nil)
+      allow(RbConfig::CONFIG).to receive(:[]).with('EXEEXT').and_return('')
+    end
+
+    describe 'when git executable exists' do
+      it 'returns true' do
+        allow(File).to receive(:exist?).and_return(true)
+        expect(cmd.have_git?).to eq(true)
+      end
+    end
+
+    describe 'when git executable does not exist' do
+      it 'returns false' do
+        allow(File).to receive(:exist?).and_return(false)
+        expect(cmd.have_git?).to eq(false)
+      end
+    end
+
+    it 'checks PATH for git executable' do
+      expect(File).to receive(:exist?).with(File.join(path, 'git'))
+      cmd.have_git?
+    end
+
+    describe 'when on Windows' do
+      before do
+        allow(ENV).to receive(:[]).with('PATHEXT').and_return('.com;.exe;.bat')
+        allow(RbConfig::CONFIG).to receive(:[]).with('EXEEXT').and_return('.exe')
+      end
+
+      it 'checks PATH for git executable with an extension found in PATHEXT' do
+        expect(File).to receive(:exist?).with(File.join(path, 'git.com'))
+        expect(File).to receive(:exist?).with(File.join(path, 'git.exe'))
+        expect(File).to receive(:exist?).with(File.join(path, 'git.bat'))
+        cmd.have_git?
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since only `git.bat` is found in the `PATH` on Windows ChefDK installs:

https://github.com/chef/omnibus-software/blob/master/config/software/git-windows.rb#L50-L52

`have_git?` improperly returns false because it only looks for an executable with an `.exe` extension. This commit modifies the method to also search for extensions found in the `PATHEXT` env variable.

http://environmentvariables.org/PathExt
