### PR TITLE
Add `dco` command line utility to easier management of DCO sign-offs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group(:omnibus_package) do
   gem "test-kitchen"
   gem "listen"
   gem "mixlib-install"
+  gem "dco"
 
   # For Delivery build node
   gem "chef-sugar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/chef/appbundler.git
-  revision: 76cb17280186ba314d31cd5751e674025ec93c79
+  revision: 6582b68884453b5ca5c962458a0c08046c719558
   specs:
-    appbundler (0.9.0)
+    appbundler (0.10.0)
       mixlib-cli (~> 1.4)
 
 GIT
@@ -79,6 +79,11 @@ GIT
       win32-service (~> 0.8.7)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
+    chef-config (12.16.42)
+      addressable
+      fuzzyurl
+      mixlib-config (~> 2.0)
+      mixlib-shellout (~> 2.0)
 
 GIT
   remote: git://github.com/chef/opscode-pushy-client.git
@@ -109,7 +114,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.3)
+    CFPropertyList (2.3.4)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -125,13 +130,13 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.6.23)
-      aws-sdk-resources (= 2.6.23)
-    aws-sdk-core (2.6.23)
+    aws-sdk (2.6.29)
+      aws-sdk-resources (= 2.6.29)
+    aws-sdk-core (2.6.29)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.23)
-      aws-sdk-core (= 2.6.23)
+    aws-sdk-resources (2.6.29)
+      aws-sdk-core (= 2.6.29)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -174,11 +179,6 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.16.42)
-      addressable
-      fuzzyurl
-      mixlib-config (~> 2.0)
-      mixlib-shellout (~> 2.0)
     chef-provisioning (2.0.2)
       cheffish (~> 4.0)
       inifile (>= 2.0.2)
@@ -187,10 +187,10 @@ GEM
       net-ssh (>= 2.9, < 4.0)
       net-ssh-gateway (~> 1.2.0)
       winrm-fs (~> 1.0)
-    chef-provisioning-aws (2.0.0)
+    chef-provisioning-aws (2.1.0)
       aws-sdk (>= 2.1.26, < 3.0)
       aws-sdk-v1 (>= 1.59.0)
-      chef-provisioning (~> 2.0)
+      chef-provisioning (>= 1.0, < 3.0)
       retryable (~> 2.0, >= 2.0.1)
       ubuntu_ami (~> 0.4, >= 0.4.1)
     chef-provisioning-azure (0.6.0)
@@ -237,6 +237,9 @@ GEM
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
     cucumber-wire (0.0.1)
+    dco (1.0.1)
+      git (~> 1.3)
+      thor (~> 0.19)
     debug_inspector (0.0.2)
     dep-selector-libgecode (1.3.1)
     dep_selector (1.0.4)
@@ -244,7 +247,7 @@ GEM
       ffi (~> 1.9)
     diff-lcs (1.2.5)
     diffy (3.1.0)
-    docker-api (1.32.1)
+    docker-api (1.33.0)
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
@@ -303,7 +306,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.12.0)
+    fog-aws (0.13.0)
       fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -342,7 +345,7 @@ GEM
       multi_json (~> 1.10)
     fog-local (0.3.1)
       fog-core (~> 1.27)
-    fog-openstack (0.1.17)
+    fog-openstack (0.1.18)
       fog-core (>= 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
@@ -387,7 +390,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.5.1)
+    fog-vsphere (1.5.2)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.2.3)
@@ -449,7 +452,7 @@ GEM
     inflecto (0.0.2)
     inifile (3.0.0)
     iniparse (1.4.2)
-    inspec (1.4.1)
+    inspec (1.6.0)
       hashie (~> 3.4)
       json (>= 1.8, < 3.0)
       method_source (~> 0.8)
@@ -459,6 +462,7 @@ GEM
       rainbow (~> 2)
       rspec (~> 3)
       rspec-its (~> 1.2)
