### PR TITLE
Ensure we do protocol version negotiation

### DIFF
--- a/lib/chef-dk/authenticated_http.rb
+++ b/lib/chef-dk/authenticated_http.rb
@@ -15,25 +15,8 @@
 # limitations under the License.
 #
 
-require "chef/http"
-require "chef/http/authenticator"
-require "chef/http/json_input"
-require "chef/http/json_output"
-require "chef/http/decompressor"
-require "chef/http/validate_content_length"
+require "chef/server_api"
 
 module ChefDK
-  class AuthenticatedHTTP < Chef::HTTP
-
-    use JSONInput
-    use JSONOutput
-    use Decompressor
-    use Authenticator
-
-    # ValidateContentLength should come after Decompressor
-    # because the order of middlewares is reversed when handling
-    # responses.
-    use ValidateContentLength
-
-  end
+  AuthenticatedHTTP = Chef::ServerAPI
 end

--- a/lib/chef-dk/command/diff.rb
+++ b/lib/chef-dk/command/diff.rb
@@ -22,7 +22,7 @@ require "chef-dk/policyfile/differ"
 require "chef-dk/policyfile/comparison_base"
 require "chef-dk/policyfile/storage_config"
 require "chef-dk/configurable"
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 
 module ChefDK
   module Command
@@ -161,9 +161,9 @@ BANNER
       end
 
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
-                                                       signing_key_filename: chef_config.client_key,
-                                                       client_name: chef_config.node_name)
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
+                                             signing_key_filename: chef_config.client_key,
+                                             client_name: chef_config.node_name)
       end
 
       def old_lock

--- a/lib/chef-dk/policyfile/chef_server_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/chef_server_cookbook_source.rb
@@ -18,7 +18,7 @@
 require "ffi_yajl"
 require "chef-dk/exceptions"
 require "chef-dk/policyfile/source_uri"
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 
 module ChefDK
   module Policyfile
@@ -82,7 +82,7 @@ module ChefDK
       private
 
       def http_connection_for(base_url)
-        @http_connections[base_url] ||= ChefDK::AuthenticatedHTTP.new(base_url,
+        @http_connections[base_url] ||= Chef::ServerAPI.new(base_url,
                                                        signing_key_filename: chef_config.client_key,
                                                        client_name: chef_config.node_name)
       end

--- a/lib/chef-dk/policyfile/lister.rb
+++ b/lib/chef-dk/policyfile/lister.rb
@@ -17,7 +17,7 @@
 
 require "set"
 
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/service_exceptions"
 
 module ChefDK
@@ -183,7 +183,7 @@ module ChefDK
       end
 
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(config.chef_server_url,
+        @http_client ||= Chef::ServerAPI.new(config.chef_server_url,
                                                        signing_key_filename: config.client_key,
                                                        client_name: config.node_name)
       end

--- a/lib/chef-dk/policyfile_services/clean_policies.rb
+++ b/lib/chef-dk/policyfile_services/clean_policies.rb
@@ -75,9 +75,9 @@ module ChefDK
       end
 
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
-                                                       signing_key_filename: chef_config.client_key,
-                                                       client_name: chef_config.node_name)
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
+                                               signing_key_filename: chef_config.client_key,
+                                               client_name: chef_config.node_name)
       end
 
       private

--- a/lib/chef-dk/policyfile_services/clean_policy_cookbooks.rb
+++ b/lib/chef-dk/policyfile_services/clean_policy_cookbooks.rb
@@ -17,7 +17,7 @@
 
 require "set"
 
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/service_exceptions"
 
 module ChefDK
@@ -111,12 +111,12 @@ module ChefDK
       end
 
       # @api private
-      # An instance of ChefDK::AuthenticatedHTTP configured with the user's
+      # An instance of Chef::ServerAPI configured with the user's
       # server URL and credentials.
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
-                                                       signing_key_filename: chef_config.client_key,
-                                                       client_name: chef_config.node_name)
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
+                                             signing_key_filename: chef_config.client_key,
+                                             client_name: chef_config.node_name)
       end
     end
   end

--- a/lib/chef-dk/policyfile_services/push.rb
+++ b/lib/chef-dk/policyfile_services/push.rb
@@ -18,7 +18,7 @@
 require "ffi_yajl"
 
 require "chef-dk/service_exceptions"
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/policyfile_compiler"
 require "chef-dk/policyfile/uploader"
 require "chef-dk/policyfile/storage_config"
