### PR TITLE
Remove trailing newline

### DIFF
--- a/lib/chef-dk/generator.rb
+++ b/lib/chef-dk/generator.rb
@@ -154,7 +154,7 @@ EOH
         end
         if comment
           # Ensure there's no trailing whitespace
-          result.gsub(/^(.+)$/, "#{comment} \\1").gsub(/^$/, "#{comment}")
+          result.gsub(/^(.+)$/, "#{comment} \\1").gsub(/^$/, "#{comment}").strip
         else
           result
         end


### PR DESCRIPTION
### Description
When I use the `chef generate cookbook` command and pass it a license `--license 'apachev2'` the resulting files fail a rubocop pass off the bat due to the file having an addtitional blankline in the following files.
```
recipes/default.rb:18:1: C: Layout/TrailingBlankLines: 1 trailing blank lines detected.
spec/unit/recipes/default_spec.rb:19:1: C: Layout/EmptyLines: Extra blank line detected.
```

### Issues Resolved
This PR strips the trailing `\n` from the `result` variable.

I only noticed this today and haven't created an issue, happy to create one if you like

### Check List

~~- [ ] New functionality includes tests~~
- [x] All tests pass

~~- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)~~

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
