### PR TITLE
Move to Chef 13 compatibility

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", "~> 2.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
   gem.add_dependency "minitar", "~> 0.5.4"
-  gem.add_dependency "chef", "~> 12.5"
+  gem.add_dependency "chef", "~> 13.0"
   gem.add_dependency "solve", "< 4.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.6"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"

--- a/spec/unit/policyfile/read_cookbook_for_compat_mode_upload_spec.rb
+++ b/spec/unit/policyfile/read_cookbook_for_compat_mode_upload_spec.rb
@@ -85,7 +85,7 @@ describe ChefDK::Policyfile::ReadCookbookForCompatModeUpload do
     end
 
     it "excludes ignored files from the list of cookbook files" do
-      expect(reader_with_ignored_files.cookbook_version.root_filenames).to_not include(chefignored_file)
+      expect(reader_with_ignored_files.cookbook_version.files_for("root_files")).to_not include(chefignored_file)
     end
 
   end

--- a/spec/unit/policyfile_lock_install_spec.rb
+++ b/spec/unit/policyfile_lock_install_spec.rb
@@ -96,8 +96,8 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from a lockfile" do
       cookbook_lock = policyfile_lock.cookbook_locks["local-cookbook"]
       expect(cookbook_lock.name).to eq("local-cookbook")
       expect(cookbook_lock.version).to eq("2.3.4")
-      expect(cookbook_lock.identifier).to eq("fab501cfaf747901bd82c1bc706beae7dc3a350c")
-      expect(cookbook_lock.dotted_decimal_identifier).to eq("70567763561641081.489844270461035.258281553147148")
+      expect(cookbook_lock.identifier).to eq("1e9dfd1134735385b425c056cb5decef9081b92c")
+      expect(cookbook_lock.dotted_decimal_identifier).to eq("8617959542256467.37634246136220509.260513665759532")
       expect(cookbook_lock.source).to eq("local-cookbook")
       expect(cookbook_lock.source_options).to eq({ path: "local-cookbook" })
       expect(cookbook_lock.cookbook_location_spec.version_constraint).to eq(Semverse::Constraint.new("= 2.3.4"))

--- a/spec/unit/policyfile_lock_validation_spec.rb
+++ b/spec/unit/policyfile_lock_validation_spec.rb
@@ -199,7 +199,7 @@ E
       it "updates the content identifier" do
         old_id = lock_generator.lock_data_for("local-cookbook").identifier
         expect(cookbook_lock_data.identifier).to_not eq(old_id)
-        expect(cookbook_lock_data.identifier).to eq("d71622904ed89b1e0066bb4ae823b2a7b49a615a")
+        expect(cookbook_lock_data.identifier).to eq("5a2b09f9d5e6e8a1a2d811c41d58ed200599adbe")
       end
 
       it "has an updated version and identifier" do
@@ -267,7 +267,7 @@ E
         old_id = lock_generator.lock_data_for("local-cookbook").identifier
 
         expect(cookbook_lock_data.identifier).to_not eq(old_id)
-        expect(cookbook_lock_data.identifier).to eq("08a96e3afbd1eaa1183a2dde8687ca29dbddc94b")
+        expect(cookbook_lock_data.identifier).to eq("0f62422f744d173c35a3e74f1a8c76c8b92908c2")
       end
 
       it "has an updated identifier but not an updated version" do
@@ -305,7 +305,7 @@ E
         old_id = lock_generator.lock_data_for("local-cookbook").identifier
 
         expect(cookbook_lock_data.identifier).to_not eq(old_id)
-        expect(cookbook_lock_data.identifier).to eq("da6a1c0f8791df713b7ff8c27285fbe7923901cc")
+        expect(cookbook_lock_data.identifier).to eq("af5e1252307bdf99b878ca5ede3c40e24ee9e45a")
       end
 
       it "has an updated identifier but not an updated version" do

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -106,7 +106,7 @@ describe ChefDK::PolicyfileServices::ExportRepo do
 
       let(:local_cookbook_path) { File.join(fixtures_path, "local_path_cookbooks/local-cookbook") }
 
-      let(:revision_id) { "60e5ad638dce219d8f87d589463ec4a9884007ba5e2adbb4c0a7021d67204f1a" }
+      let(:revision_id) { "7da81d2c7bb97f904637f97e7f8b487fa4bb1ed682edea7087743dec84c254ec" }
 
       let(:lockfile_content) do
         <<-E
@@ -119,8 +119,8 @@ describe ChefDK::PolicyfileServices::ExportRepo do
   "cookbook_locks": {
     "local-cookbook": {
       "version": "2.3.4",
-      "identifier": "fab501cfaf747901bd82c1bc706beae7dc3a350c",
-      "dotted_decimal_identifier": "70567763561641081.489844270461035.258281553147148",
+      "identifier": "1e9dfd1134735385b425c056cb5decef9081b92c",
+      "dotted_decimal_identifier": "42704157235437826.6970356709321892.63549625984142",
       "source": "#{local_cookbook_path}",
       "cache_key": null,
       "scm_info": null,
@@ -168,7 +168,7 @@ E
         context "when the given 'export_dir' is a directory" do
 
           it "sets the archive file location to $policy_name-$revision.tgz" do
-            expected = File.join(export_dir, "install-example-60e5ad638dce219d8f87d589463ec4a9884007ba5e2adbb4c0a7021d67204f1a.tgz")
+            expected = File.join(export_dir, "install-example-7da81d2c7bb97f904637f97e7f8b487fa4bb1ed682edea7087743dec84c254ec.tgz")
             expect(export_service.archive_file_location).to eq(expected)
           end
 
@@ -215,7 +215,7 @@ E
             expected << Pathname.new("metadata.json")
           end
 
-          let(:cookbook_with_version) { "local-cookbook-fab501cfaf747901bd82c1bc706beae7dc3a350c" }
+          let(:cookbook_with_version) { "local-cookbook-1e9dfd1134735385b425c056cb5decef9081b92c" }
 
           let(:exported_cookbook_root) { Pathname.new(File.join(export_dir, "cookbook_artifacts", cookbook_with_version)) }
 
@@ -422,7 +422,7 @@ CONFIG
           let(:archive) { true }
 
           let(:expected_archive_path) do
-            File.join(export_dir, "install-example-60e5ad638dce219d8f87d589463ec4a9884007ba5e2adbb4c0a7021d67204f1a.tgz")
+            File.join(export_dir, "install-example-7da81d2c7bb97f904637f97e7f8b487fa4bb1ed682edea7087743dec84c254ec.tgz")
           end
 
           it "exports the repo as a tgz archive" do

--- a/spec/unit/policyfile_services/install_spec.rb
+++ b/spec/unit/policyfile_services/install_spec.rb
@@ -128,7 +128,7 @@ E
 
       it "prints the lockfile's revision id" do
         install_service.run
-        expect(ui.output).to include("Policy revision id: 60e5ad638dce219d8f87d589463ec4a9884007ba5e2adbb4c0a7021d67204f1a")
+        expect(ui.output).to include("Policy revision id: 7da81d2c7bb97f904637f97e7f8b487fa4bb1ed682edea7087743dec84c254ec")
       end
 
     end


### PR DESCRIPTION
The SHAs all change because we're including more files in the cookbook
upload.