@@ -51,7 +51,7 @@ module ChefDK
       end
 
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(config.chef_server_url,
+        @http_client ||= Chef::ServerAPI.new(config.chef_server_url,
                                                        signing_key_filename: config.client_key,
                                                        client_name: config.node_name)
       end

--- a/lib/chef-dk/policyfile_services/push_archive.rb
+++ b/lib/chef-dk/policyfile_services/push_archive.rb
@@ -20,7 +20,7 @@ require "archive/tar/minitar"
 
 require "chef-dk/service_exceptions"
 require "chef-dk/policyfile_lock"
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/policyfile/uploader"
 
 module ChefDK
@@ -75,9 +75,9 @@ module ChefDK
 
       # @api private
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(config.chef_server_url,
-                                                       signing_key_filename: config.client_key,
-                                                       client_name: config.node_name)
+        @http_client ||= Chef::ServerAPI.new(config.chef_server_url,
+                                             signing_key_filename: config.client_key,
+                                             client_name: config.node_name)
       end
 
       private

--- a/lib/chef-dk/policyfile_services/rm_policy.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy.rb
@@ -16,7 +16,7 @@
 #
 
 require "chef-dk/service_exceptions"
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/policyfile/undo_stack"
 require "chef-dk/policyfile/undo_record"
 
@@ -72,12 +72,12 @@ module ChefDK
       end
 
       # @api private
-      # An instance of ChefDK::AuthenticatedHTTP configured with the user's
+      # An instance of Chef::ServerAPI configured with the user's
       # server URL and credentials.
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
-                                                       signing_key_filename: chef_config.client_key,
-                                                       client_name: chef_config.node_name)
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
+                                             signing_key_filename: chef_config.client_key,
+                                             client_name: chef_config.node_name)
       end
 
       private

--- a/lib/chef-dk/policyfile_services/rm_policy_group.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy_group.rb
@@ -16,7 +16,7 @@
 #
 
 require "chef-dk/service_exceptions"
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/policyfile/undo_stack"
 require "chef-dk/policyfile/undo_record"
 
@@ -73,12 +73,12 @@ module ChefDK
       end
 
       # @api private
-      # An instance of ChefDK::AuthenticatedHTTP configured with the user's
+      # An instance of Chef::ServerAPI configured with the user's
       # server URL and credentials.
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
-                                                       signing_key_filename: chef_config.client_key,
-                                                       client_name: chef_config.node_name)
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
+                                             signing_key_filename: chef_config.client_key,
+                                             client_name: chef_config.node_name)
       end
     end
   end

--- a/lib/chef-dk/policyfile_services/show_policy.rb
+++ b/lib/chef-dk/policyfile_services/show_policy.rb
@@ -218,9 +218,9 @@ module ChefDK
       end
 
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
-                                                       signing_key_filename: chef_config.client_key,
-                                                       client_name: chef_config.node_name)
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
+                                             signing_key_filename: chef_config.client_key,
+                                             client_name: chef_config.node_name)
       end
 
       private

--- a/lib/chef-dk/policyfile_services/undelete.rb
+++ b/lib/chef-dk/policyfile_services/undelete.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 require "chef-dk/service_exceptions"
 require "chef-dk/policyfile/undo_stack"
 
@@ -71,7 +71,7 @@ module ChefDK
       end
 
       def http_client
-        @http_client ||= ChefDK::AuthenticatedHTTP.new(chef_config.chef_server_url,
+        @http_client ||= Chef::ServerAPI.new(chef_config.chef_server_url,
                                                        signing_key_filename: chef_config.client_key,
                                                        client_name: chef_config.node_name)
       end

--- a/spec/unit/command/diff_spec.rb
+++ b/spec/unit/command/diff_spec.rb
@@ -45,7 +45,7 @@ describe ChefDK::Command::Diff do
 
     let(:ui) { TestHelpers::TestUI.new }
 
-    let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP") }
+    let(:http_client) { instance_double("Chef::ServerAPI") }
 
     let(:differ) { instance_double("ChefDK::Policyfile::Differ", run_report: nil) }
 

--- a/spec/unit/policyfile/chef_server_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/chef_server_cookbook_source_spec.rb
@@ -23,7 +23,7 @@ describe ChefDK::Policyfile::ChefServerCookbookSource do
 
   let(:cookbook_source) { "https://chef.example.com/organizations/example" }
 
-  let(:http_connection) { double("ChefDK::AuthenticatedHTTP") }
+  let(:http_connection) { double("Chef::ServerAPI") }
 
   let(:universe_response_encoded) { JSON.parse(IO.read(File.join(fixtures_path, "cookbooks_api/chef_server_universe.json"))) }
 

--- a/spec/unit/policyfile/comparison_base_spec.rb
+++ b/spec/unit/policyfile/comparison_base_spec.rb
@@ -222,7 +222,7 @@ E
 
     let(:group) { "acceptance" }
     let(:policy_name) { "chatserver" }
-    let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP", url: "https://chef.example/organizations/monkeynews") }
+    let(:http_client) { instance_double("Chef::ServerAPI", url: "https://chef.example/organizations/monkeynews") }
 
     subject(:comparison_base) { described_class.new(group, policy_name, http_client) }
 

--- a/spec/unit/policyfile/lister_spec.rb
+++ b/spec/unit/policyfile/lister_spec.rb
@@ -31,14 +31,14 @@ describe ChefDK::Policyfile::Lister do
            node_name: "deuce")
   end
 
