### PR TITLE
Make it clearer that chef verify is not for end users

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -55,5 +55,5 @@ ChefDK.commands do |c|
 
   c.builtin "undelete", :Undelete, desc: "Undo a delete command"
 
-  c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications"
+  c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications", hidden: true
 end

--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -114,6 +114,7 @@ BANNER
 
       justify_length = subcommands.map(&:length).max + 2
       subcommand_specs.each do |name, spec|
+        next if spec.hidden
         msg("    #{"#{name}".ljust(justify_length)}#{spec.description}")
       end
     end

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -544,6 +544,7 @@ end
       end
 
       def run(params = [ ])
+        err("[WARN] This is an internal command used by the ChefDK development team. If you are a ChefDK user, please do not run it.")
         @components_filter = parse_options(params)
 
         validate_components!

--- a/lib/chef-dk/commands_map.rb
+++ b/lib/chef-dk/commands_map.rb
@@ -54,7 +54,7 @@ module ChefDK
   class CommandsMap
     NULL_ARG = Object.new
 
-    CommandSpec = Struct.new(:name, :constant_name, :require_path, :description)
+    CommandSpec = Struct.new(:name, :constant_name, :require_path, :description, :hidden)
 
     class CommandSpec
 
@@ -72,12 +72,12 @@ module ChefDK
       @command_specs = {}
     end
 
-    def builtin(name, constant_name, require_path: NULL_ARG, desc: "")
+    def builtin(name, constant_name, require_path: NULL_ARG, desc: "", hidden: false)
       if null?(require_path)
         snake_case_path = name.tr("-", "_")
         require_path = "chef-dk/command/#{snake_case_path}"
       end
-      command_specs[name] = CommandSpec.new(name, constant_name, require_path, desc)
+      command_specs[name] = CommandSpec.new(name, constant_name, require_path, desc, hidden)
     end
 
     def instantiate(name)

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -106,6 +106,7 @@ describe ChefDK::Command::Verify do
 
   describe "when running verify command" do
     let(:stdout_io) { StringIO.new }
+    let(:stderr_io) { StringIO.new }
     let(:ruby_path) { File.join(fixtures_path, "eg_omnibus_dir/valid/embedded/bin/ruby") }
 
     def run_unit_test
@@ -170,6 +171,7 @@ describe ChefDK::Command::Verify do
     before do
       allow(Gem).to receive(:ruby).and_return(ruby_path)
       allow(command_instance).to receive(:stdout).and_return(stdout_io)
+      allow(command_instance).to receive(:stderr).and_return(stderr_io)
       allow(command_instance).to receive(:components).and_return(components)
     end
 


### PR DESCRIPTION
This both hides it from `--help` and shows a warning on stderr. Should help cut down on support requests. The plan outside of this is to refactor stuff such that `verify` will fail if you are airgapped or otherwise in a weird Ruby situation.