### PR TITLE
Bump dep_selector gem to 1.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
       thor (~> 0.19)
     debug_inspector (0.0.3)
     dep-selector-libgecode (1.3.1)
-    dep_selector (1.0.4)
+    dep_selector (1.0.5)
       dep-selector-libgecode (~> 1.0)
       ffi (~> 1.9)
     diff-lcs (1.3)


### PR DESCRIPTION
In certain cases a complicated set of cookbooks without a solution could timeout
while trying to resolve the dependency tree. This was causing a segfault.
