### PR TITLE
Now that bento ships major version slugs, let's use them

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/.kitchen.yml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/.kitchen.yml
@@ -12,7 +12,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.3
+  - name: centos-7
 
 suites:
   - name: default

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -14,7 +14,7 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.3
+  - name: centos-7
 
 suites:
   - name: default

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -23,7 +23,7 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.3
+  - name: centos-7
 
 suites:
   - name: default

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -575,7 +575,7 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.3
+  - name: centos-7
 
 suites:
   - name: default
@@ -652,7 +652,7 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.3
+  - name: centos-7
 
 suites:
   - name: default


### PR DESCRIPTION
### Description

As of bento release [201708.22.0](https://github.com/chef/bento/blob/master/CHANGELOG.md#201708220-2017-08-22) there are now major version slugs for platforms with rolling/point release versioning across the board. kitchen-vagrant already automatically looks for matching boxes so only the generator needs to be changed and this is fully backward compatible.

For example:
`centos-7` -> `centos-7.3`

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Seth Thomas <sthomas@chef.io>
