### PR TITLE
bump dependencies, particularly cheffish to 5.x

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_FROZEN: '1'
+BUNDLE_FROZEN: "1"

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 # since that's not expressible here, we make it >= the last *known* version to
 # at least prevent downgrades beyond that:
 group(:omnibus_package) do
-  gem "appbundler", github: "chef/appbundler" # until next release with multiple-gem support
+  gem "appbundler", git: "https://github.com/chef/appbundler" # until next release with multiple-gem support
   gem "berkshelf", ">= 5.0"
   # Chef 12.8.1 Gem includes some extra files which can break gem installation on
   # windows. For now we are pulling chef from github at the tag as a workaround.
@@ -54,7 +54,7 @@ group(:omnibus_package) do
   gem "chef-provisioning-vagrant", ">= 0.11.0"
   gem "chef-vault"
   # The chef version is pinned by "rake dependencies", which grabs the current version from omnibus.
-  gem "chef", github: "chef/chef", branch: "v12.19.36"
+  gem "chef", git: "https://github.com/chef/chef", branch: "v12.19.36"
   gem "cheffish", ">= 4.0"
   gem "chefspec"
   gem "fauxhai"
@@ -75,7 +75,7 @@ group(:omnibus_package) do
   gem "mixlib-versioning"
   gem "artifactory"
   # The opscode-pushy-client version is pinned by "rake dependencies", which grabs the current version from omnibus.
-  gem "opscode-pushy-client", github: "chef/opscode-pushy-client", branch: "2.1.2"
+  gem "opscode-pushy-client", git: "https://github.com/chef/opscode-pushy-client", branch: "2.1.2"
   gem "ffi-rzmq-core"
   gem "knife-push"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
-  remote: git://github.com/chef/appbundler.git
+  remote: https://github.com/chef/appbundler.git
   revision: 6582b68884453b5ca5c962458a0c08046c719558
   specs:
     appbundler (0.10.0)
       mixlib-cli (~> 1.4)
 
 GIT
-  remote: git://github.com/chef/chef.git
+  remote: https://github.com/chef/chef.git
   revision: 7b8ceacf4fe474587a485b5ad23713a5c0096145
   branch: v12.19.36
   specs:
@@ -86,7 +86,7 @@ GIT
       mixlib-shellout (~> 2.0)
 
 GIT
-  remote: git://github.com/chef/opscode-pushy-client.git
+  remote: https://github.com/chef/opscode-pushy-client.git
   revision: 960147934b353e73f7cb7601fb2ac9143fa93f4d
   branch: 2.1.2
   specs:
@@ -143,13 +143,13 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.8.4)
-      aws-sdk-resources (= 2.8.4)
-    aws-sdk-core (2.8.4)
+    aws-sdk (2.8.5)
+      aws-sdk-resources (= 2.8.5)
+    aws-sdk-core (2.8.5)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.4)
-      aws-sdk-core (= 2.8.4)
+    aws-sdk-resources (2.8.5)
+      aws-sdk-core (= 2.8.5)
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
@@ -192,8 +192,8 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-provisioning (2.1.1)
-      cheffish (~> 4.0)
+    chef-provisioning (2.2.0)
+      cheffish (>= 4.0, < 6.0)
       inifile (>= 2.0.2)
       mixlib-install (>= 1.0, < 3.0)
       net-scp (~> 1.0)
@@ -210,9 +210,9 @@ GEM
     chef-provisioning-azure (0.6.0)
       chef-provisioning (>= 1.0, < 3.0)
       stuartpreston-azure-sdk-for-ruby (~> 0.7)
-    chef-provisioning-fog (0.23.0)
+    chef-provisioning-fog (0.24.0)
       chef-provisioning (>= 1.0, < 3.0)
-      cheffish (~> 4.0)
+      cheffish (>= 4.0, < 6.0)
       fog (>= 1.37.0)
       fog-digitalocean
       fog-scaleway
@@ -230,7 +230,7 @@ GEM
       mixlib-log (~> 1.3)
       rack (~> 2.0)
       uuidtools (~> 2.1)
-    cheffish (4.1.1)
+    cheffish (5.0.1)
       chef-zero (~> 5.0)
       net-ssh
     chefspec (6.1.0)
@@ -601,7 +601,7 @@ GEM
       wmi-lite (~> 1.0)
     os (0.9.6)
     paint (1.0.1)
-    parallel (1.10.0)
+    parallel (1.11.0)
     parser (2.4.0.0)
       ast (~> 2.2)
     parslet (1.5.0)
@@ -875,4 +875,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
-  remote: https://github.com/chef/appbundler.git
+  remote: https://github.com/chef/appbundler
   revision: 6582b68884453b5ca5c962458a0c08046c719558
   specs:
     appbundler (0.10.0)
       mixlib-cli (~> 1.4)
 
 GIT
-  remote: https://github.com/chef/chef.git
+  remote: https://github.com/chef/chef
   revision: 7b8ceacf4fe474587a485b5ad23713a5c0096145
   branch: v12.19.36
   specs:
@@ -86,7 +86,7 @@ GIT
       mixlib-shellout (~> 2.0)
 
 GIT
-  remote: https://github.com/chef/opscode-pushy-client.git
+  remote: https://github.com/chef/opscode-pushy-client
   revision: 960147934b353e73f7cb7601fb2ac9143fa93f4d
   branch: 2.1.2
   specs:


### PR DESCRIPTION
gets the chef-dk and chef-provisioning world onto cheffish 5.x