### PR TITLE
Documented how to run a version of chef-dk under development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,12 @@ To build the chef-dk, we use the omnibus system. Go to the
 A standard `bundle install` in the root directory and in the `omnibus/`
 directory will get you started. You can run unit tests via:
 
+## Running `chef` Locally
+
+```
+bundle exec chef
+```
+
 ## Unit Testing
 
 ```


### PR DESCRIPTION
Signed-off-by: Robert Miesen <robert.miesen@gmail.com>

### Description

I documented a possible mechanism for running the version of chef under active development discovered during the Seattle developer's summit.

### Issues Resolved

None.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
