### PR TITLE
Bump cookstyle and foodcritic deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,13 +144,13 @@ GEM
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (2.9.3)
-      aws-sdk-resources (= 2.9.3)
-    aws-sdk-core (2.9.3)
+    aws-sdk (2.9.7)
+      aws-sdk-resources (= 2.9.7)
+    aws-sdk-core (2.9.7)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.3)
-      aws-sdk-core (= 2.9.3)
+    aws-sdk-resources (2.9.7)
+      aws-sdk-core (= 2.9.7)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
@@ -243,7 +243,7 @@ GEM
     coderay (1.1.1)
     cookbook-omnifetch (0.5.1)
       mixlib-archive (~> 0.4)
-    cookstyle (1.3.0)
+    cookstyle (1.3.1)
       rubocop (= 0.47.1)
     cucumber (2.4.0)
       builder (>= 2.1.2)
@@ -266,7 +266,7 @@ GEM
       ffi (~> 1.9)
     diff-lcs (1.3)
     diffy (3.2.0)
-    docker-api (1.33.3)
+    docker-api (1.33.4)
       excon (>= 0.38.0)
       json
     erubis (2.7.0)
@@ -420,7 +420,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.9.0)
+    fog-vsphere (1.9.1)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -429,7 +429,7 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
-    foodcritic (10.2.2)
+    foodcritic (10.4.1)
       cucumber-core (>= 1.3)
       erubis
       nokogiri (>= 1.5, < 2.0)
@@ -719,7 +719,7 @@ GEM
     solve (3.1.0)
       molinillo (>= 0.5)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.67.7)
+    specinfra (2.67.8)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -791,7 +791,7 @@ GEM
     windows-pr (1.2.6)
       win32-api (>= 1.4.5)
       windows-api (>= 0.4.0)
-    winrm (2.2.1)
+    winrm (2.2.2)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)


### PR DESCRIPTION
We need a release of ChefDK in current that has the latest cookstyle and foodcritic. Right now if someone does the right thing with amazon for Chef 13, then travis goes red since old Foodcritic blows up.

Signed-off-by: Tim Smith <tsmith@chef.io>