### PR TITLE
kitchen-dokken: Default to official `chef/chef` image

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,7 +487,7 @@ GEM
     jmespath (1.3.1)
     json (1.8.3)
     jwt (1.5.6)
-    kitchen-dokken (1.0.8)
+    kitchen-dokken (1.0.9)
       docker-api (~> 1.32)
       test-kitchen (~> 1.13)
     kitchen-ec2 (1.2.0)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,7 @@ To address bugs and confusion with the previous `test/recipes` location, all new
 cookbooks and recipes will place their Inspec tests in `test/smoke/default`. This
 placement creates the association of the `smoke` Workflow phase and the `default` Kitchen suite
 where the tests are run.
+
+## Default Docker image in kitchen-dokken is now official Chef image
+[chef/chef](https://hub.docker.com/r/chef/chef) is now the default Docker
+image used in [kitchen-dokken](https://github.com/someara/kitchen-dokken).


### PR DESCRIPTION
### Description

kitchen-dokken 1.0.9 now defaults to using the chef/chef Docker image.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>



Signed-off-by: Tom Duffield <tom@chef.io>