+      rspec_junit_formatter (~> 0.2.3)
       rubyzip (~> 1.1)
       sslshake (~> 1)
       thor (~> 0.19)
@@ -467,9 +471,9 @@ GEM
     jmespath (1.3.1)
     json (1.8.3)
     jwt (1.5.6)
-    kitchen-dokken (1.0.4)
-      docker-api (~> 1.29)
-      test-kitchen (~> 1.5)
+    kitchen-dokken (1.0.7)
+      docker-api (~> 1.32)
+      test-kitchen (~> 1.13)
     kitchen-ec2 (1.2.0)
       aws-sdk (~> 2)
       excon
@@ -480,7 +484,7 @@ GEM
       hashie (~> 3.4)
       inspec (>= 0.34.0, < 2.0.0)
       test-kitchen (~> 1.6)
-    kitchen-vagrant (0.20.0)
+    kitchen-vagrant (0.21.0)
       test-kitchen (~> 1.4)
     knife-opc (0.3.2)
     knife-push (1.0.2)
@@ -521,7 +525,7 @@ GEM
       mixlib-log
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
-    mixlib-install (2.1.6)
+    mixlib-install (2.1.7)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -557,7 +561,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.6.0)
+    octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (8.21.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
@@ -573,8 +577,8 @@ GEM
       wmi-lite (~> 1.0)
     os (0.9.6)
     paint (1.0.1)
-    parallel (1.9.0)
-    parser (2.3.1.4)
+    parallel (1.10.0)
+    parser (2.3.3.0)
       ast (~> 2.2)
     plist (3.2.0)
     polyglot (0.3.5)
@@ -584,7 +588,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.0)
+    pry-byebug (3.4.1)
       byebug (~> 9.0)
       pry (~> 0.10)
     pry-remote (0.1.8)
@@ -661,9 +665,9 @@ GEM
     rubyzip (1.2.0)
     rufus-lru (1.1.0)
     safe_yaml (1.0.4)
-    sawyer (0.8.0)
+    sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 0.10)
+      faraday (~> 0.8, < 1.0)
     semverse (2.0.0)
     serverspec (2.37.2)
       multi_json
@@ -678,8 +682,8 @@ GEM
       jwt (~> 1.5)
       multi_json (~> 1.10)
     slop (3.6.0)
-    solve (3.0.1)
-      molinillo (~> 0.4)
+    solve (3.1.0)
+      molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
     specinfra (2.66.0)
       net-scp
@@ -695,7 +699,7 @@ GEM
       uuid (~> 2.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.13.2)
+    test-kitchen (1.14.0)
       mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -703,11 +707,11 @@ GEM
       net-ssh-gateway (~> 1.2.0)
       safe_yaml (~> 1.0)
       thor (~> 0.18)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     timers (4.0.4)
       hitimes
-    train (0.21.1)
+    train (0.22.0)
       docker-api (~> 1.26)
       json (>= 1.8, < 3.0)
       mixlib-shellout (~> 2.0)
@@ -794,6 +798,7 @@ DEPENDENCIES
   chefspec
   cookstyle
   cucumber
+  dco
   dep-selector-libgecode
   dep_selector
   fauxhai

--- a/omnibus/config/software/chef-dk-appbundle.rb
+++ b/omnibus/config/software/chef-dk-appbundle.rb
@@ -23,6 +23,7 @@ build do
   appbundle_gem "cookstyle"
   appbundle_gem "rubocop"
   appbundle_gem "inspec"
+  appbundle_gem "dco"
 
   # These are not appbundled, but need to have their Gemfiles locked down so that their tests will run
 


### PR DESCRIPTION
### Description

Add @coderanger's DCO utility to ChefDK. https://github.com/coderanger/dco

### Issues Resolved

#1052 was blocked due to a rebase/merge conflict. This is something I think is useful to get in, so I duplicated the work on a branch we had control over. 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
