### PR TITLE
Don't include chef-provisioning and friends in the appbundle for the kitchen executable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,10 @@ end
 group(:omnibus_package) do
   gem "appbundler"
   gem "berkshelf", ">= 6.2"
-  gem "chef-provisioning", ">= 2.4.0"
-  gem "chef-provisioning-aws", ">= 2.0"
-  gem "chef-provisioning-azure", ">= 0.6.0"
-  gem "chef-provisioning-fog", ">= 0.20.0"
+  gem "chef-provisioning", ">= 2.4.0", group: :provisioning
+  gem "chef-provisioning-aws", ">= 2.0", group: :provisioning
+  gem "chef-provisioning-azure", ">= 0.6.0", group: :provisioning
+  gem "chef-provisioning-fog", ">= 0.20.0", group: :provisioning
   gem "chef-vault"
   gem "chef", "= 13.2.20"
   gem "cheffish", ">= 13.0"

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -64,8 +64,9 @@ build do
 
   appbundle "berkshelf", lockdir: project_dir, without: %w{guard changelog}, env:env
   appbundle "chef", lockdir: project_dir, without: %w{changelog integration docgen maintenance ci travis}, env:env
+  appbundle "test-kitchen", lockdir: project_dir, without: %w{changelog provisioning}, env: env
 
-  %w{chef-dk chef-vault foodcritic ohai test-kitchen opscode-pushy-client cookstyle inspec dco}.each do |gem|
+  %w{chef-dk chef-vault foodcritic ohai opscode-pushy-client cookstyle inspec dco}.each do |gem|
     appbundle gem, lockdir: project_dir, without: %w{changelog}, env: env
   end
 


### PR DESCRIPTION
I've not actually tested this because I think it might melt my laptop to run the build process but I think it should work. The goal is to cut down on the number of gem conflicts between chef-provisioning stuff and Test Kitchen drivers. Notably kitchen-google and kitchen-openstack are currently sadpanda.