### PR TITLE
remove "update_rubygems" from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ install:
   - gem uninstall bundler -a -x
   - gem update --system %OMNIBUS_RUBYGEMS% || gem update --system %OMNIBUS_RUBYGEMS% || gem update --system %OMNIBUS_RUBYGEMS%
   - gem install bundler -v %OMNIBUS_BUNDLER% --quiet --no-ri --no-rdoc || gem install bundler -v %OMNIBUS_BUNDLER% --quiet --no-ri --no-rdoc || gem install bundler -v %OMNIBUS_BUNDLER% --quiet --no-ri --no-rdoc
-  - update_rubygems
   - gem --version
   - bundler --version
   - SET BUNDLE_WITHOUT=guard:maintenance:tools:integration:changelog:docgen:travis:style:omnibus_package:aix:bsd:linux:mac_os_x:solaris


### PR DESCRIPTION
    defeats the purpose of our pinning rubygems.

    and is currently bringing in a broken version of rubygems.