### PR TITLE
chef: Use `test/smoke/default` instead of `test/recipes` for generated cookbooks/recipes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,7 @@
 # ChefDK 1.1 Release notes
+
+## New Inspec Test Location
+To address bugs and confusion with the previous `test/recipes` location, all newly generated
+cookbooks and recipes will place their Inspec tests in `test/smoke/default`. This
+placement creates the association of the `smoke` Workflow phase and the `default` Kitchen suite
+where the tests are run.

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -105,7 +105,7 @@ module ChefDK
             msg("\nThere are several commands you can run to get started locally developing and testing your cookbook.")
             msg("Type `delivery local --help` to see a full list.")
             msg("\nWhy not start by writing a test? Tests for the default recipe are stored at:\n")
-            msg("test/recipes/default_test.rb")
+            msg("test/smoke/default/default_test.rb")
             msg("\nIf you'd prefer to dive right in, the default recipe can be found at:")
             msg("\nrecipes/default.rb\n")
           end

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -17,11 +17,11 @@ template "#{app_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{app_dir}/test/recipes" do
+directory "#{app_dir}/test/smoke/default" do
   recursive true
 end
 
-template "#{app_dir}/test/recipes/default_test.rb" do
+template "#{app_dir}/test/smoke/default/default_test.rb" do
   source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -55,11 +55,11 @@ template "#{cookbook_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{cookbook_dir}/test/recipes" do
+directory "#{cookbook_dir}/test/smoke/default" do
   recursive true
 end
 
-template "#{cookbook_dir}/test/recipes/default_test.rb" do
+template "#{cookbook_dir}/test/smoke/default/default_test.rb" do
   source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -4,7 +4,7 @@ cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 recipe_path = File.join(cookbook_dir, "recipes", "#{context.new_file_basename}.rb")
 spec_helper_path = File.join(cookbook_dir, "spec", "spec_helper.rb")
 spec_path = File.join(cookbook_dir, "spec", "unit", "recipes", "#{context.new_file_basename}_spec.rb")
-inspec_path = File.join(cookbook_dir, "test", "recipes", "#{context.new_file_basename}.rb")
+inspec_path = File.join(cookbook_dir, "test", "smoke", "default", "#{context.new_file_basename}.rb")
 
 # Chefspec
 directory "#{cookbook_dir}/spec/unit/recipes" do
@@ -22,7 +22,7 @@ template spec_path do
 end
 
 # Inspec
-directory "#{cookbook_dir}/test/recipes" do
+directory "#{cookbook_dir}/test/smoke/default" do
   recursive true
 end
 
@@ -37,4 +37,3 @@ template recipe_path do
   source "recipe.rb.erb"
   helpers(ChefDK::Generator::TemplateHelper)
 end
-

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -3,11 +3,13 @@ context = ChefDK::Generator.context
 cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 recipe_path = File.join(cookbook_dir, "recipes", "#{context.new_file_basename}.rb")
 spec_helper_path = File.join(cookbook_dir, "spec", "spec_helper.rb")
-spec_path = File.join(cookbook_dir, "spec", "unit", "recipes", "#{context.new_file_basename}_spec.rb")
-inspec_path = File.join(cookbook_dir, "test", "smoke", "default", "#{context.new_file_basename}.rb")
+spec_dir = File.join(cookbook_dir, "spec", "unit", "recipes")
+spec_path = File.join(spec_dir, "#{context.new_file_basename}_spec.rb")
+inspec_dir = File.join(cookbook_dir, "test", "smoke", "default")
+inspec_path = File.join(inspec_dir, "#{context.new_file_basename}.rb")
 
 # Chefspec
-directory "#{cookbook_dir}/spec/unit/recipes" do
+directory spec_dir do
   recursive true
 end
 
@@ -22,7 +24,7 @@ template spec_path do
 end
 
 # Inspec
-directory "#{cookbook_dir}/test/smoke/default" do
+directory inspec_dir do
   recursive true
 end
 

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -8,6 +8,16 @@ spec_path = File.join(spec_dir, "#{context.new_file_basename}_spec.rb")
 inspec_dir = File.join(cookbook_dir, "test", "smoke", "default")
 inspec_path = File.join(inspec_dir, "#{context.new_file_basename}.rb")
 
