### PR TITLE
Accept foo.lock.json as well as foo.rb when loading a policyfile

### DIFF
--- a/lib/chef-dk/policyfile/storage_config.rb
+++ b/lib/chef-dk/policyfile/storage_config.rb
@@ -38,6 +38,9 @@ module ChefDK
       end
 
       def use_policyfile(policyfile_filename)
+        if policyfile_filename.end_with?(".lock.json")
+          policyfile_filename = policyfile_filename.sub(/\.lock.json\Z/, '.rb')
+        end
         unless policyfile_filename.end_with?(".rb")
           raise InvalidPolicyfileFilename, "Policyfile filenames must end with `.rb' extension (you gave: `#{policyfile_filename}')"
         end

--- a/lib/chef-dk/policyfile/storage_config.rb
+++ b/lib/chef-dk/policyfile/storage_config.rb
@@ -39,7 +39,7 @@ module ChefDK
 
       def use_policyfile(policyfile_filename)
         if policyfile_filename.end_with?(".lock.json")
-          policyfile_filename = policyfile_filename.sub(/\.lock.json\Z/, '.rb')
+          return use_policyfile_lock(policyfile_filename)
         end
         unless policyfile_filename.end_with?(".rb")
           raise InvalidPolicyfileFilename, "Policyfile filenames must end with `.rb' extension (you gave: `#{policyfile_filename}')"

--- a/spec/unit/policyfile/storage_config_spec.rb
+++ b/spec/unit/policyfile/storage_config_spec.rb
@@ -115,6 +115,18 @@ describe ChefDK::Policyfile::StorageConfig do
 
     end
 
+    context "when the policyfile file name is actually a lockfile" do
+
+      before do
+        storage_config.use_policyfile("foo.lock.json")
+      end
+
+      it "uses the policyfile .rb file instead" do
+        expect(storage_config.policyfile_filename).to eq("foo.rb")
+      end
+
+    end
+
   end
 
 

--- a/spec/unit/policyfile_services/push_spec.rb
+++ b/spec/unit/policyfile_services/push_spec.rb
@@ -87,6 +87,22 @@ describe ChefDK::PolicyfileServices::Push do
 
   end
 
+  context "when given a path to a Policyfile.lock.json instead of an rb" do
+
+    let(:policyfile_rb_name) { "MyPolicy.rb" }
+
+    let(:policyfile_lock_name) { "MyPolicy.lock.json" }
+
+    let(:push_service) { described_class.new(policyfile: policyfile_lock_name, policy_group: policy_group, ui: ui, config: config, root_dir: working_dir) }
+
+    it "loads the correct policyfile" do
+      storage_config = push_service.storage_config
+      expect(storage_config.policyfile_lock_filename).to eq(policyfile_lock_path)
+      expect(storage_config.policyfile_filename).to eq(policyfile_rb_path)
+    end
+
+  end
+
   context "when no lockfile is present" do
 
     it "errors out" do


### PR DESCRIPTION
### Description

Whenever you load a policyfile by name, if you specified a lockfile
instead of the policyfile, this change will change the filename to the
matching .rb file instead rather than exiting with an error.

This allows you do to things like `chef push prod mypolicy.lock.json`
instead of `chef push prod mypolicy.rb`.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

