### PR TITLE
Update Gemfile.lock using sed rather than bundler

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -8,8 +8,10 @@ set -evx
 
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/chef-dk/version.rb
 
-# Update the version inside Gemfile.lock
-bundle update chef-dk
+# There is a bug (https://github.com/bundler/bundler/issues/5644) that is preventing
+# us from updating the chef-dk gem via `bundle update` or `bundle lock --update`.
+# Until that is addressed, let's replace the version using sed.
+sed -i -r "s/chef-dk\s\(.+\)$/chef-dk \($(cat VERSION)\)/" Gemfile.lock
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.


### PR DESCRIPTION
There is a [bug](https://github.com/bundler/bundler/issues/5644) that is preventing us from updating the chef-dk gem via `bundle update` or `bundle lock --update`.

Until that is addressed, let's replace the version using sed.

### Issues Resolved

Failure to automatically bump the version. 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
