### PR TITLE
Add CentOS Platform to unit tests generated by `chef generate cookbook`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,3 +31,6 @@ cookbooks to supermarkets.
 The cookbook generator now adds a LICENSE file when creating a new
 cookbook.
 
+
+## Boilerplate tests are generated for the CentOS platform
+When `chef generate cookbook` is ran, boilerplate unit tests for the CentOS 7 platform are now generated as well.

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -7,7 +7,7 @@
 require 'spec_helper'
 
 describe '<%= cookbook_name %>::<%= recipe_name %>' do
-  context 'When all attributes are default, on an Ubuntu 16.04' do
+  context 'When all attributes are default, on Ubuntu 16.04' do
     let(:chef_run) do
       # for a complete list of available platforms and versions see:
       # https://github.com/customink/fauxhai/blob/master/PLATFORMS.md
@@ -20,7 +20,7 @@ describe '<%= cookbook_name %>::<%= recipe_name %>' do
     end
   end
 
-  context 'When all attributes are default, on a CentOS 7.4.1708' do
+  context 'When all attributes are default, on CentOS 7.4.1708' do
     let(:chef_run) do
       # for a complete list of available platforms and versions see:
       # https://github.com/customink/fauxhai/blob/master/PLATFORMS.md

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -19,4 +19,17 @@ describe '<%= cookbook_name %>::<%= recipe_name %>' do
       expect { chef_run }.to_not raise_error
     end
   end
+
+  context 'When all attributes are default, on a CentOS 7.4.1708' do
+    let(:chef_run) do
+      # for a complete list of available platforms and versions see:
+      # https://github.com/customink/fauxhai/blob/master/PLATFORMS.md
+      runner = ChefSpec::ServerRunner.new(platform: 'centos', version: '7.4.1708')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
### Description

This changes the `chef generate cookbook` command to generate baseline tests for the CentOS 7.4.170 platform that is included by the default generate .kitchen.yml file. I also stripped out a/an articles from the generated contexts.

### Issues Resolved

None

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
