### PR TITLE
Avoid override existing delivery configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,3 +4,6 @@
 Build cookbooks generated via `chef generate build-cookbook` will no longer
 depend on the delivery_build or delivery-base cookbook. Instead, the Test
 Kitchen instance will use ChefDK as per the standard Workflow Runner setup.
+
+Also the build cookbook generator will not overwrite your `config.json` or
+`project.toml` if they exist already on your project.

--- a/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/build_cookbook.rb
@@ -3,18 +3,22 @@ context = ChefDK::Generator.context
 delivery_project_dir = context.delivery_project_dir
 pipeline = context.pipeline
 dot_delivery_dir = File.join(delivery_project_dir, '.delivery')
+config_json = File.join(dot_delivery_dir, 'config.json')
+project_toml = File.join(dot_delivery_dir, 'project.toml')
 
 generator_desc('Ensuring delivery configuration')
 
 directory dot_delivery_dir
 
-cookbook_file File.join(dot_delivery_dir, 'config.json') do
+cookbook_file config_json do
   source 'delivery-config.json'
+  not_if { File.exist?(config_json) }
 end
 
 # Adding a new prototype file for delivery-cli local commands
-cookbook_file File.join(dot_delivery_dir, 'project.toml') do
+cookbook_file project_toml do
   source 'delivery-project.toml'
+  not_if { File.exist?(project_toml) }
 end
 
 generator_desc('Ensuring correct delivery build cookbook content')
@@ -124,7 +128,7 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command('git add .delivery/config.json')
     cwd delivery_project_dir
 
-    only_if 'git status --porcelain |grep "."'
+    only_if 'git status -u --porcelain |grep ".delivery/config.json"'
   end
 
   # Adding the new prototype file to the feature branch
@@ -133,14 +137,14 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command('git add .delivery/project.toml')
     cwd delivery_project_dir
 
-    only_if 'git status --porcelain |grep "."'
+    only_if 'git status -u --porcelain |grep ".delivery/project.toml"'
   end
 
   execute('git-commit-delivery-config') do
     command('git commit -m "Add generated delivery configuration"')
     cwd delivery_project_dir
 
-    only_if 'git status --porcelain |grep "."'
+    only_if 'git status -u --porcelain | egrep "config.json|project.toml"'
   end
 
   generator_desc('Adding build cookbook to feature branch')
@@ -149,14 +153,14 @@ if context.have_git && context.delivery_project_git_initialized && !context.skip
     command('git add .delivery')
     cwd delivery_project_dir
 
-    only_if 'git status --porcelain |grep "."'
+    only_if 'git status -u --porcelain |grep ".delivery"'
   end
 
   execute('git-commit-delivery-build-cookbook') do
     command('git commit -m "Add generated delivery build cookbook"')
     cwd delivery_project_dir
 
-    only_if 'git status --porcelain |grep "."'
+    only_if 'git status -u --porcelain |grep ".delivery"'
   end
 
   execute("git-return-to-#{pipeline}-branch") do


### PR DESCRIPTION
### Description
Before this change if a user ran `chef generate build-cookbook .` on a
delivery project that has already a `project.toml` and/or `config.json`
both files would get overwritten.

This change fixes this problem by adding a `not_if` guard.

Signed-off-by: Salim Afiune <afiune@chef.io>

### Issues Resolved

COOL-653 / ZD 10945

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