+if File.directory?(File.join(cookbook_dir, "test", "recipes"))
+  Chef::Log.deprecation <<-EOH
+It appears that you have Inspec tests located at "test/recipes". This location can
+cause issues with Foodcritic and has been deprecated in favor of "test/smoke/default".
+Please move your existing Inspec tests to the newly created "test/smoke/default"
+directory, and update the 'inspec_tests' value in your .kitchen.yml file(s) to
+point to "test/smoke/default".
+  EOH
+end
+
 # Chefspec
 directory spec_dir do
   recursive true

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -22,5 +22,5 @@ suites:
       - recipe[<%= cookbook_name %>::default]
     verifier:
       inspec_tests:
-        - test/recipes
+        - test/smoke/default
     attributes:

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -29,5 +29,5 @@ suites:
   - name: default
     verifier:
       inspec_tests:
-        - test/recipes
+        - test/smoke/default
     attributes:

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -31,8 +31,9 @@ describe ChefDK::Command::GeneratorCommands::App do
       .gitignore
       .kitchen.yml
       test
-      test/recipes
-      test/recipes/default_test.rb
+      test/smoke
+      test/smoke/default
+      test/smoke/default/default_test.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore
@@ -128,8 +129,8 @@ describe ChefDK::Command::GeneratorCommands::App do
         end
       end
 
-      describe "test/recipes/default_test.rb" do
-        let(:file) { File.join(tempdir, "new_app", "test", "recipes", "default_test.rb") }
+      describe "test/smoke/default/default_test.rb" do
+        let(:file) { File.join(tempdir, "new_app", "test", "smoke", "default", "default_test.rb") }
 
         include_examples "a generated file", :cookbook_name do
           let(:line) { "describe port" }
@@ -163,4 +164,3 @@ describe ChefDK::Command::GeneratorCommands::App do
     end
   end
 end
-

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -34,8 +34,8 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       .gitignore
       .kitchen.yml
       test
-      test/recipes
-      test/recipes/default_test.rb
+      test/smoke
+      test/smoke/default/default_test.rb
       Berksfile
       chefignore
       metadata.rb
@@ -65,7 +65,7 @@ Type `delivery local --help` to see a full list.
 
 Why not start by writing a test? Tests for the default recipe are stored at:
 
-test/recipes/default_test.rb
+test/smoke/default/default_test.rb
 
 If you'd prefer to dive right in, the default recipe can be found at:
 
@@ -460,8 +460,8 @@ OUTPUT
 
         end
 
-        describe "test/recipes/default_test.rb" do
-          let(:file) { File.join(tempdir, "new_cookbook", "test", "recipes", "default_test.rb") }
+        describe "test/smoke/default/default_test.rb" do
+          let(:file) { File.join(tempdir, "new_cookbook", "test", "smoke", "default", "default_test.rb") }
 
           include_examples "a generated file", :cookbook_name do
             let(:line) { "describe port" }
@@ -570,7 +570,7 @@ suites:
   - name: default
     verifier:
       inspec_tests:
-        - test/recipes
+        - test/smoke/default
     attributes:
 KITCHEN_YML
         end
@@ -647,7 +647,7 @@ suites:
       - recipe[new_cookbook::default]
     verifier:
       inspec_tests:
-        - test/recipes
+        - test/smoke/default
     attributes:
 KITCHEN_YML
         end

--- a/spec/unit/command/generator_commands/recipe_spec.rb
+++ b/spec/unit/command/generator_commands/recipe_spec.rb
@@ -27,7 +27,7 @@ describe ChefDK::Command::GeneratorCommands::Recipe do
     let(:generated_files) { [ "recipes/new_recipe.rb",
                               "spec/spec_helper.rb",
                               "spec/unit/recipes/new_recipe_spec.rb",
-                              "test/recipes/new_recipe.rb"
+                              "test/smoke/default/new_recipe.rb"
                             ] }
     let(:new_file_name) { "new_recipe" }
 


### PR DESCRIPTION
### Description

Storing generated inspec tests in `test/recipes` causes Foodcritic to
fail, as Foodcritic assumes the `test` directory is now a
cookbook (which is false). Using `test/smoke/default` fixes this issue
and creates direct associations with the existing Kitchen and Workflow
templates.

1. The delivery-project.toml already runs `kitchen verify` during
smoke. There is now a connection between the phase and the tests that
are run by default.
2. The `default` folder in smoke is associated with the `default` suite
already provided in the Kitchen YAML. This indicates and guides the user
that additional suites can be created under smoke, and gives implicit
guidance as to their naming.

### Issues Resolved

* COOL-585

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Tom Duffield <tom@chef.io>