### PR TITLE
Link inspec bin to /usr/bin (and /user/local/bin on MacOS)

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -387,6 +387,7 @@ end
 
             sh!("#{usr_bin_path("ohai")} -v")
             sh!("#{usr_bin_path("foodcritic")} -V")
+            sh!("#{usr_bin_path("inspec")} version")
           end
 
           # Test blocks are expected to return a Mixlib::ShellOut compatible

--- a/omnibus/package-scripts/chefdk/postinst
+++ b/omnibus/package-scripts/chefdk/postinst
@@ -36,7 +36,7 @@ fi
 
 # We test for the presence of /usr/bin/chef-client to know if this script succeeds,
 # so chef-client must appear as the last item here.
-binaries="berks chef chef-apply chef-shell chef-solo chef-zero delivery fauxhai foodcritic kitchen knife ohai push-apply pushy-client pushy-service-manager rubocop cookstyle chef-client"
+binaries="berks chef chef-apply chef-shell chef-solo chef-zero cookstyle delivery fauxhai foodcritic inspec kitchen knife ohai push-apply pushy-client pushy-service-manager rubocop chef-client"
 
 # rm -f before ln -sf is required for solaris 9
 for binary in $binaries; do


### PR DESCRIPTION
Fixes #1070.

Signed-off-by: Seth Chisamore <schisamo@chef.io>

/cc @chef/client-core @lnxchk @chef/inspec-maintainers 