-  let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+  let(:http_client) { instance_double(Chef::ServerAPI) }
 
   subject(:info_fetcher) do
     described_class.new(config: config)
   end
 
   it "configures an HTTP client" do
-    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+    expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
                                                        client_name: "deuce")
     info_fetcher.http_client

--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -20,7 +20,7 @@ require "chef-dk/policyfile/uploader"
 
 # We load this here to ensure we get the "verifying doubles" behavior from
 # RSpec. It's not used by Policyfile::Uploader, but it's a collaborator.
-require "chef-dk/authenticated_http"
+require "chef/server_api"
 
 describe ChefDK::Policyfile::Uploader do
 
@@ -50,7 +50,7 @@ describe ChefDK::Policyfile::Uploader do
 
   let(:policy_group) { "unit-test" }
 
-  let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP") }
+  let(:http_client) { instance_double("Chef::ServerAPI") }
 
   let(:policy_document_native_api) { false }
 

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -357,10 +357,8 @@ E
         end
 
         it "has a default source" do
-          skip "Chef server isn't yet supported in cookbook-omnifetch (pending /universe endpoint in Chef Server)"
-
           expect(policyfile.errors).to eq([])
-          expected = ChefDK::Policyfile::ChefServerCookbookSource.new("https://mychef.example.com")
+          expected = [ ChefDK::Policyfile::ChefServerCookbookSource.new("https://mychef.example.com") ]
           expect(policyfile.default_source).to eq(expected)
         end
 
@@ -536,9 +534,7 @@ MESSAGE
           EOH
         end
 
-        # Chef server isn't yet supported in cookbook-omnifetch (pending /universe endpoint in Chef Server)
-        # We have to skip at the example definition level or else we fail in the before block
-        skip "sets the source of the cookbook to the git URL" do
+        it "sets the source of the cookbook to the git URL" do
           expected_cb_spec = ChefDK::Policyfile::CookbookLocationSpecification.new("foo", ">= 0.0.0", { chef_server: "https://mychefserver.example.com" }, storage_config)
           expect(policyfile.cookbook_location_specs).to eq("foo" => expected_cb_spec)
         end

--- a/spec/unit/policyfile_services/clean_policies_spec.rb
+++ b/spec/unit/policyfile_services/clean_policies_spec.rb
@@ -37,7 +37,7 @@ describe ChefDK::PolicyfileServices::CleanPolicies do
 
   describe "when there is an error listing data from the server" do
 
-    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+    let(:http_client) { instance_double(Chef::ServerAPI) }
 
     let(:response) do
       Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
@@ -66,7 +66,7 @@ describe ChefDK::PolicyfileServices::CleanPolicies do
 
   context "when existing policies are listed successfully" do
 
-    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+    let(:http_client) { instance_double(Chef::ServerAPI) }
 
     before do
       policy_lister.set!(policies_by_name, policies_by_group)

--- a/spec/unit/policyfile_services/clean_policy_cookbooks_spec.rb
+++ b/spec/unit/policyfile_services/clean_policy_cookbooks_spec.rb
@@ -72,7 +72,7 @@ describe ChefDK::PolicyfileServices::CleanPolicyCookbooks do
     }
   end
 
-  let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+  let(:http_client) { instance_double(Chef::ServerAPI) }
 
   let(:ui) { TestHelpers::TestUI.new }
 
@@ -88,7 +88,7 @@ describe ChefDK::PolicyfileServices::CleanPolicyCookbooks do
   end
 
   it "configures an HTTP client with the user's credentials" do
-    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+    expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
                                                        client_name: "deuce")
     clean_policy_cookbooks_service.http_client

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -120,7 +120,7 @@ E
   end
 
   it "configures an HTTP client" do
