### PR TITLE
Upgrade to rubygems 2.6.13

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -58,14 +58,14 @@ end
 dependency "chef-dk"
 
 dependency "gem-permissions"
+dependency "rubygems-customization"
+dependency "shebang-cleanup"
 
 if windows?
   dependency "chef-dk-env-customization"
   dependency "chef-dk-powershell-scripts"
 end
 
-dependency "rubygems-customization"
-dependency "shebang-cleanup"
 dependency "version-manifest"
 dependency "openssl-customization"
 


### PR DESCRIPTION
This requires us to ensure that we run the correct gem binary during
omnibus builds
