### PR TITLE
Remove chefstyle from DK and pin cookstyle with a minimal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,6 @@ matrix:
       script: $(which bundle) exec rake style:cookstyle
     - rvm: 2.3.1
       env:
-        CHEFSTYLE: 1
-      script: $(which bundle) exec rake style:chefstyle
-    - rvm: 2.3.1
-      env:
         FOODCRITIC: 1
       script: $(which bundle) exec rake style:foodcritic
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,9 +35,8 @@ group(:omnibus_package, :development, :test) do
   gem "dep_selector"
   gem "guard"
   gem "ruby-prof"
-  gem "cookstyle"
-  gem "chefstyle"
-  gem "foodcritic", ">= 8.0"
+  gem "cookstyle", ">= 1.3.0"
+  gem "foodcritic", ">= 9.0"
 end
 
 # All software we recognize needs to stay at the latest possible version. But

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,6 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     aws-sigv4 (1.0.0)
-    backports (3.6.8)
     berkshelf (5.6.2)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (>= 2.0.2, < 4.0)
@@ -234,14 +233,12 @@ GEM
       chef (>= 12.0)
       fauxhai (~> 3.6)
       rspec (~> 3.0)
-    chefstyle (0.3.1)
-      rubocop (= 0.39.0)
     cleanroom (1.0.0)
     coderay (1.1.1)
     cookbook-omnifetch (0.5.1)
       mixlib-archive (~> 0.4)
-    cookstyle (0.0.1)
-      rubocop (= 0.39.0)
+    cookstyle (1.3.0)
+      rubocop (= 0.47.1)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -503,7 +500,7 @@ GEM
       hashie (~> 3.4)
       inspec (>= 0.34.0, < 2.0.0)
       test-kitchen (~> 1.6)
-    kitchen-vagrant (1.0.1)
+    kitchen-vagrant (1.0.2)
       test-kitchen (~> 1.4)
     knife-opc (0.3.2)
     knife-push (1.0.2)
@@ -583,7 +580,7 @@ GEM
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (8.23.0)
-      chef-config (>= 12.5.0.alpha.1, < 14)
+      chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
@@ -669,8 +666,8 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.39.0)
-      parser (>= 2.3.0.7, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -703,7 +700,7 @@ GEM
     solve (3.1.0)
       molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.66.9)
+    specinfra (2.67.0)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -815,8 +812,7 @@ DEPENDENCIES
   chef-vault
   cheffish (>= 4.0)
   chefspec
-  chefstyle
-  cookstyle
+  cookstyle (>= 1.3.0)
   cucumber
   dco
   dep-selector-libgecode
@@ -824,7 +820,7 @@ DEPENDENCIES
   fauxhai
   ffi
   ffi-rzmq-core
-  foodcritic (>= 8.0)
+  foodcritic (>= 9.0)
   github_changelog_generator!
   guard
   inspec (>= 0.17.1)
@@ -867,4 +863,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.14.3


### PR DESCRIPTION
When we added chefstyle we accidentally dropped cookstyle to a very old release. We’re pinning a minimum version now to avoid ever doing that again. Also we’re removing chefstyle from DK. In the ideal world we’d run DK through Chefstyle, but we don’t want to ship chefstyle with DK. There’s already a huge amount of confusion with customers as to the difference between our two linters. Shipping both with DK would make that much much worse. Let’s avoid the whole problem.

Signed-off-by: Tim Smith <tsmith@chef.io>