### PR TITLE
bump+pin chef-provisioning-fog, bump deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group(:omnibus_package) do
   gem "chef-provisioning", ">= 2.4.0", group: :provisioning
   gem "chef-provisioning-aws", ">= 2.0", group: :provisioning
   gem "chef-provisioning-azure", ">= 0.6.0", group: :provisioning
-  gem "chef-provisioning-fog", ">= 0.20.0", group: :provisioning
+  gem "chef-provisioning-fog", ">= 0.26.0", group: :provisioning
   gem "chef-vault"
   gem "chef", "= 13.4.24"
   gem "cheffish", ">= 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,34 +17,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.5)
-    activesupport (4.2.9)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     app_conf (0.4.2)
     appbundler (0.10.0)
       mixlib-cli (~> 1.4)
+      mixlib-shellout (~> 2.0)
     artifactory (2.8.2)
     ast (2.3.0)
-    autoparse (0.3.3)
-      addressable (>= 2.3.1)
-      extlib (>= 0.9.15)
-      multi_json (>= 1.0.0)
-    aws-sdk (2.10.52)
-      aws-sdk-resources (= 2.10.52)
-    aws-sdk-core (2.10.52)
+    aws-sdk (2.10.69)
+      aws-sdk-resources (= 2.10.69)
+    aws-sdk-core (2.10.69)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.52)
-      aws-sdk-core (= 2.10.52)
+    aws-sdk-resources (2.10.69)
+      aws-sdk-core (= 2.10.69)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
     aws-sigv4 (1.0.2)
+    backports (3.10.3)
     berkshelf (6.3.1)
       buff-config (~> 2.0)
       buff-extensions (~> 2.0)
@@ -61,7 +53,7 @@ GEM
       ridley (~> 5.0)
       solve (~> 4.0)
       thor (~> 0.19, < 0.19.2)
-    binding_of_caller (0.7.2)
+    binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
     blankslate (2.1.2.4)
     buff-config (2.0.0)
@@ -177,13 +169,16 @@ GEM
     chef-provisioning-azure (0.6.0)
       chef-provisioning (>= 1.0, < 3.0)
       stuartpreston-azure-sdk-for-ruby (~> 0.7)
-    chef-provisioning-fog (0.21.0)
+    chef-provisioning-fog (0.26.0)
       chef-provisioning (>= 1.0, < 3.0)
-      fog (>= 1.37.0)
+      cheffish (>= 13.1.0, < 14.0)
       fog-digitalocean
+      fog-joyent
+      fog-openstack
+      fog-rackspace
       fog-scaleway
-      fog-softlayer (~> 1.1.0)
-      google-api-client (~> 0.8.0)
+      fog-softlayer
+      fog-xenserver
       retryable
       winrm-elevated
     chef-sugar (3.5.0)
@@ -194,7 +189,7 @@ GEM
       mixlib-log (~> 1.3)
       rack (~> 2.0)
       uuidtools (~> 2.1)
-    cheffish (13.0.0)
+    cheffish (13.1.0)
       chef-zero (~> 13.0)
       net-ssh
     chefspec (7.1.0)
@@ -210,16 +205,21 @@ GEM
       mixlib-archive (~> 0.4)
     cookstyle (2.1.0)
       rubocop (= 0.49.1)
-    cucumber (2.4.0)
+    cucumber (3.0.1)
       builder (>= 2.1.2)
-      cucumber-core (~> 1.5.0)
+      cucumber-core (~> 3.0.0)
+      cucumber-expressions (~> 4.0.3)
       cucumber-wire (~> 0.0.1)
