### PR TITLE
"build" devkit last

### DIFF
--- a/omnibus/config/software/chef-dk-complete.rb
+++ b/omnibus/config/software/chef-dk-complete.rb
@@ -22,9 +22,6 @@ dependency "gem-permissions"
 if windows?
   dependency "chef-dk-env-customization"
   dependency "chef-dk-powershell-scripts"
-  # TODO can this be safely moved to before the chef-dk?
-  # It would make caching better ...
-  dependency "ruby-windows-devkit"
 end
 
 dependency "chef-dk-cleanup"
@@ -34,3 +31,7 @@ dependency "version-manifest"
 dependency "openssl-customization"
 
 dependency "stunnel" if fips_mode?
+
+# This *has* to be last, as it mutates the build environment and causes all
+# compilations that use ./configure et all (the msys env) to break
+dependency "ruby-windows-devkit"

--- a/omnibus/config/software/chef-dk-complete.rb
+++ b/omnibus/config/software/chef-dk-complete.rb
@@ -34,4 +34,4 @@ dependency "stunnel" if fips_mode?
 
 # This *has* to be last, as it mutates the build environment and causes all
 # compilations that use ./configure et all (the msys env) to break
-dependency "ruby-windows-devkit"
+dependency "ruby-windows-devkit" if windows?


### PR DESCRIPTION
### Description

Something in the installation of devkit munges the ruby environment of the build itself, which causes any defs after that to fail with strange pathing issues. This moves it to the end of the build so that it won't cause issues.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
