### PR TITLE
install ohai from Gemfile.lock instead of omnibus software dep

### DIFF
--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -43,7 +43,6 @@ end
 dependency "ruby"
 dependency "rubygems"
 dependency "bundler"
-dependency "ohai"
 dependency "appbundler"
 
 


### PR DESCRIPTION
not from the software dep

this fixes the multiple chef-config gem issue.