### PR TITLE
Fix `chef generate template` with a content source

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/template.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/template.rb
@@ -19,7 +19,7 @@ end
 if context.content_source
 
   file template_path do
-    content(IO.read(context.context_source))
+    content(IO.read(context.content_source))
   end
 
 else


### PR DESCRIPTION
A typo in the template recipe inside the generator is preventing
the `chef generate template` command from working if the user
passes a content source with `-s`:

```
ChefDK::ChefConvergeError: Chef failed to converge: undefined method `context_source' for #<ChefDK::Generator::Context:0x007fb6e1d6d590>
```

The proper method name is `content_source`, not `context_source`.