### PR TITLE
Do not run Chef Acceptance tests

### DIFF
--- a/ci/verify-chefdk.sh
+++ b/ci/verify-chefdk.sh
@@ -33,7 +33,9 @@ done
 if [ "x$ACCEPTANCE" != "x" ]; then
   export PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:$PATH
 
-  for GEM_NAME in chef chef-dk
+  # Don't run the chef acceptance tests in chef-dk (until rainbow gem debacle is over)
+  # for GEM_NAME in chef chef-dk
+  for GEM_NAME in chef-dk
   do
 
     # copy acceptance suites into workspace


### PR DESCRIPTION
We currently run both chef and chef-dk acceptance tests under ChefDK. This is causing a problem because stable chef (12.18.31) does not have the necessary fixes for the rainbow/rubygems bug we're currently dealing with. To avoid this issue, and save some time on acceptance tests, we are (temporarily?) disabling chef acceptance tests and running only chef-dk acceptance tests. 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
