### PR TITLE
add VOLUME to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+VOLUME [ "/opt/chefdk" ]
 CMD ["/bin/bash"]
+


### PR DESCRIPTION
Signed-off-by: Sean OMeara <sean@sean.io>

- expose /opt/chefdk as VOLUME for mounting by other containers
