### PR TITLE
Add inspec to chef --version output

### DIFF
--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -97,12 +97,12 @@ BANNER
     def show_version
       msg("Chef Development Kit Version: #{ChefDK::VERSION}")
 
-      ["chef-client", "delivery", "berks", "kitchen"].each do |component|
+      ["chef-client", "delivery", "berks", "kitchen", "inspec"].each do |component|
         result = Bundler.with_clean_env { shell_out("#{component} --version") }
         if result.exitstatus != 0
           msg("#{component} version: ERROR")
         else
-          version = result.stdout.scan(/(?:master\s)?[\d+\.\(\)]+\S+/).join("\s")
+          version = result.stdout.lines.first.scan(/(?:master\s)?[\d+\.\(\)]+\S+/).join("\s")
           msg("#{component} version: #{version}")
         end
       end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -143,6 +143,10 @@ E
           "version_output" => "Test Kitchen version 1.3.1",
           "expected_version" => "1.3.1",
         },
+        "inspec" => {
+          "version_output" => "1.19.1\n\nYour version of InSpec is out of date! The latest version is 1.21.0.",
+          "expected_version" => "1.19.1"
+        }
       }
     }
 


### PR DESCRIPTION
This change adds InSpec to the output of the `chef --version`
command since InSpec is properly app-bundled inside the DK
and is promoted as a component of the DK.