-      diff-lcs (>= 1.1.3)
+      diff-lcs (~> 1.3)
       gherkin (~> 4.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
-    cucumber-core (1.5.0)
-      gherkin (~> 4.0)
+    cucumber-core (3.0.0)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (>= 1.0.1)
+      gherkin (>= 4.1.3)
+    cucumber-expressions (4.0.4)
+    cucumber-tag_expressions (1.0.1)
     cucumber-wire (0.0.1)
     dco (1.0.1)
       git (~> 1.3)
@@ -236,7 +236,6 @@ GEM
       json
     erubis (2.7.0)
     excon (0.59.0)
-    extlib (0.9.16)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     fauxhai (5.4.0)
@@ -252,64 +251,6 @@ GEM
       ffi
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (1.41.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.45)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 1.0)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-internet-archive
-      fog-joyent
-      fog-json
-      fog-local
-      fog-openstack
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (>= 1.8, < 2.0)
-    fog-aliyun (0.2.0)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (1.4.1)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.13.0)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
     fog-core (1.45.0)
       builder
       excon (~> 0.58)
@@ -319,90 +260,34 @@ GEM
       fog-json (>= 1.0)
       fog-xml (>= 0.1)
       ipaddress (>= 0.5)
-    fog-dnsimple (1.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-internet-archive (0.0.1)
-      fog-core
-      fog-json
-      fog-xml
     fog-joyent (0.0.1)
       fog-core (~> 1.42)
       fog-json (>= 1.0)
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
-    fog-local (0.4.0)
-      fog-core (~> 1.27)
-    fog-openstack (0.1.21)
+    fog-openstack (0.1.22)
       fog-core (>= 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (4.0.0)
-      fog-core (~> 1.42)
-      fog-json (~> 1.0)
     fog-rackspace (0.1.5)
       fog-core (>= 1.35)
       fog-json (>= 1.0)
       fog-xml (>= 0.1)
       ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
     fog-scaleway (0.3.0)
       fog-core (~> 1.42)
       fog-json (~> 1.0)
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
     fog-softlayer (1.1.4)
       fog-core
       fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (1.13.0)
-      fog-core
-      rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
       fog-core
       fog-xml
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
-    foodcritic (11.4.0)
+    foodcritic (12.0.1)
       cucumber-core (>= 1.3)
       erubis
       ffi-yajl (~> 2.0)
@@ -414,25 +299,6 @@ GEM
     fuzzyurl (0.9.0)
     gherkin (4.1.3)
     git (1.3.0)
-    google-api-client (0.8.7)
-      activesupport (>= 3.2, < 5.0)
-      addressable (~> 2.3)
-      autoparse (~> 0.3)
-      extlib (~> 0.9)
-      faraday (~> 0.9)
-      googleauth (~> 0.3)
-      launchy (~> 2.4)
-      multi_json (~> 1.10)
-      retriable (~> 1.4)
-      signet (~> 0.6)
-    googleauth (0.5.3)
-      faraday (~> 0.12)
-      jwt (~> 1.4)
-      logging (~> 2.0)
-      memoist (~> 0.12)
-      multi_json (~> 1.11)
-      os (~> 0.9)
-      signet (~> 0.7)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     guard (2.14.1)
@@ -452,11 +318,9 @@ GEM
     hitimes (1.2.6-x86-mingw32)
     htmlentities (4.3.4)
     httpclient (2.8.3)
-    i18n (0.8.6)
-    inflecto (0.0.2)
     inifile (3.0.0)
     iniparse (1.4.4)
-    inspec (1.40.0)
+    inspec (1.42.3)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       hashie (~> 3.4)
@@ -480,7 +344,6 @@ GEM
     iso8601 (0.9.1)
     jmespath (1.3.1)
     json (1.8.6)
-    jwt (1.5.6)
     kitchen-dokken (2.6.5)
       docker-api (~> 1.33)
       lockfile (~> 2.1)
@@ -502,7 +365,7 @@ GEM
     knife-opc (0.3.2)
     knife-push (1.0.3)
       chef (>= 12.7.2)
-    knife-spork (1.6.3)
+    knife-spork (1.7.0)
       app_conf (>= 0.4.0)
       chef (>= 11.0.0)
       diffy (>= 3.0.1)
@@ -510,8 +373,6 @@ GEM
     knife-windows (1.9.0)
       winrm (~> 2.1)
       winrm-elevated (~> 1.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     libyajl2 (1.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -526,14 +387,12 @@ GEM
     lumberjack (1.0.12)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
-    memoist (0.16.0)
     method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitar (0.5.4)
-    minitest (5.10.3)
     mixlib-archive (0.4.1)
       mixlib-log
     mixlib-authentication (1.4.2)
@@ -595,7 +454,6 @@ GEM
       ffi-rzmq
       ohai (>= 8.23, < 14.0)
       uuidtools
-    os (0.9.6)
     paint (1.0.1)
     parallel (1.12.0)
     parser (2.4.0.0)
@@ -606,7 +464,7 @@ GEM
     polyglot (0.3.5)
     powerpack (0.1.1)
     proxifier (1.0.3)
-    pry (0.11.1)
+    pry (0.11.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.5.0)
@@ -627,14 +485,8 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rb-readline (0.5.5)
-    rbvmomi (1.11.3)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      trollop (~> 2.1)
     rdoc (5.1.0)
     rdp-ruby-wmi (0.3.1)
-    retriable (1.4.1)
     retryable (2.0.4)
     ridley (5.1.1)
       addressable
@@ -654,22 +506,22 @@ GEM
       retryable (~> 2.0)
       semverse (~> 2.0)
       varia_model (~> 0.6)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
+      rspec-support (~> 3.7.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.6.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -681,7 +533,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-prof (0.16.2)
-    ruby-progressbar (1.8.3)
+    ruby-progressbar (1.9.0)
     ruby-shadow (2.5.0)
     ruby_dep (1.5.0)
     rubyntlm (0.6.2)
@@ -692,18 +544,13 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     semverse (2.0.0)
-    serverspec (2.40.0)
+    serverspec (2.41.1)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.68)
+      specinfra (~> 2.72)
     sfl (2.3)
     shellany (0.0.1)
-    signet (0.7.3)
-      addressable (~> 2.3)
-      faraday (~> 0.9)
-      jwt (~> 1.5)
-      multi_json (~> 1.10)
     slop (3.6.0)
     solve (4.0.0)
       molinillo (~> 0.6)
@@ -737,7 +584,6 @@ GEM
       winrm-elevated (~> 1.0)
       winrm-fs (~> 1.0.2)
     thor (0.19.1)
-    thread_safe (0.3.6)
     timers (4.0.4)
       hitimes
     toml (0.1.2)
@@ -752,9 +598,6 @@ GEM
       winrm-fs (~> 1.0)
     treetop (1.6.8)
       polyglot (~> 0.3)
-    trollop (2.1.2)
-    tzinfo (1.2.3)
-      thread_safe (~> 0.1)
     ubuntu_ami (0.4.1)
     unicode-display_width (1.3.0)
     uuid (2.3.8)
@@ -804,7 +647,6 @@ GEM
       rubyzip (~> 1.1)
       winrm (~> 2.0)
     wmi-lite (1.0.0)
-    xml-simple (1.1.5)
     yard (0.9.9)
 
 PLATFORMS
@@ -822,7 +664,7 @@ DEPENDENCIES
   chef-provisioning (>= 2.4.0)
   chef-provisioning-aws (>= 2.0)
   chef-provisioning-azure (>= 0.6.0)
-  chef-provisioning-fog (>= 0.20.0)
+  chef-provisioning-fog (>= 0.26.0)
   chef-sugar
   chef-vault
   cheffish (>= 13.0)


### PR DESCRIPTION
- bumps and pins chef-provisioning-fog to version that supports
  cheffish >= 13.0 (actually requires >= 13.1.0 because of bugfixes
  it needs that went into that version).

- prior releases of ChefDK 2.x had as far as I know completely
  broken chef-provisioning-fog since bundler was helpfully finding
  very old versions that had no cheffish pin at all.

- floor of chef-provisioning-fog is pinned to address that issue

- the fog gem is no longer included, which removes swaths of fog
  gems which were completely useless other than to cause dep
  conflicts.  users which need to use support from the fog gem
  must now `chef gem install fog` by hand.

- fog-aws is removed, users should use chef-provisioning-aws or
  (discouraged) `chef gem install fog-aws` by hand.

- fog-google is still a mess and essentially broken so has been
  removed as a direct dep (but all of c-p-f has been broken completely
  throughout ChefDK 2.x because of cheffish issues afaik).

