### PR TITLE
Ensure that necessary system libraries are installed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     app_conf (0.4.2)
     appbundler (0.10.0)
       mixlib-cli (~> 1.4)
-      mixlib-shellout (~> 2.0)
     artifactory (2.8.2)
     ast (2.3.0)
     autoparse (0.3.3)
@@ -201,7 +200,7 @@ GEM
       retryable
       winrm-elevated
     chef-sugar (3.4.0)
-    chef-vault (3.0.3)
+    chef-vault (3.1.0)
     chef-zero (13.0.0)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)

--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "lcg/improve-appbundling"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "lcg/workaround-omnibus-api"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: d66650a1edd17fec9ebfcf8e8d0653f4d5308b0a
-  branch: lcg/workaround-omnibus-api
+  revision: 8531995ec3a13001ae8991b32f2e5531ee27c2c1
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -77,6 +77,7 @@ if windows?
   override :"ruby-windows-devkit", version: "4.5.2-20111229-1559" if windows_arch_i386?
   dependency "ruby-windows-devkit"
   dependency "ruby-windows-devkit-bash"
+  dependency "ruby-windows-system-libraries"
 end
 
 package :rpm do

--- a/omnibus/config/software/chef-dk-env-customization.rb
+++ b/omnibus/config/software/chef-dk-env-customization.rb
@@ -19,6 +19,7 @@
 
 name "chef-dk-env-customization"
 
+skip_transitive_dependency_licensing true
 license :project_license
 
 source path: "#{project.files_path}/#{name}"

--- a/omnibus/config/software/chef-dk-powershell-scripts.rb
+++ b/omnibus/config/software/chef-dk-powershell-scripts.rb
@@ -19,6 +19,7 @@
 
 name "chef-dk-powershell-scripts"
 
+skip_transitive_dependency_licensing true
 license :project_license
 
 build do

--- a/omnibus/config/software/ruby-windows-system-libraries.rb
+++ b/omnibus/config/software/ruby-windows-system-libraries.rb
@@ -1,0 +1,38 @@
+name "ruby-windows-system-libraries"
+
+default_version "0.0.1"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+dependency "ruby"
+
+build do
+  if windows?
+    # Needed now that we switched to msys2 and have not figured out how to tell
+    # it how to statically link yet
+    dlls = ["libwinpthread-1"]
+    if windows_arch_i386?
+      dlls << "libgcc_s_dw2-1"
+    else
+      dlls << "libgcc_s_seh-1"
+    end
+    dlls.each do |dll|
+      mingw = ENV["MSYSTEM"].downcase
+      msys_path = ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"] ? "#{ENV["OMNIBUS_TOOLCHAIN_INSTALL_DIR"]}/embedded/bin" : "C:/msys2"
+      windows_path = "#{msys_path}/#{mingw}/bin/#{dll}.dll"
+      if File.exist?(windows_path)
+        copy windows_path, "#{install_dir}/embedded/bin/#{dll}.dll"
+      else
+        raise "Cannot find required DLL needed for dynamic linking: #{windows_path}"
+      end
+    end
+
+    if version.satisfies?(">= 2.4")
+      %w{ erb gem irb rdoc ri }.each do |cmd|
+        copy "#{project_dir}/bin/#{cmd}", "#{install_dir}/embedded/bin/#{cmd}"
+      end
+    end
+
+  end
+end

--- a/omnibus/config/software/rubygems-customization.rb
+++ b/omnibus/config/software/rubygems-customization.rb
@@ -17,6 +17,7 @@
 
 name "rubygems-customization"
 
+skip_transitive_dependency_licensing true
 license :project_license
 
 source path: "#{project.files_path}/#{name}"


### PR DESCRIPTION
My suspicion is that the rust uninstall script accidentally clobbers
libgcc from embedded/bin, and that's why it's going AWOL. So this new
software project gets run as late as possible to put it back.