### PR TITLE
Require Chef 12.1+ in the skeleton cookbook and use chef_version

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/metadata.rb.erb
@@ -3,6 +3,7 @@ maintainer '<%= copyright_holder %>'
 maintainer_email '<%= email %>'
 license '<%= license %>'
 version '0.1.0'
+chef_version '>= 12.1' if respond_to?(:chef_version)
 <% if build_cookbook_parent_is_cookbook -%>
 
 depends 'delivery-truck'

--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -5,15 +5,16 @@ license '<%= license %>'
 description 'Installs/Configures <%= cookbook_name %>'
 long_description 'Installs/Configures <%= cookbook_name %>'
 version '0.1.0'
+chef_version '>= 12.1' if respond_to?(:chef_version)
 
 # The `issues_url` points to the location where issues for this cookbook are
 # tracked.  A `View Issues` link will be displayed on this cookbook's page when
 # uploaded to a Supermarket.
 #
-# issues_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>/issues' if respond_to?(:issues_url)
+# issues_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>/issues'
 
 # The `source_url` points to the development reposiory for this cookbook.  A
 # `View Source` link will be displayed on this cookbook's page when uploaded to
 # a Supermarket.
 #
-# source_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>' if respond_to?(:source_url)
+# source_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>'

--- a/spec/unit/command/generator_commands/build_cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/build_cookbook_spec.rb
@@ -198,6 +198,7 @@ maintainer 'The Authors'
 maintainer_email 'you@example.com'
 license 'all_rights'
 version '0.1.0'
+chef_version '>= 12.1' if respond_to?(:chef_version)
 
 depends 'delivery-truck'
 METADATA


### PR DESCRIPTION
Without this these are going to fail foodcritic. The 12.1+ is common sense at this point

Signed-off-by: Tim Smith <tsmith@chef.io>