### PR TITLE
Added support for source urls (#1341)

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -24,10 +24,32 @@ spdx_license =  case context.license
                   'All Rights Reserved'
                 end
 
+cookbook_urls = case context.git
+                when 'default'
+                  <<-EOF
+# The `issues_url` points to the location where issues for this cookbook are
+# tracked.  A `View Issues` link will be displayed on this cookbook's page when
+# uploaded to a Supermarket.
+#
+# issues_url 'https://github.com/<insert_org_here>/#{context.cookbook_name}/issues'
+# The `source_url` points to the development repository for this cookbook.  A
+# `View Source` link will be displayed on this cookbook's page when uploaded to
+# a Supermarket.
+#
+# source_url 'https://github.com/<insert_org_here>/#{context.cookbook_name}'
+EOF
+                else
+                  <<-EOF
+issues_url '#{URI.join(context.git, 'issues')}' if respond_to?(:issues_url)
+source_url '#{URI.join(context.git, '/')}' if respond_to?(:source_url)
+EOF
+                end
+
 template "#{cookbook_dir}/metadata.rb" do
   helpers(ChefDK::Generator::TemplateHelper)
   variables(
-    spdx_license: spdx_license
+    spdx_license: spdx_license,
+    cookbook_urls: cookbook_urls.strip
   )
   action :create_if_missing
 end

--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -7,14 +7,4 @@ long_description 'Installs/Configures <%= cookbook_name %>'
 version '0.1.0'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
-# The `issues_url` points to the location where issues for this cookbook are
-# tracked.  A `View Issues` link will be displayed on this cookbook's page when
-# uploaded to a Supermarket.
-#
-# issues_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>/issues'
-
-# The `source_url` points to the development repository for this cookbook.  A
-# `View Source` link will be displayed on this cookbook's page when uploaded to
-# a Supermarket.
-#
-# source_url 'https://github.com/<insert_org_here>/<%= cookbook_name %>'
+<%= @cookbook_urls %>

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -102,7 +102,7 @@ EOF
     expect(cookbook_generator.chef_runner.cookbook_path).to eq(File.expand_path("lib/chef-dk/skeletons", project_root))
   end
 
-  context "when given invalid/incomplete arguments" do
+  context "when given invalid/incomplete arguments it" do
 
     let(:expected_help_message) do
       "Usage: chef generate cookbook NAME [options]\n"
@@ -132,6 +132,17 @@ EOF
       expect(stdout_io.string).to include(message)
     end
 
+    it "errors if an invalid uri is passed to --git-url" do
+      expect(with_argv(%w{new_cookbook --git-url "invalid uri"}).run).to eq(1)
+      message = "Unable to parse `--git-url` provided, please check it's valid"
+      expect(stderr_io.string).to include(message)
+    end
+
+    it "errors if uri.scheme is missing from --git-url" do
+      expect(with_argv(%w{new_cookbook --git-url uri_minus_scheme.com}).run).to eq(1)
+      message = "Please prefix a uri.scheme to '--git-url' e.g. 'https://'"
+      expect(stderr_io.string).to include(message)
+    end
   end
 
   context "when given the name of the cookbook to generate" do
@@ -603,6 +614,23 @@ SPEC_HELPER
 
       end
 
+    end
+
+    context "and given a custom git-url" do
+
+      let(:argv) { %w{new_cookbook --git-url https://chefspec.can.be.fun} }
+
+      before do
+        reset_tempdir
+      end
+
+      describe "it creates a custom metadata.rb" do
+        let(:file) { File.join(tempdir, "new_cookbook", "metadata.rb") }
+
+        include_examples "a generated file", :cookbook_name do
+          let(:line) { /https:\/\/chefspec.can.be.fun/m }
+        end
+      end
     end
 
     context "when configured for Berkshelf" do


### PR DESCRIPTION
### Description
I've had ago at adding a switch that defines the `issues_url`  & `source_url` options within the `metadata.rb` file.  If the switch `--git-url` is not provided then normal service is resumed.

'chef generate cookbook new_cookbook --git-url https://github.com/chef/chef-dk'

### Issues Resolved

This PR resolves #1341 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
~~- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)~~
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

I'll be honest I'm still finding my way with ruby so feel free to steer me in the right direction if you don't agree with my implimentation and I suppose I was pretty much flying by the seat of my pants with that chefspec stuff.

Anyway let me know think

Gary