### PR TITLE
They are integration tests, not smoke tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # ChefDK 2.4 Release Notes
 
+## Rename `smoke` tests to `integration` tests.
+
+The cookbook, recipe, and app generators now name the test directory
+`integration` instead of `smoke`.
+
 ## Improved Performance Downloading Cookbooks from a Chef Server
 
 Policyfile users who use a Chef Server as a cookbook source will
@@ -84,7 +89,7 @@ Lockfile written to /home/jaym/workspace/chef-dk/users.lock.json
 Policy revision id: 20fac68f987152f62a2761e1cfc7f1dc29b598303bfb2d84a115557e2a4a8f27
 ```
 
-This will produce a `users.lock.json` that has the `base` policyfile lock merged in. 
+This will produce a `users.lock.json` that has the `base` policyfile lock merged in.
 
 More information can be found in
 [RFC097](https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md) and

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -105,7 +105,7 @@ module ChefDK
             msg("\nThere are several commands you can run to get started locally developing and testing your cookbook.")
             msg("Type `delivery local --help` to see a full list.")
             msg("\nWhy not start by writing a test? Tests for the default recipe are stored at:\n")
-            msg("test/smoke/default/default_test.rb")
+            msg("test/integration/default/default_test.rb")
             msg("\nIf you'd prefer to dive right in, the default recipe can be found at:")
             msg("\nrecipes/default.rb\n")
           end

--- a/lib/chef-dk/skeletons/code_generator/recipes/app.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/app.rb
@@ -17,11 +17,11 @@ template "#{app_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{app_dir}/test/smoke/default" do
+directory "#{app_dir}/test/integration/default" do
   recursive true
 end
 
-template "#{app_dir}/test/smoke/default/default_test.rb" do
+template "#{app_dir}/test/integration/default/default_test.rb" do
   source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -77,11 +77,11 @@ template "#{cookbook_dir}/.kitchen.yml" do
 end
 
 # Inspec
-directory "#{cookbook_dir}/test/smoke/default" do
+directory "#{cookbook_dir}/test/integration/default" do
   recursive true
 end
 
-template "#{cookbook_dir}/test/smoke/default/default_test.rb" do
+template "#{cookbook_dir}/test/integration/default/default_test.rb" do
   source 'inspec_default_test.rb.erb'
   helpers(ChefDK::Generator::TemplateHelper)
   action :create_if_missing

--- a/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/recipe.rb
@@ -6,16 +6,16 @@ recipe_path = File.join(cookbook_dir, 'recipes', "#{context.new_file_basename}.r
 spec_helper_path = File.join(cookbook_dir, 'spec', 'spec_helper.rb')
 spec_dir = File.join(cookbook_dir, 'spec', 'unit', 'recipes')
 spec_path = File.join(spec_dir, "#{context.new_file_basename}_spec.rb")
-inspec_dir = File.join(cookbook_dir, 'test', 'smoke', 'default')
+inspec_dir = File.join(cookbook_dir, 'test', 'integration', 'default')
 inspec_path = File.join(inspec_dir, "#{context.new_file_basename}_test.rb")
 
 if File.directory?(File.join(cookbook_dir, 'test', 'recipes'))
   Chef::Log.deprecation <<-EOH
 It appears that you have Inspec tests located at "test/recipes". This location can
-cause issues with Foodcritic and has been deprecated in favor of "test/smoke/default".
-Please move your existing Inspec tests to the newly created "test/smoke/default"
+cause issues with Foodcritic and has been deprecated in favor of "test/integration/default".
+Please move your existing Inspec tests to the newly created "test/integration/default"
 directory, and update the 'inspec_tests' value in your .kitchen.yml file(s) to
-point to "test/smoke/default".
+point to "test/integration/default".
   EOH
 end
 

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -22,5 +22,5 @@ suites:
       - recipe[<%= cookbook_name %>::default]
     verifier:
       inspec_tests:
-        - test/smoke/default
+        - test/integration/default
     attributes:

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -29,5 +29,5 @@ suites:
   - name: default
     verifier:
       inspec_tests:
-        - test/smoke/default
+        - test/integration/default
     attributes:

--- a/spec/unit/command/generator_commands/app_spec.rb
+++ b/spec/unit/command/generator_commands/app_spec.rb
@@ -31,9 +31,9 @@ describe ChefDK::Command::GeneratorCommands::App do
       .gitignore
       .kitchen.yml
       test
-      test/smoke
-      test/smoke/default
-      test/smoke/default/default_test.rb
+      test/integration
+      test/integration/default
+      test/integration/default/default_test.rb
       README.md
       cookbooks/new_app/Berksfile
       cookbooks/new_app/chefignore
@@ -129,8 +129,8 @@ describe ChefDK::Command::GeneratorCommands::App do
         end
       end
 
-      describe "test/smoke/default/default_test.rb" do
-        let(:file) { File.join(tempdir, "new_app", "test", "smoke", "default", "default_test.rb") }
+      describe "test/integration/default/default_test.rb" do
+        let(:file) { File.join(tempdir, "new_app", "test", "integration", "default", "default_test.rb") }
 
         include_examples "a generated file", :cookbook_name do
           let(:line) { "describe port" }

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -34,8 +34,8 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       .gitignore
       .kitchen.yml
       test
-      test/smoke
-      test/smoke/default/default_test.rb
+      test/integration
+      test/integration/default/default_test.rb
       Berksfile
       chefignore
       LICENSE
@@ -66,7 +66,7 @@ Type `delivery local --help` to see a full list.
 
 Why not start by writing a test? Tests for the default recipe are stored at:
 
-test/smoke/default/default_test.rb
+test/integration/default/default_test.rb
 
 If you'd prefer to dive right in, the default recipe can be found at:
 
@@ -474,8 +474,8 @@ OUTPUT
 
         end
 
-        describe "test/smoke/default/default_test.rb" do
-          let(:file) { File.join(tempdir, "new_cookbook", "test", "smoke", "default", "default_test.rb") }
+        describe "test/integration/default/default_test.rb" do
+          let(:file) { File.join(tempdir, "new_cookbook", "test", "integration", "default", "default_test.rb") }
 
           include_examples "a generated file", :cookbook_name do
             let(:line) { "describe port" }
@@ -584,7 +584,7 @@ suites:
   - name: default
     verifier:
       inspec_tests:
-        - test/smoke/default
+        - test/integration/default
     attributes:
 KITCHEN_YML
         end
@@ -663,7 +663,7 @@ suites:
       - recipe[new_cookbook::default]
     verifier:
       inspec_tests:
-        - test/smoke/default
+        - test/integration/default
     attributes:
 KITCHEN_YML
         end

--- a/spec/unit/command/generator_commands/recipe_spec.rb
+++ b/spec/unit/command/generator_commands/recipe_spec.rb
@@ -28,7 +28,7 @@ describe ChefDK::Command::GeneratorCommands::Recipe do
       [ "recipes/new_recipe.rb",
                               "spec/spec_helper.rb",
                               "spec/unit/recipes/new_recipe_spec.rb",
-                              "test/smoke/default/new_recipe_test.rb",
+                              "test/integration/default/new_recipe_test.rb",
                             ] end
     let(:new_file_name) { "new_recipe" }
 


### PR DESCRIPTION
### Update the tests for the new directory name

The tests now live in an `integration` directory instead of a `smoke` directory.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
