### PR TITLE
Add knife-opc to chefdk

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_FROZEN: '1'
+BUNDLE_FROZEN: "1"

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group(:omnibus_package) do
   gem "kitchen-inspec"
   gem "kitchen-vagrant"
   gem "knife-windows"
+  gem "knife-opc", ">= 0.3.2"
   gem "ohai", ">= 8.13.0"
   gem "test-kitchen"
   gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,6 +480,7 @@ GEM
       test-kitchen (~> 1.6)
     kitchen-vagrant (0.20.0)
       test-kitchen (~> 1.4)
+    knife-opc (0.3.2)
     knife-push (1.0.2)
       chef (>= 12.7.2)
     knife-spork (1.6.2)
@@ -803,6 +804,7 @@ DEPENDENCIES
   kitchen-ec2
   kitchen-inspec
   kitchen-vagrant
+  knife-opc (>= 0.3.2)
   knife-push
   knife-spork
   knife-windows
@@ -837,4 +839,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.13.3


### PR DESCRIPTION
### Description

For users interacting with a Chef-Server without using Manage, knife-opc
would be the first option -- so it should be included in chefdk, since
this is the package (new) users install to get started.

First, I had added knife-opc to lockdown_gem's, but apparently, its
Gemfile.lock contains dependencies of the development group, making this
impossible: "Build chef-dk-appbundle" would fail trying to find the 'sdoc'
dependency.

Even without the `lockdown_gem "knife-opc"`, I tried adding `knife opc
user list --help` as a component smoke test, however, since this exits
with 1 even when everything is installed properly, it wouldn't make a
good smoke test. So I've left that off again.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

### Notes

I've seen #1069 just now -- I can rebase this after that change is merged and apply its changes -- do we want to get this in first?