### PR TITLE
Rename LWRP to Resource

### DIFF
--- a/lib/chef-dk/command/generate.rb
+++ b/lib/chef-dk/command/generate.rb
@@ -23,7 +23,7 @@ require "chef-dk/command/generator_commands/cookbook"
 require "chef-dk/command/generator_commands/app"
 require "chef-dk/command/generator_commands/attribute"
 require "chef-dk/command/generator_commands/cookbook_file"
-require "chef-dk/command/generator_commands/lwrp"
+require "chef-dk/command/generator_commands/resource"
 require "chef-dk/command/generator_commands/recipe"
 require "chef-dk/command/generator_commands/template"
 require "chef-dk/command/generator_commands/repo"
@@ -51,7 +51,8 @@ module ChefDK
       generator(:attribute, :Attribute, "Generate an attributes file")
       generator(:template, :Template, "Generate a file template")
       generator(:file, :CookbookFile, "Generate a cookbook file")
-      generator(:lwrp, :LWRP, "Generate a lightweight resource/provider")
+      generator(:lwrp, :Resource, "Generate a custom resource")
+      generator(:resource, :Resource, "Generate a custom resource")
       generator(:repo, :Repo, "Generate a Chef code repository")
       generator(:policyfile, :Policyfile, "Generate a Policyfile for use with the install/push commands")
       generator(:generator, :GeneratorGenerator, "Copy ChefDK's generator cookbook so you can customize it")

--- a/lib/chef-dk/command/generator_commands/resource.rb
+++ b/lib/chef-dk/command/generator_commands/resource.rb
@@ -15,17 +15,22 @@
 # limitations under the License.
 #
 
-require "spec_helper"
-require "shared/a_file_generator"
-require "chef-dk/command/generator_commands/lwrp"
+require "chef-dk/command/generator_commands/cookbook_code_file"
 
-describe ChefDK::Command::GeneratorCommands::LWRP do
+module ChefDK
+  module Command
+    module GeneratorCommands
+      # chef generate resource [path/to/cookbook_root] NAME
+      class Resource < CookbookCodeFile
 
-  include_examples "a file generator" do
+        banner "Usage: chef generate resource [path/to/cookbook] NAME [options]"
 
-    let(:generator_name) { "lwrp" }
-    let(:generated_files) { [ "resources/new_lwrp.rb", "providers/new_lwrp.rb" ] }
-    let(:new_file_name) { "new_lwrp" }
+        options.merge!(SharedGeneratorOptions.options)
 
+        def recipe
+          "resource"
+        end
+      end
+    end
   end
 end

--- a/lib/chef-dk/skeletons/code_generator/recipes/resource.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/resource.rb
@@ -5,19 +5,9 @@ cookbook_dir = File.join(context.cookbook_root, context.cookbook_name)
 resource_dir = File.join(cookbook_dir, 'resources')
 resource_path = File.join(resource_dir, "#{context.new_file_basename}.rb")
 
-provider_dir = File.join(cookbook_dir, 'providers')
-provider_path = File.join(provider_dir, "#{context.new_file_basename}.rb")
-
 directory resource_dir
 
 template resource_path do
   source 'resource.rb.erb'
-  helpers(ChefDK::Generator::TemplateHelper)
-end
-
-directory provider_dir
-
-template provider_path do
-  source 'provider.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/resource.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/resource.rb.erb
@@ -1,0 +1,1 @@
+# To learn more about Custom Resources, see https://docs.chef.io/custom_resources.html

--- a/spec/unit/command/generator_commands/resource_spec.rb
+++ b/spec/unit/command/generator_commands/resource_spec.rb
@@ -15,22 +15,17 @@
 # limitations under the License.
 #
 
-require "chef-dk/command/generator_commands/cookbook_code_file"
+require "spec_helper"
+require "shared/a_file_generator"
+require "chef-dk/command/generator_commands/resource"
 
-module ChefDK
-  module Command
-    module GeneratorCommands
-      # chef generate lwrp [path/to/cookbook_root] NAME
-      class LWRP < CookbookCodeFile
+describe ChefDK::Command::GeneratorCommands::Resource do
 
-        banner "Usage: chef generate lwrp [path/to/cookbook] NAME [options]"
+  include_examples "a file generator" do
 
-        options.merge!(SharedGeneratorOptions.options)
+    let(:generator_name) { "resource" }
+    let(:generated_files) { [ "resources/new_resource.rb" ] }
+    let(:new_file_name) { "new_resource" }
 
-        def recipe
-          "lwrp"
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
We've been careful to talk only about custom Resources of late, and so
we should continue to do so in our tools.

This is a breaking change and will need to wait for chef-dk 2.0. cc @chef/maintainers