### PR TITLE
Dont fail the version bump if changelog fails

### DIFF
--- a/ci/version_bump.sh
+++ b/ci/version_bump.sh
@@ -7,6 +7,6 @@ export LANG=en_US.UTF-8
 . ci/bundle_install.sh
 
 bundle exec rake version:bump
-bundle exec rake changelog
+bundle exec rake changelog || true
 
 git checkout .bundle/config


### PR DESCRIPTION
### Description

We don't want to fail the version bump if the changelog update fails.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Salim Afiune <afiune@chef.io>