### PR TITLE
Bump bundler, libxml2, libxslt and libyaml to the latest

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: af33863799451fa78788a7dfc7b17ce0686ec585
+  revision: 65a9bed9e37e0b6ba7c8aae0b588f11ce5fc399a
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -29,15 +29,14 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    artifactory (2.8.2)
     awesome_print (1.8.0)
-    aws-sdk (2.10.52)
-      aws-sdk-resources (= 2.10.52)
-    aws-sdk-core (2.10.52)
+    aws-sdk (2.10.73)
+      aws-sdk-resources (= 2.10.73)
+    aws-sdk-core (2.10.73)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.52)
-      aws-sdk-core (= 2.10.52)
+    aws-sdk-resources (2.10.73)
+      aws-sdk-core (= 2.10.73)
     aws-sigv4 (1.0.2)
     berkshelf (6.3.1)
       buff-config (~> 2.0)
@@ -138,7 +137,7 @@ GEM
       fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
-    chef-sugar (3.5.0)
+    chef-sugar (3.6.0)
     chef-zero (4.9.0)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -189,8 +188,7 @@ GEM
     mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
-    mixlib-install (2.1.12)
-      artifactory
+    mixlib-install (3.6.0)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -218,7 +216,7 @@ GEM
     nori (2.6.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (8.24.1)
+    ohai (8.25.0)
       chef-config (>= 12.5.0.alpha.1, < 14)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -237,7 +235,7 @@ GEM
       progressbar
       zhexdump (>= 0.0.2)
     plist (3.3.0)
-    progressbar (1.8.2)
+    progressbar (1.9.0)
     proxifier (1.0.3)
     public_suffix (3.0.0)
     rack (1.6.8)
@@ -279,7 +277,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    ruby-progressbar (1.8.3)
+    ruby-progressbar (1.9.0)
     rubyntlm (0.6.2)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
@@ -287,11 +285,11 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     semverse (2.0.0)
-    serverspec (2.40.0)
+    serverspec (2.41.2)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.68)
+      specinfra (~> 2.72)
     sfl (2.3)
     solve (4.0.0)
       molinillo (~> 0.6)
@@ -303,14 +301,17 @@ GEM
       sfl
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.17.0)
-      mixlib-install (>= 1.2, < 3.0)
+    test-kitchen (1.18.0)
+      mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.9, < 5.0)
       net-ssh-gateway (~> 1.2)
       safe_yaml (~> 1.0)
       thor (~> 0.19, < 0.19.2)
+      winrm (~> 2.0)
+      winrm-elevated (~> 1.0)
+      winrm-fs (~> 1.0.2)
     thor (0.19.1)
     timers (4.0.4)
       hitimes

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -2,14 +2,14 @@
 # .travis.yml and appveyor.yml consume this,
 # try to keep it machine-parsable.
 override :rubygems, version: "2.6.13"
-override :bundler, version: "1.15.1"
+override :bundler, version: "1.15.4"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
 override "liblzma", version: "5.2.3"
 override "libtool", version: "2.4.2"
-override "libxml2", version: "2.9.4"
-override "libxslt", version: "1.1.29"
-override "libyaml", version: "0.1.6"
+override "libxml2", version: "2.9.5"
+override "libxslt", version: "1.1.30"
+override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "5.9"
 override "pkg-config-lite", version: "0.28-1"


### PR DESCRIPTION
Both libxml2 and libxslt have CVEs in the previous releases. This syncs us with the versions in chef/chef.

Signed-off-by: Tim Smith <tsmith@chef.io>