-    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+    expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
                                                        client_name: "deuce")
     push_archive_service.http_client
@@ -336,7 +336,7 @@ MESSAGE
       ]
     end
 
-    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+    let(:http_client) { instance_double(Chef::ServerAPI) }
 
     let(:uploader) { instance_double(ChefDK::Policyfile::Uploader) }
 

--- a/spec/unit/policyfile_services/push_spec.rb
+++ b/spec/unit/policyfile_services/push_spec.rb
@@ -59,7 +59,7 @@ describe ChefDK::PolicyfileServices::Push do
   let(:push_service) { described_class.new(policyfile: policyfile_rb_name, policy_group: policy_group, ui: ui, config: config, root_dir: working_dir) }
 
   it "configures an HTTP client" do
-    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+    expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
                                                        client_name: "deuce")
     push_service.http_client
@@ -180,7 +180,7 @@ describe ChefDK::PolicyfileServices::Push do
 E
       end
 
-      let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+      let(:http_client) { instance_double(Chef::ServerAPI) }
 
       let(:updated_lockfile_io) { StringIO.new }
 

--- a/spec/unit/policyfile_services/rm_policy_group_spec.rb
+++ b/spec/unit/policyfile_services/rm_policy_group_spec.rb
@@ -22,7 +22,7 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
 
   let(:policy_group) { "preprod" }
 
-  let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+  let(:http_client) { instance_double(Chef::ServerAPI) }
 
   let(:ui) { TestHelpers::TestUI.new }
 
@@ -78,7 +78,7 @@ describe ChefDK::PolicyfileServices::RmPolicyGroup do
   end
 
   it "configures an HTTP client" do
-    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+    expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
                                                        client_name: "deuce")
     rm_policy_group_service.http_client

--- a/spec/unit/policyfile_services/rm_policy_spec.rb
+++ b/spec/unit/policyfile_services/rm_policy_spec.rb
@@ -22,7 +22,7 @@ describe ChefDK::PolicyfileServices::RmPolicy do
 
   let(:policy_name) { "appserver" }
 
-  let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+  let(:http_client) { instance_double(Chef::ServerAPI) }
 
   let(:policy_revisions_data) do
     {
@@ -54,7 +54,7 @@ describe ChefDK::PolicyfileServices::RmPolicy do
   end
 
   it "configures an HTTP client" do
-    expect(ChefDK::AuthenticatedHTTP).to receive(:new).with("https://localhost:10443",
+    expect(Chef::ServerAPI).to receive(:new).with("https://localhost:10443",
                                                        signing_key_filename: "/path/to/client/key.pem",
                                                        client_name: "deuce")
     rm_policy_service.http_client

--- a/spec/unit/policyfile_services/show_policy_spec.rb
+++ b/spec/unit/policyfile_services/show_policy_spec.rb
@@ -56,7 +56,7 @@ describe ChefDK::PolicyfileServices::ShowPolicy do
 
     describe "when an error occurs fetching data from the server" do
 
-      let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+      let(:http_client) { instance_double(Chef::ServerAPI) }
 
       let(:response) do
         Net::HTTPResponse.send(:response_class, "500").new("1.0", "500", "Internal Server Error").tap do |r|
@@ -804,7 +804,7 @@ OUTPUT
 
     let(:policy_group) { "dev" }
 
-    let(:http_client) { instance_double("ChefDK::AuthenticatedHTTP", url: "https://chef.example/organizations/monkeynews") }
+    let(:http_client) { instance_double("Chef::ServerAPI", url: "https://chef.example/organizations/monkeynews") }
 
     before do
       allow(show_policy_service).to receive(:http_client).and_return(http_client)

--- a/spec/unit/policyfile_services/undelete_spec.rb
+++ b/spec/unit/policyfile_services/undelete_spec.rb
@@ -169,7 +169,7 @@ OUTPUT
       end
     end
 
-    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+    let(:http_client) { instance_double(Chef::ServerAPI) }
 
     before do
       allow(undelete_service).to receive(:http_client).and_return(http_client)
@@ -276,7 +276,7 @@ OUTPUT
       end
     end
 
-    let(:http_client) { instance_double(ChefDK::AuthenticatedHTTP) }
+    let(:http_client) { instance_double(Chef::ServerAPI) }
 
     before do
       allow(undelete_service).to receive(:http_client).and_return(http_client)


### PR DESCRIPTION
When pushing policies, we need to ensure that we send a cookbook that
the server can cope with, rather than just always the latest. To that
end, we'll use Chef::ServerAPI which has negotiation built in, rather
than our own API Client