### PR TITLE
administrivia from chef-dk 1.6.1 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# ChefDK 1.6.0 Release Notes
+# ChefDK 1.6.1 Release Notes
 
 This release of ChefDK update the embedded git to 2.14.1 to address [CVE-2017-1000117](https://www.cvedetails.com/cve/CVE-2017-1000117/)
 

--- a/tasks/announce.rb
+++ b/tasks/announce.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ class ReleaseAnnouncement
 
   def initialize(version, date, type)
     @version = version
-    @maj_minor = version.split(".")[0..1].join(".")
     @date = Date.parse(date) unless date.nil?
     @release_notes = release_notes_from_file
     @type = type
@@ -41,7 +40,7 @@ class ReleaseAnnouncement
   end
 
   def release_notes_from_file
-    File.read("RELEASE_NOTES.md").match(/^# ChefDK #{@maj_minor} Release Notes\n\n(.*)/m)[1]
+    File.read("RELEASE_NOTES.md").match(/^# ChefDK #{@version} Release Notes\n\n(.*)/m)[1]
   end
 end
 

--- a/tasks/templates/prerelease.md.erb
+++ b/tasks/templates/prerelease.md.erb
@@ -1,6 +1,6 @@
 Ohai Chefs!
 
-We have selected <%= @version %> as our ChefDK v<%= @maj_minor %> release candidate which is scheduled for release on <%= @date.strftime('%A %B %-d, %Y') %>.
+We have selected <%= @version %> as our ChefDK v<%= @version %> release candidate which is scheduled for release on <%= @date.strftime('%A %B %-d, %Y') %>.
 
 # Release Highlights
 

--- a/tasks/templates/release.md.erb
+++ b/tasks/templates/release.md.erb
@@ -1,6 +1,6 @@
 Ohai Chefs!
 
-We're happy to announce the release of ChefDK v<%= @maj_minor %>!
+We're happy to announce the release of ChefDK v<%= @version %>!
 
 # Release Highlights
 


### PR DESCRIPTION
bumps RELEASE_NOTES to 1.6.1 since that is what was actually released.  goes back to three digit versions in the templates.