### PR TITLE
Fix `delivery local` failures by adding 'chef exec' prefix to all commands in project.toml

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
   - An optional `functional` phase.
   - New `remote_file` option to specify a remote project.toml.
   - The ability to run stages (collection of phases).
+- Fixed bug where the generated `project.toml` file didn't include the prefix `chef exec` for some phases.
 - Project git remotes will now be updated automatically, if applicable, based on the values in the `cli.toml` or options provided through the command-line.
 - Project names specified in project config (`cli.toml`) or options provided through the command-line will now be honored.
 

--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
@@ -12,13 +12,13 @@
 # config.json file and it will continue working as usual.
 
 [local_phases]
-unit = "rspec spec/"
-lint = "cookstyle"
+unit = "chef exec rspec spec/"
+lint = "chef exec cookstyle"
 # Foodcritic includes rules only appropriate for community cookbooks
 # uploaded to Supermarket. We turn off any rules tagged "supermarket"
 # by default. If you plan to share this cookbook you should remove
 # '-t ~supermarket' below to enable supermarket rules.
-syntax = "foodcritic . --exclude spec -f any -t ~supermarket"
+syntax = "chef exec foodcritic . --exclude spec -f any -t ~supermarket"
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -193,13 +193,13 @@ EOF
 # config.json file and it will continue working as usual.
 
 [local_phases]
-unit = "rspec spec/"
-lint = "cookstyle"
+unit = "chef exec rspec spec/"
+lint = "chef exec cookstyle"
 # Foodcritic includes rules only appropriate for community cookbooks
 # uploaded to Supermarket. We turn off any rules tagged "supermarket"
 # by default. If you plan to share this cookbook you should remove
 # '-t ~supermarket' below to enable supermarket rules.
-syntax = "foodcritic . --exclude spec -f any -t ~supermarket"
+syntax = "chef exec foodcritic . --exclude spec -f any -t ~supermarket"
 provision = "chef exec kitchen create"
 deploy = "chef exec kitchen converge"
 smoke = "chef exec kitchen verify"


### PR DESCRIPTION
### Description

We have encountered a problem when users install ChefDK for the first time and they do not have it on its `PATH` env variable, they end-up with the following behavior:
```
$ chef generate cookbook test
$ cd test
$ delivery local unit
Chef Delivery
Running Unit Phase
thread 'main' panicked at 'Unexpected error: Failed to execute process: No such file or directory (os error 2)', src/delivery/command/local.rs:53
```

The main problem is that the `project.toml` doesn't have the prefix `chef exec` to run the unit phase in the context of ChefDK. 

This change is adding the prefix to the default generated `project.toml` so if the user doesn't have ChefDK configured on its PATH, it wont matter and you will be able to run all phases.
```
$ delivery local unit
Chef Delivery
Running Unit Phase
.

Finished in 2.59 seconds (files took 1.51 seconds to load)
1 example, 0 failures
```

### Issues Resolved

BUG-345

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
