### PR TITLE
The Workflow V2 job dispatch key should be with an underscore

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
@@ -5,7 +5,7 @@
     "path": ".delivery/build_cookbook"
   },
   "skip_phases": [],
-  "job-dispatch": {
+  "job_dispatch": {
     "version": "v2"
   },
   "dependencies": []

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -226,7 +226,7 @@ cleanup = "chef exec kitchen destroy"
     "path": ".delivery/build_cookbook"
   },
   "skip_phases": [],
-  "job-dispatch": {
+  "job_dispatch": {
     "version": "v2"
   },
   "dependencies": []


### PR DESCRIPTION
### Description

We had a typo here. Should be `job_dispatch`, not `job-dispatch`

\cc @rmoshier @dmccown @tylercloke 

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

