### PR TITLE
Remove support for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ env:
 
 matrix:
   include:
-    - rvm: 2.2.5
-      env:
-        RSPEC: 1
-      script: $(which bundle) exec rspec
     - rvm: 2.3.1
       env:
         RSPEC: 1

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.summary       = gem.description
   gem.homepage      = "https://www.chef.io/"
 
-  gem.required_ruby_version = ">= 2.2"
+  gem.required_ruby_version = ">= 2.3"
 
   gem.files = %w{Rakefile LICENSE README.md warning.txt} +
     %w{version_policy.rb omnibus_overrides.rb} +


### PR DESCRIPTION
We’re shipping on 2.3 anyways and will be shipping on 2.4 in the near future. I’m not sure what the goal of 2.2 support was really since we tell people to use the package. Seems like this just makes testing take longer.

Signed-off-by: Tim Smith <tsmith@chef.io>