### PR TITLE
Use kitchen-dokken 2.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ group(:omnibus_package) do
   gem "fauxhai"
   gem "inspec", ">= 0.17.1"
   gem "kitchen-ec2"
-  gem "kitchen-dokken", "= 1.1.0"
+  gem "kitchen-dokken", ">= 2.1.0"
   gem "kitchen-inspec"
   gem "kitchen-vagrant"
   gem "knife-windows"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,27 +130,26 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.5)
-    activesupport (4.2.7.1)
+    activesupport (4.2.8)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
     app_conf (0.4.2)
-    artifactory (2.6.0)
+    artifactory (2.7.0)
     ast (2.3.0)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.7.11)
-      aws-sdk-resources (= 2.7.11)
-    aws-sdk-core (2.7.11)
+    aws-sdk (2.7.13)
+      aws-sdk-resources (= 2.7.13)
+    aws-sdk-core (2.7.13)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.11)
-      aws-sdk-core (= 2.7.11)
+    aws-sdk-resources (2.7.13)
+      aws-sdk-core (= 2.7.13)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -407,7 +406,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.7.0)
+    fog-vsphere (1.7.1)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.2.3)
@@ -460,12 +459,12 @@ GEM
       thor (>= 0.18.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.3)
+    hashie (3.5.4)
     highline (1.7.8)
     hitimes (1.2.4)
     hitimes (1.2.4-x86-mingw32)
     httpclient (2.8.3)
-    i18n (0.8.0)
+    i18n (0.8.1)
     inflecto (0.0.2)
     inifile (3.0.0)
     iniparse (1.4.2)
@@ -489,7 +488,7 @@ GEM
     jmespath (1.3.1)
     json (1.8.6)
     jwt (1.5.6)
-    kitchen-dokken (1.1.0)
+    kitchen-dokken (2.1.1)
       docker-api (~> 1.33)
       test-kitchen (~> 1.13)
     kitchen-ec2 (1.3.1)
@@ -725,7 +724,7 @@ GEM
       safe_yaml (~> 1.0)
       thor (~> 0.18)
     thor (0.19.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     timers (4.0.4)
       hitimes
     train (0.22.1)
@@ -826,7 +825,7 @@ DEPENDENCIES
   github_changelog_generator!
   guard
   inspec (>= 0.17.1)
-  kitchen-dokken (= 1.1.0)
+  kitchen-dokken (>= 2.1.0)
   kitchen-ec2
   kitchen-inspec
   kitchen-vagrant


### PR DESCRIPTION
The failures with ServerSpec have been resolved.

Signed-off-by: Tim Smith <tsmith@chef.io>