### PR TITLE
Adding maintainer and email fields to example

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/repo/cookbooks/example/metadata.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/repo/cookbooks/example/metadata.rb
@@ -1,3 +1,6 @@
 name 'example'
 description 'An example cookbook'
+maintainer 'Example maintainer'
+maintainer_email 'maintainer@example.com'
+license 'Apache v2'
 version '1.0.0'


### PR DESCRIPTION
### Description

- added maintainer field
- added maintainer_email field
- added license field

If you don't have these fields if you attempt to upload this cookbook this error happens:

```
15:55:39 JJs-MacBook-Pro vmware_playground > (master) knife cookbook upload example
Uploading example        [1.0.0]
ERROR: The data in your request was invalid
Response: Field 'metadata.maintainer' invalid
```

Signed-off-by: JJ Asghar <jj@chef.io>