### PR TITLE
Added LICENSE generation to skeleton

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -57,6 +57,13 @@ else
 
 end
 
+# LICENSE
+template "#{cookbook_dir}/LICENSE" do
+  helpers(ChefDK::Generator::TemplateHelper)
+  source "LICENSE.#{context.license}.erb"
+  action :create_if_missing
+end
+
 # Test Kitchen
 template "#{cookbook_dir}/.kitchen.yml" do
   if context.use_berkshelf

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -38,6 +38,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       test/smoke/default/default_test.rb
       Berksfile
       chefignore
+      LICENSE
       metadata.rb
       README.md
       recipes


### PR DESCRIPTION
### Description

Generates a LICENSE file based on the license chosen by the generator. Chooses template based on a valid license command argument input. Since this is enforced, we're good

### Issues Resolved


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
