### PR TITLE
Ensure a config object is passed down in the update action

### DIFF
--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -101,7 +101,7 @@ BANNER
       end
 
       def installer
-        @installer ||= PolicyfileServices::Install.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd, overwrite: true)
+        @installer ||= PolicyfileServices::Install.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd, config: chef_config, overwrite: true)
       end
 
       def attributes_updater

--- a/spec/unit/command/install_spec.rb
+++ b/spec/unit/command/install_spec.rb
@@ -78,7 +78,7 @@ describe ChefDK::Command::Install do
 
     it "creates the installer service with a `nil` policyfile path" do
       expect(ChefDK::PolicyfileServices::Install).to receive(:new).
-        with(hash_including(policyfile: nil, ui: command.ui, root_dir: Dir.pwd)).
+        with(hash_including(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, config: Chef::Config)).
         and_return(install_service)
       expect(command.installer).to eq(install_service)
     end
@@ -95,7 +95,7 @@ describe ChefDK::Command::Install do
 
     it "creates the installer service with the specified policyfile path" do
       expect(ChefDK::PolicyfileServices::Install).to receive(:new).
-        with(hash_including(policyfile: "MyPolicy.rb", ui: command.ui, root_dir: Dir.pwd)).
+        with(hash_including(policyfile: "MyPolicy.rb", ui: command.ui, root_dir: Dir.pwd, config: Chef::Config)).
         and_return(install_service)
       expect(command.installer).to eq(install_service)
     end

--- a/spec/unit/command/update_spec.rb
+++ b/spec/unit/command/update_spec.rb
@@ -96,7 +96,7 @@ describe ChefDK::Command::Update do
 
     it "creates the installer service with a `nil` policyfile path" do
       expect(ChefDK::PolicyfileServices::Install).to receive(:new).
-        with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, overwrite: true).
+        with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, config: Chef::Config, overwrite: true).
         and_return(install_service)
       expect(command.installer).to eq(install_service)
     end
@@ -113,7 +113,7 @@ describe ChefDK::Command::Update do
 
     it "creates the installer service with the specified policyfile path" do
       expect(ChefDK::PolicyfileServices::Install).to receive(:new).
-        with(policyfile: "MyPolicy.rb", ui: command.ui, root_dir: Dir.pwd, overwrite: true).
+        with(policyfile: "MyPolicy.rb", ui: command.ui, root_dir: Dir.pwd, config: Chef::Config, overwrite: true).
         and_return(install_service)
       expect(command.installer).to eq(install_service)
     end


### PR DESCRIPTION
### Description

The install action was already doing this, just updates the update action to match.

### Issues Resolved

* An "undefined method for nil" error when running `chef update` with a Chef Server or Artifactory source.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Jonathan Hartman <j@p4nt5.com>