### PR TITLE
bring in more gems to the chef-dk bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,28 +38,32 @@ end
 # We equality pin the chef gem itself to assert which version we're shipping.
 group(:omnibus_package) do
   gem "appbundler"
-  gem "berkshelf", ">= 6.3"
+  gem "berkshelf", ">= 6.3.1"
   gem "chef-provisioning", ">= 2.4.0", group: :provisioning
   gem "chef-provisioning-aws", ">= 2.0", group: :provisioning
   gem "chef-provisioning-azure", ">= 0.6.0", group: :provisioning
   gem "chef-provisioning-fog", ">= 0.26.0", group: :provisioning
-  gem "chef-vault"
+  gem "chef-vault", ">= 3.3.0"
   gem "chef", "= 13.4.24"
-  gem "cheffish", ">= 13.0"
-  gem "chefspec"
-  gem "fauxhai"
-  gem "inspec", ">= 0.29.0"
-  gem "kitchen-ec2"
+  gem "cheffish", ">= 13.1.0"
+  gem "chefspec", ">= 7.1.0"
+  gem "fauxhai", ">= 5.4.0"
+  gem "inspec", ">= 1.42.3"
+  gem "kitchen-ec2", ">= 1.3.2"
+  gem "kitchen-digitalocean", ">= 0.9.8"
   gem "kitchen-dokken", ">= 2.5.0"
-  gem "kitchen-hyperv"
-  gem "kitchen-inspec"
-  gem "kitchen-vagrant"
-  gem "knife-windows"
+  gem "kitchen-google", ">= 1.4.0"
+  gem "kitchen-hyperv", ">= 0.5.1"
+  gem "kitchen-inspec", ">= 0.19.0"
+  gem "kitchen-vagrant", ">= 1.2.1"
+  gem "knife-ec2", ">= 0.15.0"
+  gem "knife-google", ">= 3.2.0"
+  gem "knife-windows", ">= 1.9.0"
   gem "knife-opc", ">= 0.3.2"
   gem "ohai", ">= 13.1.0"
   # net-ssh 4.2.0 explodes the world. FIXME
   gem "net-ssh", "= 4.1.0"
-  gem "test-kitchen"
+  gem "test-kitchen", ">= 1.18.0"
   gem "listen"
   gem "dco"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     app_conf (0.4.2)
@@ -25,17 +30,21 @@ GEM
       mixlib-shellout (~> 2.0)
     artifactory (2.8.2)
     ast (2.3.0)
-    aws-sdk (2.10.69)
-      aws-sdk-resources (= 2.10.69)
-    aws-sdk-core (2.10.69)
+    aws-sdk (2.10.70)
+      aws-sdk-resources (= 2.10.70)
+    aws-sdk-core (2.10.70)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.69)
-      aws-sdk-core (= 2.10.69)
+    aws-sdk-resources (2.10.70)
+      aws-sdk-core (= 2.10.70)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
     aws-sigv4 (1.0.2)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     backports (3.10.3)
     berkshelf (6.3.1)
       buff-config (~> 2.0)
@@ -200,6 +209,8 @@ GEM
       rubocop (= 0.49.1)
     cleanroom (1.0.0)
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
     cookbook-omnifetch (0.6.0)
       mixlib-archive (~> 0.4)
@@ -229,11 +240,20 @@ GEM
     dep_selector (1.0.6)
       dep-selector-libgecode (~> 1.0)
       ffi (~> 1.9)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     diffy (3.2.0)
     docker-api (1.33.6)
       excon (>= 0.38.0)
       json
+    droplet_kit (2.2.1)
+      activesupport (> 3.0, < 6)
+      faraday (~> 0.9)
+      kartograph (~> 0.2.3)
+      resource_kit (~> 0.1.5)
+      virtus (~> 1.0.3)
+    equalizer (0.0.11)
     erubis (2.7.0)
     excon (0.59.0)
     faraday (0.13.1)
@@ -251,6 +271,11 @@ GEM
       ffi
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
+    fog-aws (1.4.1)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
     fog-core (1.45.0)
       builder
       excon (~> 0.58)
@@ -297,8 +322,27 @@ GEM
       treetop (~> 1.4)
     formatador (0.2.5)
     fuzzyurl (0.9.0)
+    gcewinpass (1.0.0)
+      google-api-client (~> 0.9.0)
     gherkin (4.1.3)
     git (1.3.0)
+    google-api-client (0.9.28)
+      addressable (~> 2.3)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+    googleauth (0.6.1)
+      faraday (~> 0.12)
+      jwt (>= 1.4, < 3.0)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
     gssapi (1.2.0)
       ffi (>= 1.0.1)
     guard (2.14.1)
@@ -318,6 +362,10 @@ GEM
     hitimes (1.2.6-x86-mingw32)
     htmlentities (4.3.4)
     httpclient (2.8.3)
+    hurley (0.2)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     inifile (3.0.0)
     iniparse (1.4.4)
     inspec (1.42.3)
@@ -344,6 +392,11 @@ GEM
     iso8601 (0.9.1)
     jmespath (1.3.1)
     json (1.8.6)
+    jwt (2.1.0)
+    kartograph (0.2.4)
+    kitchen-digitalocean (0.9.8)
+      droplet_kit (~> 2.2)
+      test-kitchen (~> 1.17)
     kitchen-dokken (2.6.5)
       docker-api (~> 1.33)
       lockfile (~> 2.1)
