### PR TITLE
Remove the old doc changes doc

### DIFF
--- a/DOC_CHANGES.md
+++ b/DOC_CHANGES.md
@@ -1,8 +1,0 @@
-# ChefDK 0.10.0
-
-## knife-windows updated to 1.1.1
-See the [knife-windows DOC_CHANGES](https://github.com/chef/knife-windows/blob/master/DOC_CHANGES.md)
-
-## Inspec now included
-
-Currently you must execute `bundle exec inspec` to access the `inspec` command line tool installed with the ChefDK.  This behavior will persist until we appbundle Inspec (which we plan on doing).


### PR DESCRIPTION
We're not doing this anymore. We add the release notes to the docs site instead