### PR TITLE
remove iconv from ruby build

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 35ccd6f45c2c876947e134573eac403ca11312f8
+  revision: 4e3a4599e66d85f64a91fe5586e3d2760988aea2
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -30,13 +30,13 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     artifactory (2.8.1)
     awesome_print (1.7.0)
-    aws-sdk (2.9.7)
-      aws-sdk-resources (= 2.9.7)
-    aws-sdk-core (2.9.7)
+    aws-sdk (2.9.9)
+      aws-sdk-resources (= 2.9.9)
+    aws-sdk-core (2.9.9)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.7)
-      aws-sdk-core (= 2.9.7)
+    aws-sdk-resources (2.9.9)
+      aws-sdk-core (= 2.9.9)
     aws-sigv4 (1.0.0)
     berkshelf (5.6.4)
       addressable (~> 2.3, >= 2.3.4)
@@ -98,7 +98,7 @@ GEM
     iostruct (0.0.4)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.0.4)
+    json (2.1.0)
     kitchen-vagrant (1.1.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
@@ -210,7 +210,7 @@ GEM
       hashie (>= 2.0.2, < 4.0.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    winrm (2.2.1)
+    winrm (2.2.2)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -245,4 +245,4 @@ DEPENDENCIES
   winrm-elevated
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -26,7 +26,6 @@ end
 # For nokogiri
 dependency "libxml2"
 dependency "libxslt"
-dependency "libiconv"
 dependency "liblzma"
 dependency "zlib"
 

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright 2014-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ dependency "curl"
 dependency "zlib"
 dependency "openssl"
 dependency "pcre"
-dependency "libiconv"
+dependency "libiconv"  # FIXME: can we figure out how to remove this?
 dependency "expat"
 
 relative_path "git-#{version}"

--- a/omnibus/files/chef-dk-gem/build-chef-dk-gem.rb
+++ b/omnibus/files/chef-dk-gem/build-chef-dk-gem.rb
@@ -94,7 +94,7 @@ module BuildChefDKGem
         --with-xml2-include=#{Shellwords.escape("#{install_dir}/embedded/include/libxml2")}
         --with-xslt-lib=#{Shellwords.escape("#{install_dir}/embedded/lib")}
         --with-xslt-include=#{Shellwords.escape("#{install_dir}/embedded/include/libxslt")}
-        --with-iconv-dir=#{Shellwords.escape("#{install_dir}/embedded")}
+        --without-iconv-dir
         --with-zlib-dir=#{Shellwords.escape("#{install_dir}/embedded")}
       }.join(" "),
     }


### PR DESCRIPTION
we still have iconv in chef-dk due to git

