### PR TITLE
A cookbook may not contain a recipe

### DIFF
--- a/lib/chef-dk/command/generator_commands/cookbook_code_file.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook_code_file.rb
@@ -85,7 +85,7 @@ module ChefDK
         end
 
         def validate_cookbook_path
-          unless File.directory?(File.join(cookbook_path, "recipes"))
+          unless File.file?(File.join(cookbook_path, "metadata.rb"))
             @errors << "Directory #{cookbook_path} is not a cookbook"
             @params_valid = false
           end


### PR DESCRIPTION
When checking for a cookbook's validity, we should only look for
metadata.rb; recipes or any other directory are not required.

cc @chef/maintainers