### PR TITLE
Allow a local cookbook to not check for git information

### DIFF
--- a/lib/chef-dk/policyfile/cookbook_locks.rb
+++ b/lib/chef-dk/policyfile/cookbook_locks.rb
@@ -281,7 +281,7 @@ module ChefDK
       # Whether this cookbook is part of a git repo. If nil, it is dynamically
       # computed. If true/false, then no checking is performed
       attr_accessor :cookbook_in_git_repo
-      
+
       def initialize(name, storage_config)
         @name = name
         @identifier = nil
@@ -395,20 +395,12 @@ module ChefDK
       end
 
       def cookbook_in_git_repo?
-        return @cookbook_in_git_repo unless @cookbook_in_git_repo.nil?
+        return cookbook_in_git_repo unless cookbook_in_git_repo.nil?
 
-        @cookbook_in_git_repo = false
-
-        dot_git = Pathname.new(".git")
-        Pathname.new(cookbook_path).ascend do |parent_dir|
-          possbile_git_dir = parent_dir + dot_git
-          if possbile_git_dir.exist?
-            @cookbook_in_git_repo = true
-            break
-          end
+        @cookbook_in_git_repo = begin
+          dot_git = Pathname.new('.git')
+          Pathname.new(cookbook_path).ascend.map { |parent_dir| parent_dir + dot_git }.any?(&:exist?)
         end
-
-        @cookbook_in_git_repo
       end
 
     end

--- a/lib/chef-dk/policyfile/cookbook_locks.rb
+++ b/lib/chef-dk/policyfile/cookbook_locks.rb
@@ -278,6 +278,10 @@ module ChefDK
       # given, it is resolved relative to #relative_paths_root
       attr_accessor :source
 
+      # Whether this cookbook is part of a git repo. If nil, it is dynamically
+      # computed. If true/false, then no checking is performed
+      attr_accessor :cookbook_in_git_repo
+      
       def initialize(name, storage_config)
         @name = name
         @identifier = nil

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -240,6 +240,7 @@ module ChefDK
           local_cookbook(cookbook_name) do |local_cb|
             local_cb.source = spec.relative_path
             local_cb.source_options = spec.source_options_for_lock
+            local_cb.cookbook_in_git_repo = spec.source_options[:cookbook_in_git_repo]
           end
         end
       end

--- a/spec/unit/command/generator_commands/repo_spec.rb
+++ b/spec/unit/command/generator_commands/repo_spec.rb
@@ -167,7 +167,7 @@ describe ChefDK::Command::GeneratorCommands::Repo do
         context "gplv3" do
           let(:argv) { ["new_repo", "-I", "gplv3" ] }
 
-          it "is the GPL version 2 license" do
+          it "is the GPL version 3 license" do
             expect(file_contents).to match(/GNU GENERAL PUBLIC LICENSE/)
             expect(file_contents).to match(/Version 3, 29 June 2007/)
           end

--- a/spec/unit/policyfile/cookbook_locks_spec.rb
+++ b/spec/unit/policyfile/cookbook_locks_spec.rb
@@ -283,6 +283,18 @@ describe ChefDK::Policyfile::LocalCookbook do
           expect(cookbook_lock.scm_profiler).to be_an_instance_of(ChefDK::CookbookProfiler::Git)
         end
 
+        context "when the cookbook opts out of detecting git repos" do
+
+          before do
+            allow(cookbook_lock).to receive(:cookbook_in_git_repo).and_return(false)
+          end
+
+          it "selects the null profiler" do
+            expect(cookbook_lock.scm_profiler).to be_an_instance_of(ChefDK::CookbookProfiler::NullSCM)
+          end
+
+        end
+
       end
 
       context "when the cookbook is a subdirectory of a git repo" do

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -872,6 +872,7 @@ REVISION_STRING
               mirrors_canonical_upstream?: true,
               cache_key: "foo-1.0.0",
               uri: cached_cookbook_uri,
+              source_options: {},
               source_options_for_lock: { "artifactserver" => cached_cookbook_uri, "version" => "1.0.0" })
     end
 
@@ -880,6 +881,7 @@ REVISION_STRING
               mirrors_canonical_upstream?: false,
               relative_paths_root: relative_paths_root,
               relative_path: "bar",
+              source_options: {},
               source_options_for_lock: { "path" => "bar" })
     end
 


### PR DESCRIPTION
### Description

This allows cookbooks to opt in/out of dynamic git repository detection

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

