### PR TITLE
Use ChefDK, rather than Chef Client, as build-cookbook Test Kitchen base

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,6 @@
 # ChefDK 1.3 Release Notes
+
+## Workflow Build Cookbooks
+Build cookbooks generated via `chef generate build-cookbook` will no longer
+depend on the delivery_build or delivery-base cookbook. Instead, the Test
+Kitchen instance will use ChefDK as per the standard Workflow Runner setup.

--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/.kitchen.yml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/.kitchen.yml
@@ -8,6 +8,7 @@ provisioner:
   name: chef_zero
   encrypted_data_bag_secret_key_path: 'secrets/fakey-mcfakerton'
   data_bags_path: './data_bags'
+  product_name: chefdk
 
 platforms:
   - name: ubuntu-16.04
@@ -16,6 +17,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[delivery_build::default]
       - recipe[test]
     attributes:

--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/test-fixture-recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/test-fixture-recipe.rb
@@ -3,5 +3,6 @@
   execute "HOME=/home/vagrant delivery job verify #{phase} --server localhost --ent test --org kitchen" do
     cwd '/tmp/repo-data'
     user 'vagrant'
+    environment("GIT_DISCOVERY_ACROSS_FILESYSTEM" => "1")
   end
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/Berksfile.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/Berksfile.erb
@@ -3,7 +3,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :delivery do
-  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
-  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
   cookbook 'test', path: './test/fixtures/cookbooks/test'
 end

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -287,8 +287,6 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :delivery do
-  cookbook 'delivery_build', git: 'https://github.com/chef-cookbooks/delivery_build'
-  cookbook 'delivery-base', git: 'https://github.com/chef-cookbooks/delivery-base'
   cookbook 'test', path: './test/fixtures/cookbooks/test'
 end
   CONFIG_DOT_JSON


### PR DESCRIPTION
### Description

The delivery-base and delivery_build cookbooks are no longer required for Automate Workflow. To test a build cookbook, all you need is the ChefDK! Update the build-cookbook generator to use ChefDK as the kitchen base rather than the Chef Client.

The GIT_DISCOVERY_ACROSS_FILESYSTEM is necessary for the command to
work successfully, since the cookbook under test is on a volume.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
