### PR TITLE
Ensure rake is installed via the CI tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,12 @@ gem "chef-dk", path: "."
 # EXPERIMENTAL: ALL gems specified here will be installed in chef-dk omnibus.
 # This represents all gems that will be part of chef-dk.
 
+# Ensure that we can always install rake, regardless of gem groups
+# Including the travis group to address https://github.com/sickill/rainbow/issues/44
+gem "rake", group: [ :omnibus_package, :development, :test, :travis ]
+
 group(:omnibus_package, :development, :test) do
   gem "pry"
-  gem "rake"
   gem "rdoc"
   gem "yard"
   gem "dep_selector"


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

cc @tyler-ball 

### Description

Due to a bug in Rubygems, we need to ensure that the `rake` gem is installed. 

### Issues Resolved

* Should fix failing acceptance tests

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