@@ -354,6 +407,10 @@ GEM
       multi_json
       retryable (~> 2.0)
       test-kitchen (~> 1.4, >= 1.4.1)
+    kitchen-google (1.4.0)
+      gcewinpass (~> 1.0)
+      google-api-client (~> 0.9.0)
+      test-kitchen
     kitchen-hyperv (0.5.1)
       test-kitchen (~> 1.4)
     kitchen-inspec (0.19.0)
@@ -362,6 +419,19 @@ GEM
       test-kitchen (~> 1.6)
     kitchen-vagrant (1.2.1)
       test-kitchen (~> 1.4)
+    knife-cloud (1.2.1)
+      chef (>= 0.10.10)
+      knife-windows (>= 0.5.14)
+      mixlib-shellout
+    knife-ec2 (0.15.0)
+      fog-aws (~> 1.0)
+      knife-windows (~> 1.0)
+      mime-types
+    knife-google (3.2.0)
+      chef (>= 12.0)
+      gcewinpass (~> 1.0)
+      google-api-client (~> 0.9.0)
+      knife-cloud (~> 1.2.0)
     knife-opc (0.3.2)
     knife-push (1.0.3)
       chef (>= 12.7.2)
@@ -387,12 +457,14 @@ GEM
     lumberjack (1.0.12)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
+    memoist (0.16.0)
     method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitar (0.5.4)
+    minitest (5.10.3)
     mixlib-archive (0.4.1)
       mixlib-log
     mixlib-authentication (1.4.2)
@@ -454,6 +526,7 @@ GEM
       ffi-rzmq
       ohai (>= 8.23, < 14.0)
       uuidtools
+    os (0.9.6)
     paint (1.0.1)
     parallel (1.12.0)
     parser (2.4.0.0)
@@ -487,6 +560,11 @@ GEM
     rb-readline (0.5.5)
     rdoc (5.1.0)
     rdp-ruby-wmi (0.3.1)
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    resource_kit (0.1.7)
+      addressable (>= 2.3.6, < 3.0.0)
+    retriable (2.1.0)
     retryable (2.0.4)
     ridley (5.1.1)
       addressable
@@ -551,6 +629,11 @@ GEM
       specinfra (~> 2.72)
     sfl (2.3)
     shellany (0.0.1)
+    signet (0.8.1)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     slop (3.6.0)
     solve (4.0.0)
       molinillo (~> 0.6)
@@ -584,6 +667,7 @@ GEM
       winrm-elevated (~> 1.0)
       winrm-fs (~> 1.0.2)
     thor (0.19.1)
+    thread_safe (0.3.6)
     timers (4.0.4)
       hitimes
     toml (0.1.2)
@@ -598,6 +682,9 @@ GEM
       winrm-fs (~> 1.0)
     treetop (1.6.8)
       polyglot (~> 0.3)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    uber (0.0.15)
     ubuntu_ami (0.4.1)
     unicode-display_width (1.3.0)
     uuid (2.3.8)
@@ -606,6 +693,11 @@ GEM
     varia_model (0.6.0)
       buff-extensions (~> 2.0)
       hashie (>= 2.0.2, < 4.0.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     win32-api (1.5.3-universal-mingw32)
     win32-dir (0.5.1)
       ffi (>= 1.0.0)
@@ -657,7 +749,7 @@ PLATFORMS
 DEPENDENCIES
   appbundler
   artifactory
-  berkshelf (>= 6.3)
+  berkshelf (>= 6.3.1)
   bundler
   chef (= 13.4.24)
   chef-dk!
@@ -666,30 +758,34 @@ DEPENDENCIES
   chef-provisioning-azure (>= 0.6.0)
   chef-provisioning-fog (>= 0.26.0)
   chef-sugar
-  chef-vault
-  cheffish (>= 13.0)
-  chefspec
+  chef-vault (>= 3.3.0)
+  cheffish (>= 13.1.0)
+  chefspec (>= 7.1.0)
   chefstyle
   cookstyle (>= 2.0.0)
   cucumber
   dco
   dep-selector-libgecode
   dep_selector
-  fauxhai
+  fauxhai (>= 5.4.0)
   ffi
   ffi-rzmq-core
   foodcritic (>= 11.2)
   guard
-  inspec (>= 0.29.0)
+  inspec (>= 1.42.3)
+  kitchen-digitalocean (>= 0.9.8)
   kitchen-dokken (>= 2.5.0)
-  kitchen-ec2
-  kitchen-hyperv
-  kitchen-inspec
-  kitchen-vagrant
+  kitchen-ec2 (>= 1.3.2)
+  kitchen-google (>= 1.4.0)
+  kitchen-hyperv (>= 0.5.1)
+  kitchen-inspec (>= 0.19.0)
+  kitchen-vagrant (>= 1.2.1)
+  knife-ec2 (>= 0.15.0)
+  knife-google (>= 3.2.0)
   knife-opc (>= 0.3.2)
   knife-push
   knife-spork
-  knife-windows
+  knife-windows (>= 1.9.0)
   listen
   mixlib-install
   mixlib-versioning
@@ -712,7 +808,7 @@ DEPENDENCIES
   ruby-prof
   ruby-shadow
   stove
-  test-kitchen
+  test-kitchen (>= 1.18.0)
   win32-api
   win32-dir
   win32-event


### PR DESCRIPTION
- kitchen-google
- kitchen-digitalocean
- knife-google
- knife-ec2

it also does some additional bumps of the floors to prevent the
depsolver from ever getting too smart for its own good.

replaces #1429 
