### PR TITLE
Properly skip generated skeleton Inspec tests

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
@@ -6,13 +6,13 @@
 # found at http://inspec.io/docs/reference/resources/
 
 unless os.windows?
-  describe user('root') do
+  # This is an example test, replace with your own test.
+  describe user('root'), :skip do
     it { should exist }
-    skip 'This is an example test, replace with your own test.'
   end
 end
 
-describe port(80) do
+# This is an example test, replace it with your own test.
+describe port(80), :skip do
   it { should_not be_listening }
-  skip 'This is an example test, replace with your own test.'
 end


### PR DESCRIPTION
### Description

Having a `skip` parameter in your describe block does not mean that the entire describe block is skipped. Instead, we need to use the `:skip` flag.

### Issues Resolved

* Internal Ticket COOL-664

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
