### PR TITLE
[Dockerfile] Install ChefDK via packages.chef.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM ubuntu:16.04
 MAINTAINER Chef Software, Inc. <docker@chef.io>
 
 ARG CHANNEL=stable
-ARG VERSION=latest
+ARG VERSION=1.1.16
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN apt-get update && \
     apt-get install -y wget ssh && \
-    wget --content-disposition "https://omnitruck.chef.io/${CHANNEL}/chefdk/download?p=ubuntu&pv=16.04&m=x86_64&v=${VERSION}" -O /tmp/chefdk.deb && \
+    wget --content-disposition "http://packages.chef.io/files/${CHANNEL}/chefdk/${VERSION}/ubuntu/16.04/chefdk_${VERSION}-1_amd64.deb" -O /tmp/chefdk.deb && \
     dpkg -i /tmp/chefdk.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Rakefile
+++ b/Rakefile
@@ -21,3 +21,12 @@ require_relative "tasks/bundle"
 require_relative "tasks/dependencies"
 require_relative "tasks/github_changelog_generator"
 require_relative "tasks/announce"
+
+desc "Keep the Dockerfile up-to-date"
+task :update_dockerfile do
+  require "mixlib/install"
+  latest_stable_version = Mixlib::Install.available_versions("chefdk", "stable").last
+  text = File.read("Dockerfile")
+  new_text = text.gsub(/^ARG VERSION=[\d\.]+$/, "ARG VERSION=#{latest_stable_version}")
+  File.open("Dockerfile", "w+") { |f| f.write(new_text) }
+end

--- a/ci/version_bump.sh
+++ b/ci/version_bump.sh
@@ -8,5 +8,6 @@ export LANG=en_US.UTF-8
 
 bundle exec rake version:bump
 bundle exec rake changelog || true
+bundle exec rake update_dockerfile
 
 git checkout .bundle/config


### PR DESCRIPTION
To avoid the potential race condition between build and omnitruck,
install ChefDK directly via packages.chef.io. Included with this
is a simply handler to keep the Dockerfile up to date.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
