### PR TITLE
Depend on mixlib-install on two gem groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ group(:omnibus_package) do
   gem "ohai", ">= 8.13.0"
   gem "test-kitchen"
   gem "listen"
-  gem "mixlib-install"
   gem "dco"
 
   # For Delivery build node
@@ -102,6 +101,9 @@ end
 group(:changelog) do
   gem "github_changelog_generator", git: "https://github.com/tduffield/github-changelog-generator", branch: "adjust-tag-section-mapping"
 end
+
+# mixlib-install is used by two groups
+gem 'mixlib-install', :group => [:changelog, :omnibus_package]
 
 # TODO delete this when we figure out how to include the pushy windows dependencies
 # correctly


### PR DESCRIPTION
### Description

Depend on mixlib-install on two gem groups
### Check List

- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Salim Afiune <afiune@chef.io>