### PR TITLE
Be more selective about what dev gems we bundle

### DIFF
--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -57,10 +57,12 @@ build do
 
   env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
 
-  appbundle "berkshelf", lockdir: project_dir, without: %w{guard changelog}, env: env
-  appbundle "chef", lockdir: project_dir, without: %w{changelog integration docgen maintenance ci travis}, env: env
+  appbundle "chef", lockdir: project_dir, without: %w{integration docgen maintenance ci travis}, env: env
+  appbundle "foodcritic", lockdir: project_dir, without: %w{development}, env: env
+  appbundle "test-kitchen", lockdir: project_dir, without: %w{changelog debug docs}, env: env
+  appbundle "inspec", lockdir: project_dir, without: %w{deploy tools maintenance}, env: env
 
-  %w{chef-dk chef-vault foodcritic ohai test-kitchen opscode-pushy-client cookstyle inspec dco}.each do |gem|
+  %w{chef-dk chef-vault ohai opscode-pushy-client cookstyle dco berkshelf}.each do |gem|
     appbundle gem, lockdir: project_dir, without: %w{changelog}, env: env
   end
 


### PR DESCRIPTION
`berkshelf` no longer has a guard group in the gemfile so remove that exclusion
`chef` no longer has a changelog group so remove that exclusion
`foodcritic` has no changelog group, but it does have a development group: ronn, pry
`test-kitchen` (master currently) has a debug group and a docs group: yard, pry, pry-byebug, and pry-stack_explorer
`inspec` no longer has a changelog group, but it does have deploy, tools, and maintenance groups: pry, rb-readline, license_finder, tomlrb, octokit, netrc, and inquirer

Signed-off-by: Tim Smith <tsmith@chef.io>