### PR TITLE
Add cookstyle linting as default

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-config.json
@@ -4,6 +4,9 @@
     "name": "build_cookbook",
     "path": ".delivery/build_cookbook"
   },
+  "delivery-truck": {
+    "enable_cookstyle": true
+  },
   "skip_phases": [],
   "job_dispatch": {
     "version": "v2"

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -235,6 +235,9 @@ PROJECT_DOT_TOML
     "name": "build_cookbook",
     "path": ".delivery/build_cookbook"
   },
+  "delivery-truck": {
+    "enable_cookstyle": true
+  },
   "skip_phases": [],
   "job_dispatch": {
     "version": "v2"


### PR DESCRIPTION
### Description

This modifies the default `config.json` in a generated cookbook to include cookstyle linting in the build cookbook.

### Issues Resolved

Fixes #1146

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
