### PR TITLE
Generate content with the proper yard parsable headers

### DIFF
--- a/lib/chef-dk/generator.rb
+++ b/lib/chef-dk/generator.rb
@@ -73,10 +73,10 @@ module ChefDK
       def license_description(comment=nil)
         case license
         when 'all_rights'
-          result = "Copyright (c) #{year} #{copyright_holder}, All Rights Reserved."
+          result = "Copyright:: #{year}, #{copyright_holder}, All Rights Reserved."
         when 'apachev2'
           result = <<-EOH
-Copyright #{year} #{copyright_holder}
+Copyright:: #{year}, #{copyright_holder}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ EOH
           result = <<-EOH
 The MIT License (MIT)
 
-Copyright (c) #{year} #{copyright_holder}
+Copyright:: #{year}, #{copyright_holder}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -116,7 +116,7 @@ THE SOFTWARE.
 EOH
         when 'gplv2'
           result = <<-EOH
-Copyright (C) #{year}  #{copyright_holder}
+Copyright:: #{year},  #{copyright_holder}
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -134,7 +134,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 EOH
         when 'gplv3'
           result = <<-EOH
-Copyright (C) #{year}  #{copyright_holder}
+Copyright:: #{year},  #{copyright_holder}
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/recipe.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/recipe.rb.erb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: build_cookbook
+# Cookbook:: build_cookbook
 # Recipe:: <%= @phase %>
 #
 <%= license_description('#') %>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe.rb.erb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: <%= cookbook_name %>
+# Cookbook:: <%= cookbook_name %>
 # Recipe:: <%= recipe_name %>
 #
 <%= license_description('#') %>

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: <%= cookbook_name %>
+# Cookbook:: <%= cookbook_name %>
 # Spec:: default
 #
 <%= license_description('#') %>

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -148,7 +148,7 @@ describe ChefDK::Command::GeneratorCommands::App do
         let(:file) { File.join(tempdir, "new_app", "cookbooks", "new_app", "recipes", "default.rb") }
 
         include_examples "a generated file", :cookbook_name do
-          let(:line) { "# Cookbook Name:: new_app" }
+          let(:line) { "# Cookbook:: new_app" }
         end
       end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -249,10 +249,10 @@ cleanup = "chef exec kitchen destroy"
         let(:expected_content) do
           <<-CONFIG_DOT_JSON
 #
-# Cookbook Name:: build_cookbook
+# Cookbook:: build_cookbook
 # Recipe:: publish
 #
-# Copyright (c) 2016 The Authors, All Rights Reserved.
+# Copyright:: 2016, The Authors, All Rights Reserved.
 include_recipe 'delivery-truck::publish'
   CONFIG_DOT_JSON
         end
@@ -679,7 +679,7 @@ SPEC_HELPER
       let(:file) { File.join(tempdir, "new_cookbook", "recipes", "default.rb") }
 
       include_examples "a generated file", :cookbook_name do
-        let(:line) { "# Cookbook Name:: new_cookbook" }
+        let(:line) { "# Cookbook:: new_cookbook" }
       end
     end
 

--- a/spec/unit/generator_spec.rb
+++ b/spec/unit/generator_spec.rb
@@ -63,7 +63,7 @@ describe ChefDK::Generator::TemplateHelper do
     let(:license) { "all_rights" }
     context "all_rights" do
       it "should match the license" do
-        expect(helper.license_description).to match(/^Copyright \(c\)/)
+        expect(helper.license_description).to match(/^Copyright:: /)
       end
 
       it "should comment if requested" do


### PR DESCRIPTION
The format we use here is mostly a leftover from rdoc as far as I can tell, but we’re not even consistently using that format at the moment. Fields with :: will get parsed by YARD. For a time we used Copyright:: and we seem to have slowly removed that. We should be using that format in cookbooks since it’ll get parses. Also “Cookbook Name” makes no sense when every other field omits “Name”. It should just be “Cookbook”

Signed-off-by: Tim Smith <tsmith@chef.io>