### PR TITLE
Default cookbook generation of delivery config to new job dispatch system.

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
@@ -5,6 +5,8 @@
     "path": ".delivery/build_cookbook"
   },
   "skip_phases": [],
-  "build_nodes": {},
+  "job-dispatch": {
+    "version": "v2"
+  },
   "dependencies": []
 }

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -226,7 +226,9 @@ cleanup = "chef exec kitchen destroy"
     "path": ".delivery/build_cookbook"
   },
   "skip_phases": [],
-  "build_nodes": {},
+  "job-dispatch": {
+    "version": "v2"
+  },
   "dependencies": []
 }
   CONFIG_DOT_JSON


### PR DESCRIPTION
### Description

Updates the `config.json` generated by `chef generate cookbook / build-cookbook` to contain:

```
{
...
  "job-dispatch": {
    "version": "v2"
  },
...
}
```

in place of `build_nodes`.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>