### PR TITLE
These metadata fields are always helpful.

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -6,10 +6,14 @@ description 'Installs/Configures <%= cookbook_name %>'
 long_description 'Installs/Configures <%= cookbook_name %>'
 version '0.1.0'
 
-# If you upload to Supermarket you should set this so your cookbook
-# gets a `View Issues` link
+# The `issues_url` points to the location where issues for this cookbook are
+# tracked.  A `View Issues` link will be displayed on this cookbook's page when
+# uploaded to a Supermarket.
+#
 # issues_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>/issues' if respond_to?(:issues_url)
 
-# If you upload to Supermarket you should set this so your cookbook
-# gets a `View Source` link
+# The `source_url` points to the development reposiory for this cookbook.  A
+# `View Source` link will be displayed on this cookbook's page when uploaded to
+# a Supermarket.
+#
 # source_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>' if respond_to?(:source_url)


### PR DESCRIPTION
### Description

This changes updates the commentary that describes two metadata attributes:  `issues_url` and `source_url`.

### Issues Resolved

None

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

I'm not sure this warrants an update to the RELEASE\_NOTES.md but am happy to add something if you think it's warranted.

There are no tests for this as it's simply a change to code comments.


The `issues_url` and `source_url` are, indeed, helpful when the cookbook
is published to a Supermarket.  Even when they aren't, consumers of this
cookbook may want to know where the source code is stored and/or where
issues for this cookbook are tracked.

This changes updates the commentary that describes these two metadata
attributes.

Signed-off-by: Nathen Harvey <nharvey@chef.io>