### PR TITLE
Bump ChefDK to 1.0 (and associated changes)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,11 +79,6 @@ GIT
       win32-service (~> 0.8.7)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (12.16.42)
-      addressable
-      fuzzyurl
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
 
 GIT
   remote: git://github.com/chef/opscode-pushy-client.git
@@ -99,7 +94,7 @@ GIT
 PATH
   remote: .
   specs:
-    chef-dk (0.20.10)
+    chef-dk (1.0.0)
       chef (~> 12.5)
       chef-provisioning (~> 2.0)
       cookbook-omnifetch (~> 0.2, >= 0.2.2)
@@ -177,6 +172,11 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
+    chef-config (12.16.42)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
     chef-provisioning (2.0.2)
       cheffish (~> 4.0)
       inifile (>= 2.0.2)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# ChefDK 1.0 Release notes
+
+## Version 1.0!
+* Recognize ChefDK's continued stability with the honor of a 1.0 tag. There is
+nothing in this release that breaks backwards compatibility with previous
+installations of ChefDK: it is simply a formal recognition of the stability of
+the product.
+
+## Foodcritic
+* Foodcritic constraint updated to require v8.0 or greater.
+* Supermarket Foodcritic rules are now disabled by default when you run `chef generate cookbook`.
+
 # ChefDK 0.19 Release notes
 
 ## InSpec
@@ -9,7 +21,7 @@
 ## Delivery CLI
 * Deprecation of Github V1 backed project initialization.
 * Initialization of Github V2 backed projects (`delivery init --github`). Requires Chef Automate server version `0.5.432` or above.
-* Project name verification with repository name for projects with SCM Integration. 
+* Project name verification with repository name for projects with SCM Integration.
 * Increased clarity of the command structure by introducing the `--pipeline` alias for the `--for` option.
 * Honor custom config on project initialization (`delivery init -c /my/config.json`).
 * Build cookbook is now generated using the more appropriate `chef generate build-cookbook` on project initialization.

--- a/lib/chef-dk/version.rb
+++ b/lib/chef-dk/version.rb
@@ -16,5 +16,5 @@
 #
 
 module ChefDK
-  VERSION = "0.20.10"
+  VERSION = "1.0.0"
 end

--- a/tasks/version.rb
+++ b/tasks/version.rb
@@ -53,6 +53,34 @@ namespace :version do
     IO.write(version_rb_path, new_version_file)
   end
 
+  desc "Bump the minor version in lib/chef-dk/version.rb"
+  task :bump_minor do
+    current_version_file = IO.read(version_rb_path)
+    new_version = nil
+    new_version_file = current_version_file.sub(/^(\s*VERSION\s*=\s*")(\d+)\.(\d+)\.(\d+)/) do
+      new_version = "#{$2}.#{$3.to_i + 1}.0"
+      "#{$1}#{new_version}"
+    end
+    puts "Updating version in #{version_rb_path} from #{version} to #{new_version.chomp}"
+    IO.write(version_rb_path, new_version_file)
+    Rake::Task["version:update_gemfile_lock"].invoke
+    Rake::Task["bundle:install"].invoke
+  end
+
+  desc "Bump the major version in lib/chef-dk/version.rb"
+  task :bump_major do
+    current_version_file = IO.read(version_rb_path)
+    new_version = nil
+    new_version_file = current_version_file.sub(/^(\s*VERSION\s*=\s*")(\d+)\.(\d+)\.(\d+)/) do
+      new_version = "#{$2.to_i + 1}.0.0"
+      "#{$1}#{new_version}"
+    end
+    puts "Updating version in #{version_rb_path} from #{version} to #{new_version.chomp}"
+    IO.write(version_rb_path, new_version_file)
+    Rake::Task["version:update_gemfile_lock"].invoke
+    Rake::Task["bundle:install"].invoke
+  end
+
   desc "Update the Gemfile.lock to include the current chef-dk version"
   task :update_gemfile_lock do
     if File.exist?(gemfile_lock_path)
@@ -64,6 +92,5 @@ namespace :version do
       IO.write(gemfile_lock_path, contents)
     end
   end
-
 
 end


### PR DESCRIPTION
### Description

* Add rake tasks for bumping major/minor versions
* Bump major version to 1.0

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
