### PR TITLE
Smoke tests always end with `_test.rb`

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -6,7 +6,7 @@ spec_helper_path = File.join(cookbook_dir, 'spec', 'spec_helper.rb')
 spec_dir = File.join(cookbook_dir, 'spec', 'unit', 'recipes')
 spec_path = File.join(spec_dir, "#{context.new_file_basename}_spec.rb")
 inspec_dir = File.join(cookbook_dir, 'test', 'smoke', 'default')
-inspec_path = File.join(inspec_dir, "#{context.new_file_basename}.rb")
+inspec_path = File.join(inspec_dir, "#{context.new_file_basename}_test.rb")
 
 if File.directory?(File.join(cookbook_dir, 'test', 'recipes'))
   Chef::Log.deprecation <<-EOH

--- a/spec/unit/command/generator_commands/recipe_spec.rb
+++ b/spec/unit/command/generator_commands/recipe_spec.rb
@@ -27,7 +27,7 @@ describe ChefDK::Command::GeneratorCommands::Recipe do
     let(:generated_files) { [ "recipes/new_recipe.rb",
                               "spec/spec_helper.rb",
                               "spec/unit/recipes/new_recipe_spec.rb",
-                              "test/smoke/default/new_recipe.rb",
+                              "test/smoke/default/new_recipe_test.rb",
                             ] }
     let(:new_file_name) { "new_recipe" }
 


### PR DESCRIPTION
Previously the smoke test had the same name as the recipe.  This changes
that so that the smoke test will match `#{context.new_file_basename}_test.rb`

Signed-off-by: Nathen Harvey <nharvey@chef.io>
