### PR TITLE
Add support for multiple policy files

### DIFF
--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -83,13 +83,6 @@ BANNER
 
       def run(params = [])
         return 1 unless apply_params!(params)
-
-        # Force config file to be loaded. We don't use the configuration
-        # directly, but the user may have SSL configuration options that they
-        # need to talk to a private supermarket (e.g., trusted_certs or
-        # ssl_verify_mode)
-        chef_config
-
         attributes_updater.run
         installer.run(@cookbooks_to_update) unless update_attributes_only?
         0
@@ -104,7 +97,7 @@ BANNER
 
       def attributes_updater
         @attributes_updater ||=
-          PolicyfileServices::UpdateAttributes.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd)
+          PolicyfileServices::UpdateAttributes.new(policyfile: policyfile_relative_path, ui: ui, root_dir: Dir.pwd, chef_config: chef_config)
       end
 
       def debug?

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -96,6 +96,9 @@ module ChefDK
   class BUG < RuntimeError
   end
 
+  class IncludePolicyCookbookSourceConflict < StandardError
+  end
+
   class CookbookSourceConflict < StandardError
 
     attr_reader :conflicting_cookbooks

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -142,4 +142,6 @@ EXAMPLE
   class PolicyfileLockDownloadError < StandardError
   end
 
+  class LocalPolicyfileLockNotFound < StandardError
+  end
 end

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -144,4 +144,7 @@ EXAMPLE
 
   class LocalPolicyfileLockNotFound < StandardError
   end
+
+  class InvalidPolicyfileLocation < StandardError
+  end
 end

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -139,4 +139,7 @@ EXAMPLE
 
   end
 
+  class PolicyfileLockDownloadError < StandardError
+  end
+
 end

--- a/lib/chef-dk/policyfile/attribute_merge_checker.rb
+++ b/lib/chef-dk/policyfile/attribute_merge_checker.rb
@@ -1,0 +1,75 @@
+require "chef/mash"
+module ChefDK
+  module Policyfile
+    class AttributeMergeChecker
+      class ConflictError < StandardError
+        attr_reader :attribute_path
+        attr_reader :provided_by
+
+        def initialize(attribute_path, provided_by)
+          @attribute_path = attribute_path
+          @provided_by = provided_by
+          super("Attribute '#{attribute_path}' provided conflicting values by the following sources #{provided_by}")
+        end
+      end
+
+      class Leaf
+        attr_reader :provided_by
+        attr_reader :val
+
+        def initialize(provided_by, val)
+          @provided_by = provided_by
+          @val = val
+        end
+      end
+
+      class AttributeHashInfo
+        attr_reader :source_name
+        attr_reader :hash
+        def initialize(source_name, hash)
+          @source_name = source_name
+          @hash = hash
+        end
+      end
+
+      attr_reader :attribute_hash_infos
+
+      def initialize
+        @attribute_hash_infos = []
+      end
+
+      def with_attributes(source_name, hash)
+        attribute_hash_infos << AttributeHashInfo.new(source_name, hash)
+      end
+
+      def check!
+        check_struct = Mash.new
+        attribute_hash_infos.each do |attr_hash_info|
+          fill!(check_struct, attr_hash_info.source_name, "", attr_hash_info.hash)
+        end
+      end
+
+      private
+
+      def fill!(acc, source_name, path, hash)
+        hash.each do |(key, val)|
+          new_path = "#{path}[#{key}]"
+          if val.kind_of?(Hash)
+            acc[key] ||= Mash.new
+            fill!(acc[key], source_name, new_path, val)
+          else
+            if acc[key].nil?
+              acc[key] = Leaf.new(source_name, val)
+            else
+              leaf = acc[key]
+              if leaf.val != val
+                raise ConflictError.new(new_path, [leaf.provided_by, source_name])
+              end
+            end
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/chef-dk/policyfile/attribute_merge_checker.rb
+++ b/lib/chef-dk/policyfile/attribute_merge_checker.rb
@@ -1,7 +1,26 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef/mash"
+
 module ChefDK
   module Policyfile
     class AttributeMergeChecker
+      # A ConflictError is used to specify a conflict has occurred
       class ConflictError < StandardError
         attr_reader :attribute_path
         attr_reader :provided_by
@@ -13,6 +32,10 @@ module ChefDK
         end
       end
 
+      # A Leaf is used to mark an individual attribute that has already
+      # been provided, along with its value and by who
+      #
+      # @api private
       class Leaf
         attr_reader :provided_by
         attr_reader :val
@@ -23,6 +46,7 @@ module ChefDK
         end
       end
 
+      # An AttributeHashInfo holds a set of attributes along with where they came from
       class AttributeHashInfo
         attr_reader :source_name
         attr_reader :hash
@@ -32,16 +56,27 @@ module ChefDK
         end
       end
 
+      # @return [Array<AttributeHashInfo>] A list of attributes and who they were provided by
       attr_reader :attribute_hash_infos
 
       def initialize
         @attribute_hash_infos = []
       end
 
+      # Add a hash of attributes to the set of attributes that will be compared
+      # for conflicts
+      #
+      # @param source_name [String] Where the attributes came from
+      # @param hash [Hash] attributes from source_name
       def with_attributes(source_name, hash)
         attribute_hash_infos << AttributeHashInfo.new(source_name, hash)
       end
 
+      # Check all added attributes for conflicts. Different sources can provide
+      # the same attribute if they have the same value. Otherwise, it is considered
+      # a conflict
+      #
+      # @raise ConflictError if there are conflicting attributes
       def check!
         check_struct = Mash.new
         attribute_hash_infos.each do |attr_hash_info|

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -1,4 +1,5 @@
 require "chef-dk/policyfile_lock"
+require "chef-dk/exceptions"
 
 module ChefDK
   module Policyfile
@@ -21,26 +22,47 @@ module ChefDK
       def errors
         error_messages = []
 
-        [:server, :policy_name, :policy_revision_id].each do |key|
+        [:server, :policy_name].each do |key|
           error_messages << "include_policy for #{name} is missing key #{key}" unless source_options[key]
+        end
+
+        if [:policy_revision_id, :policy_group].all? { |key| source_options[key].nil? }
+          error_messages << "include_policy for #{name} must specify policy_revision_id or policy_group"
         end
 
         error_messages
       end
 
+      def source_options_for_lock
+        source_options.merge({
+          policy_revision_id: lock_data["revision_id"],
+        })
+      end
+
       def lock_data
-        http_client.get("policies/#{policy_name}/revisions/#{revision}")
-      rescue Net::ProtocolError => e
-        if e.respond_to?(:response) && e.response.code.to_s == "404"
-          raise PolicyfileDownloadError.new("No policyfile lock named '#{policy_name}' found with revision '#{revision}' at #{http_client.url}", e)
-        else
-          raise PolicyfileDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}", e)
-        end
-      rescue => e
-        raise PolicyfileDownloadError.new("Failed to fetch policyfile lock from #{http_client.url}", e)
+        @lock_data ||= fetch_lock_data
       end
 
       private
+
+      def fetch_lock_data
+        if revision
+          http_client.get("policies/#{policy_name}/revisions/#{revision}")
+        elsif policy_group
+          http_client.get("policy_groups/#{policy_group}/policies/#{policy_name}")
+        else
+          raise ChefDK::BUG.new("The source_options should have been validated")
+        end
+      rescue Net::ProtocolError => e
+        if e.respond_to?(:response) && e.response.code.to_s == "404"
+          raise ChefDK::PolicyfileLockDownloadError.new("No policyfile lock named '#{policy_name}' found with revision '#{revision}' at #{http_client.url}") if revision
+          raise ChefDK::PolicyfileLockDownloadError.new("No policyfile lock named '#{policy_name}' found with policy group '#{policy_group}' at #{http_client.url}") if policy_group
+        else
+          raise ChefDK::PolicyfileLockDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}")
+        end
+      rescue => e
+        raise e
+      end
 
       def policy_name
         source_options[:policy_name]
@@ -48,6 +70,10 @@ module ChefDK
 
       def revision
         source_options[:policy_revision_id]
+      end
+
+      def policy_group
+        source_options[:policy_group]
       end
 
       def http_client

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -13,6 +13,8 @@ module ChefDK
         @name = name
         @source_options = source_options
         @chef_config = chef_config
+
+        @source_options[:policy_name] ||= name
       end
 
       def valid?

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -39,6 +39,15 @@ module ChefDK
         })
       end
 
+      def apply_locked_source_options(options_from_lock)
+        options = options_from_lock.inject({}) do |acc, (key, value)|
+          acc[key.to_sym] = value
+          acc
+        end
+        source_options.merge!(options)
+        raise ChefDK::InvalidLockfile, "Invalid source_options provided from lock data: #{options_from_lock_file.inspect}" if !valid?
+      end
+
       def lock_data
         @lock_data ||= fetch_lock_data
       end
@@ -51,7 +60,7 @@ module ChefDK
         elsif policy_group
           http_client.get("policy_groups/#{policy_group}/policies/#{policy_name}")
         else
-          raise ChefDK::BUG.new("The source_options should have been validated")
+          raise ChefDK::BUG.new("The source_options should have been validated: #{source_options.inspect}")
         end
       rescue Net::ProtocolError => e
         if e.respond_to?(:response) && e.response.code.to_s == "404"

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -50,15 +50,11 @@ module ChefDK
 
       def lock_data
         @lock_data ||= fetch_lock_data.tap do |data|
-          cookbook_locks = data["cookbook_locks"].inject({}) do |acc, (cookbook_name, cookbook_lock)|
+          data["cookbook_locks"].each do |cookbook_name, cookbook_lock|
             cookbook_lock["source_options"] = {
               "chef_server_artifact" => server,
-              "identifier" => cookbook_lock["identifier"]
+              "identifier" => cookbook_lock["identifier"],
             }
-
-            acc[cookbook_name] = cookbook_lock
-
-            acc
           end
         end
       end

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -1,4 +1,4 @@
-require 'chef-dk/policyfile_lock'
+require "chef-dk/policyfile_lock"
 
 module ChefDK
   module Policyfile
@@ -7,7 +7,7 @@ module ChefDK
       attr_accessor :name
       attr_accessor :source_options
       attr_accessor :chef_config
-     
+
       def initialize(name, source_options, chef_config)
         @name = name
         @source_options = source_options
@@ -59,5 +59,3 @@ module ChefDK
     end
   end
 end
-
-

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -1,14 +1,58 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef-dk/policyfile_lock"
 require "chef-dk/exceptions"
 
 module ChefDK
   module Policyfile
+
+    # A policyfile lock fetcher that can read a lock from a chef server
     class ChefServerLockFetcher
 
       attr_accessor :name
       attr_accessor :source_options
       attr_accessor :chef_config
 
+      # Initialize a LocalLockFetcher
+      #
+      # @param name [String] The name of the policyfile
+      # @param source_options [Hash] A hash with a :server key pointing at the chef server,
+      # along with :policy_name and either :policy_group or :policy_revision_id. If :policy_name
+      # is not provided, name is used.
+      # @param storage_config [StorageConfig]
+      #
+      # @example ChefServerLockFetcher for a policyfile with a specific revision id
+      #   ChefServerLockFetcher.new("foo",
+      #     {server: "http://example.com", policy_revision_id: "abcdabcdabcd"},
+      #     chef_config)
+      #
+      #   ChefServerLockFetcher.new("foo",
+      #     {server: "http://example.com", policy_name: "foo", policy_revision_id: "abcdabcdabcd"},
+      #     chef_config)
+      #
+      # @example ChefServerLockFetcher for a policyfile with the latest revision_id for a policy group
+       #   ChefServerLockFetcher.new("foo",
+      #     {server: "http://example.com", policy_group: "dev"},
+      #     chef_config)
+      #
+      #   ChefServerLockFetcher.new("foo",
+      #     {server: "http://example.com", policy_name: "foo", policy_group: "dev"},
+      #     chef_config)
       def initialize(name, source_options, chef_config)
         @name = name
         @source_options = source_options
@@ -17,10 +61,15 @@ module ChefDK
         @source_options[:policy_name] ||= name
       end
 
+      # @return [True] if there were no errors with the provided source_options
+      # @return [False] if there were errors with the provided source_options
       def valid?
         errors.empty?
       end
 
+      # Check the options provided when craeting this class for errors
+      #
+      # @return [Array<String>] A list of errors found
       def errors
         error_messages = []
 
@@ -35,12 +84,17 @@ module ChefDK
         error_messages
       end
 
+      # @return [Hash] The source_options that describe how to fetch this exact lock again
       def source_options_for_lock
         source_options.merge({
           policy_revision_id: lock_data["revision_id"],
         })
       end
 
+      # Applies source options from a lock file. This is used to make sure that the same
+      # policyfile lock is loaded that was locked
+      #
+      # @param options_from_lock [Hash] The source options loaded from a policyfile lock
       def apply_locked_source_options(options_from_lock)
         options = options_from_lock.inject({}) do |acc, (key, value)|
           acc[key.to_sym] = value
@@ -50,6 +104,7 @@ module ChefDK
         raise ChefDK::InvalidLockfile, "Invalid source_options provided from lock data: #{options_from_lock_file.inspect}" if !valid?
       end
 
+      # @return [String] of the policyfile lock data
       def lock_data
         @lock_data ||= fetch_lock_data.tap do |data|
           data["cookbook_locks"].each do |cookbook_name, cookbook_lock|

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -1,0 +1,63 @@
+require 'chef-dk/policyfile_lock'
+
+module ChefDK
+  module Policyfile
+    class ChefServerLockFetcher
+
+      attr_accessor :name
+      attr_accessor :source_options
+      attr_accessor :chef_config
+     
+      def initialize(name, source_options, chef_config)
+        @name = name
+        @source_options = source_options
+        @chef_config = chef_config
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      def errors
+        error_messages = []
+
+        [:server, :policy_name, :policy_revision_id].each do |key|
+          error_messages << "include_policy for #{name} is missing key #{key}" unless source_options[key]
+        end
+
+        error_messages
+      end
+
+      def lock_data
+        http_client.get("policies/#{policy_name}/revisions/#{revision}")
+      rescue Net::ProtocolError => e
+        if e.respond_to?(:response) && e.response.code.to_s == "404"
+          raise PolicyfileDownloadError.new("No policyfile lock named '#{policy_name}' found with revision '#{revision}' at #{http_client.url}", e)
+        else
+          raise PolicyfileDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}", e)
+        end
+      rescue => e
+        raise PolicyfileDownloadError.new("Failed to fetch policyfile lock from #{http_client.url}", e)
+      end
+
+      private
+
+      def policy_name
+        source_options[:policy_name]
+      end
+
+      def revision
+        source_options[:policy_revision_id]
+      end
+
+      def http_client
+        @http_client ||= Chef::ServerAPI.new(source_options[:server],
+                                             signing_key_filename: chef_config.client_key,
+                                             client_name: chef_config.node_name)
+      end
+
+    end
+  end
+end
+
+

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -49,7 +49,18 @@ module ChefDK
       end
 
       def lock_data
-        @lock_data ||= fetch_lock_data
+        @lock_data ||= fetch_lock_data.tap do |data|
+          cookbook_locks = data["cookbook_locks"].inject({}) do |acc, (cookbook_name, cookbook_lock)|
+            cookbook_lock["source_options"] = {
+              "chef_server_artifact" => server,
+              "identifier" => cookbook_lock["identifier"]
+            }
+
+            acc[cookbook_name] = cookbook_lock
+
+            acc
+          end
+        end
       end
 
       private
@@ -83,6 +94,10 @@ module ChefDK
 
       def policy_group
         source_options[:policy_group]
+      end
+
+      def server
+        source_options[:server]
       end
 
       def http_client

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -18,6 +18,7 @@
 require "chef-dk/policyfile/cookbook_sources"
 require "chef-dk/policyfile/cookbook_location_specification"
 require "chef-dk/policyfile/storage_config"
+require "chef-dk/policyfile/policyfile_location_specification"
 
 require "chef/node/attribute"
 require "chef/run_list/run_list_item"
@@ -36,6 +37,7 @@ module ChefDK
       attr_reader :run_list
       attr_reader :default_source
       attr_reader :cookbook_location_specs
+      attr_reader :included_policies
 
       attr_reader :named_run_lists
       attr_reader :node_attributes
@@ -48,6 +50,7 @@ module ChefDK
         @errors = []
         @run_list = []
         @named_run_lists = {}
+        @included_policies = []
         @default_source = [ NullCookbookSource.new ]
         @cookbook_location_specs = {}
         @storage_config = storage_config
@@ -119,6 +122,18 @@ module ChefDK
           @cookbook_location_specs[name] = spec
           @errors += spec.errors
         end
+      end
+
+      def include_policy(name, source_options = {})
+        puts "Adding #{name} with options #{source_options}"
+        if source_options[:local] != nil 
+          # TODO: storage_config is meant for cookbooks. We use it here to get the relative_paths_root.
+          spec = PolicyfileLocationSpecification.new(name, source_options, storage_config)
+          included_policies << spec
+        else
+          raise "unimplemented"
+        end
+
       end
 
       def default

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -125,9 +125,17 @@ module ChefDK
       end
 
       def include_policy(name, source_options = {})
-        spec = PolicyfileLocationSpecification.new(name, source_options, storage_config, chef_config)
-        included_policies << spec
-        @errors += spec.errors
+        #TODO: Make included_policies a map
+        if existing = included_policies.find { |p| p.name == name }
+          err = "Included policy '#{name}' assigned conflicting locations or was already specified\n\n"
+          err << "Previous source: #{existing.source_options.inspect}\n"
+          err << "Conflicts with: #{source_options.inspect}\n"
+          @errors << err
+        else
+          spec = PolicyfileLocationSpecification.new(name, source_options, storage_config, chef_config)
+          included_policies << spec
+          @errors += spec.errors
+        end
       end
 
       def default

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -125,15 +125,9 @@ module ChefDK
       end
 
       def include_policy(name, source_options = {})
-        puts "Adding #{name} with options #{source_options}"
-        if source_options[:local] != nil 
-          # TODO: storage_config is meant for cookbooks. We use it here to get the relative_paths_root.
-          spec = PolicyfileLocationSpecification.new(name, source_options, storage_config)
-          included_policies << spec
-        else
-          raise "unimplemented"
-        end
-
+        spec = PolicyfileLocationSpecification.new(name, source_options, storage_config, chef_config)
+        included_policies << spec
+        @errors += spec.errors
       end
 
       def default

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -125,7 +125,6 @@ module ChefDK
       end
 
       def include_policy(name, source_options = {})
-        #TODO: Make included_policies a map
         if existing = included_policies.find { |p| p.name == name }
           err = "Included policy '#{name}' assigned conflicting locations or was already specified\n\n"
           err << "Previous source: #{existing.source_options.inspect}\n"

--- a/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
@@ -65,6 +65,10 @@ module ChefDK
         universe_graph.include?(cookbook_name)
       end
 
+      def preferred_cookbooks
+        universe_graph.keys
+      end
+
       def ==(other)
         other.kind_of?(self.class) && other.included_policy_location_specs == included_policy_location_specs
       end

--- a/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
@@ -1,0 +1,154 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef-dk/ui"
+
+module ChefDK
+  module Policyfile
+    class IncludedPoliciesCookbookSource
+
+      class ConflictingCookbookVersions < StandardError
+      end
+
+      class ConflictingCookbookDependencies < StandardError
+      end
+
+      class ConflictingCookbookSources < StandardError
+      end
+
+
+      # Why do we need this class?
+      # If we rely on default sources, we may not have the the universe of cookbooks
+      # provided in the included policies
+      #
+      # This is not meant to be used from the DSL
+
+      # A list of included policies
+      attr_reader :included_policy_location_specs
+      # UI object for output
+      attr_accessor :ui
+
+      # Constructor
+      #
+      def initialize(included_policy_location_specs)
+        @included_policy_location_specs = included_policy_location_specs
+        @ui = UI.new
+        @preferred_cookbooks = []
+        yield self if block_given?
+      end
+
+      def default_source_args
+        [:included_policies, []]
+      end
+
+      def check_for_conflicts!
+        source_options
+        universe_graph
+      end
+
+      # All are preferred here
+      def preferred_source_for?(cookbook_name)
+        universe_graph.include?(cookbook_name)
+      end
+
+      def ==(other)
+        other.kind_of?(self.class) && other.included_policy_location_specs == included_policy_location_specs
+      end
+
+      # Calls the slurp_metadata! helper once to calculate the @universe_graph
+      # and @cookbook_version_paths metadata.  Returns the @universe_graph.
+      #
+      # @return [Hash] universe_graph
+      def universe_graph
+        @universe_graph ||= build_universe
+      end
+
+      # Returns the metadata (path and version) for an individual cookbook
+      #
+      # @return [Hash] metadata for a single cookbook version
+      def source_options_for(cookbook_name, cookbook_version)
+        source_options[cookbook_name][cookbook_version]
+      end
+
+      def null?
+        false
+      end
+
+      def desc
+        "included_policies()"
+      end
+
+      private
+
+      def build_universe
+        included_policy_location_specs.inject({}) do |acc, policy_spec|
+          lock = policy_spec.policyfile_lock
+          cookbook_dependencies = lock.solution_dependencies.cookbook_dependencies
+          cookbook_dependencies.each do |(cookbook, deps)|
+            name = cookbook.name
+            version = cookbook.version
+            mapped_deps = deps.map do |dep|
+              [dep[0], dep[1].to_s]
+            end
+            if acc[name]
+              if acc[name][version]
+                #TODO: Should compare sets
+                if acc[name][version] != mapped_deps
+                  raise ConflictingCookbookDependencies.new("Conflicting dependencies provided for cookbook #{name}")
+                end
+              else
+                raise ConflictingCookbookVersions.new("Multiple versions provided for cookbook #{name}")
+              end
+            else
+              acc[name] = {}
+              acc[name][version] = mapped_deps
+            end
+          end
+          acc
+        end
+      end
+
+      def source_options
+        @source_options ||= build_source_options
+      end
+
+      ## Collect all the source options
+      def build_source_options
+        included_policy_location_specs.inject({}) do |acc, policy_spec|
+          lock = policy_spec.policyfile_lock
+          lock.cookbook_locks.each do |(name, cookbook_lock)|
+            version = cookbook_lock.version
+            if acc[name]
+              if acc[name][version]
+                if acc[name][version] != cookbook_lock.source_options
+                  raise ConflictingCookbookSources.new("Conflicting sources provided for cookbook #{name}")
+                end
+              else
+                raise ConflictingCookbookVersions.new("Multiple sources provided for cookbook #{name}")
+              end
+            else
+              acc[name] = {}
+              acc[name][version] = cookbook_lock.source_options
+            end
+          end
+          acc
+        end
+      end
+
+    end
+  end
+end

--- a/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
@@ -109,7 +109,6 @@ module ChefDK
             end
             if acc[name]
               if acc[name][version]
-                #TODO: Should compare sets
                 if acc[name][version] != mapped_deps
                   raise ConflictingCookbookDependencies.new("Conflicting dependencies provided for cookbook #{name}")
                 end

--- a/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/included_policies_cookbook_source.rb
@@ -30,7 +30,6 @@ module ChefDK
       class ConflictingCookbookSources < StandardError
       end
 
-
       # Why do we need this class?
       # If we rely on default sources, we may not have the the universe of cookbooks
       # provided in the included policies

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -1,24 +1,54 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "chef-dk/policyfile_lock"
 require "chef-dk/exceptions"
 
 module ChefDK
   module Policyfile
+
+    # A policyfile lock fetcher that can read a lock from a local disk
     class LocalLockFetcher
 
       attr_reader :name
       attr_reader :source_options
       attr_reader :storage_config
 
+      # Initialize a LocalLockFetcher
+      #
+      # @param name [String] The name of the policyfile
+      # @param source_options [Hash] A hash with a :path key pointing at the location
+      #                              of the lock
+      # @param storage_config [StorageConfig]
       def initialize(name, source_options, storage_config)
         @name = name
         @source_options = source_options
         @storage_config = storage_config
       end
 
+      # @return [True] if there were no errors with the provided source_options
+      # @return [False] if there were errors with the provided source_options
       def valid?
         errors.empty?
       end
 
+      # Check the options provided when craeting this class for errors
+      #
+      # @return [Array<String>] A list of errors found
       def errors
         error_messages = []
 
@@ -29,14 +59,20 @@ module ChefDK
         error_messages
       end
 
+      # @return [Hash] The source_options that describe how to fetch this exact lock again
       def source_options_for_lock
         source_options
       end
 
+      # Applies source options from a lock file. This is used to make sure that the same
+      # policyfile lock is loaded that was locked
+      #
+      # @param options_from_lock [Hash] The source options loaded from a policyfile lock
       def apply_locked_source_options(options_from_lock)
         # There are no options the lock could provide
       end
 
+      # @return [String] of the policyfile lock data
       def lock_data
         FFI_Yajl::Parser.new.parse(content).tap do |data|
           data["cookbook_locks"].each do |cookbook_name, cookbook_lock|

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -4,14 +4,14 @@ module ChefDK
   module Policyfile
     class LocalLockFetcher
 
-      attr_accessor :name
-      attr_accessor :source_options
-      attr_accessor :chef_config
+      attr_reader :name
+      attr_reader :source_options
+      attr_reader :storage_config
 
-      def initialize(name, source_options, chef_config = nil)
+      def initialize(name, source_options, storage_config)
         @name = name
         @source_options = source_options
-        @chef_config = chef_config
+        @storage_config = storage_config
       end
 
       def valid?
@@ -37,17 +37,34 @@ module ChefDK
       end
 
       def lock_data
-        FFI_Yajl::Parser.new.parse(content)
+        FFI_Yajl::Parser.new.parse(content).tap do |data|
+          data["cookbook_locks"].each do |cookbook_name, cookbook_lock|
+            cookbook_path = cookbook_lock["source_options"]["path"]
+            if !cookbook_path.nil?
+              cookbook_lock["source_options"]["path"] = transform_path(cookbook_path)
+            end
+          end
+        end
       end
 
       private
+
+      def transform_path(path_to_transform)
+        cur_path = Pathname.new(storage_config.relative_paths_root)
+        include_path = Pathname.new(path).dirname
+        include_path.relative_path_from(cur_path).join(path_to_transform).to_s
+      end
 
       def content
         IO.read(path)
       end
 
       def path
-        Pathname.new(source_options[:local])
+        path = Pathname.new(source_options[:local])
+        if !path.absolute?
+          path = Pathname.new(storage_config.relative_paths_root).join(path)
+        end
+        path
       end
     end
   end

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -28,6 +28,14 @@ module ChefDK
         error_messages
       end
 
+      def source_options_for_lock
+        source_options
+      end
+
+      def apply_locked_source_options(options_from_lock)
+        # There are no options the lock could provide
+      end
+
       def lock_data
         FFI_Yajl::Parser.new.parse(content)
       end

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -1,0 +1,49 @@
+require 'chef-dk/policyfile_lock'
+
+module ChefDK
+  module Policyfile
+    class LocalLockFetcher
+
+      attr_accessor :name
+      attr_accessor :source_options
+      attr_accessor :chef_config
+     
+      def initialize(name, source_options, chef_config)
+        @name = name
+        @source_options = source_options
+        @chef_config = chef_config
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      def errors
+        error_messages = []
+
+        [:local].each do |key|
+          error_messages << "include_policy for #{name} is missing key #{key}" unless source_options[key]
+        end
+
+        error_messages
+      end
+
+      def lock_data
+        FFI_Yajl::Parser.new.parse(content)
+      end
+
+      private
+
+      def content
+        IO.read(path)
+      end
+
+      def path
+        Pathname.new(source_options[:local])
+      end
+
+    end
+  end
+end
+
+

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -8,7 +8,7 @@ module ChefDK
       attr_accessor :source_options
       attr_accessor :chef_config
      
-      def initialize(name, source_options, chef_config)
+      def initialize(name, source_options, chef_config = nil)
         @name = name
         @source_options = source_options
         @chef_config = chef_config

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -1,4 +1,4 @@
-require 'chef-dk/policyfile_lock'
+require "chef-dk/policyfile_lock"
 
 module ChefDK
   module Policyfile
@@ -7,7 +7,7 @@ module ChefDK
       attr_accessor :name
       attr_accessor :source_options
       attr_accessor :chef_config
-     
+
       def initialize(name, source_options, chef_config = nil)
         @name = name
         @source_options = source_options
@@ -41,9 +41,6 @@ module ChefDK
       def path
         Pathname.new(source_options[:local])
       end
-
     end
   end
 end
-
-

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -21,7 +21,7 @@ module ChefDK
       def errors
         error_messages = []
 
-        [:local].each do |key|
+        [:path].each do |key|
           error_messages << "include_policy for #{name} is missing key #{key}" unless source_options[key]
         end
 
@@ -60,7 +60,7 @@ module ChefDK
       end
 
       def path
-        path = Pathname.new(source_options[:local])
+        path = Pathname.new(source_options[:path])
         if !path.absolute?
           path = Pathname.new(storage_config.relative_paths_root).join(path)
         end

--- a/lib/chef-dk/policyfile/lock_applier.rb
+++ b/lib/chef-dk/policyfile/lock_applier.rb
@@ -1,0 +1,50 @@
+module ChefDK
+  module Policyfile
+
+    # A class that can apply constraints from a lock to a compiler
+    class LockApplier
+      attr_reader :unlocked_policies
+      attr_reader :policyfile_lock
+      attr_reader :policyfile_compiler
+
+      def initialize(policyfile_lock, policyfile_compiler)
+        @policyfile_lock = policyfile_lock
+        @policyfile_compiler = policyfile_compiler
+        @unlocked_policies = []
+      end
+
+      def with_unlocked_policies(policies)
+        if policies == :all || unlocked_policies == :all
+          @unlocked_policies = :all
+        else
+          policies.each do |policy|
+            @unlocked_policies << policy
+          end
+        end
+        self
+      end
+
+      # No changes are applied until apply! is invoked
+      def apply!
+        prepare_constraints_for_policies
+      end
+
+      private
+
+      def prepare_constraints_for_policies
+        if unlocked_policies == :all
+          return
+        end
+
+        policyfile_compiler.included_policies.each do |policy|
+          if !unlocked_policies.include?(policy.name)
+            lock = policyfile_lock.included_policy_locks.find do |policy_lock|
+              policy_lock["name"] == policy.name
+            end
+            policy.apply_locked_source_options(lock["source_options"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/chef-dk/policyfile/lock_applier.rb
+++ b/lib/chef-dk/policyfile/lock_applier.rb
@@ -1,3 +1,20 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 module ChefDK
   module Policyfile
 
@@ -7,12 +24,22 @@ module ChefDK
       attr_reader :policyfile_lock
       attr_reader :policyfile_compiler
 
+      # Initialize a LockApplier. By default, all locked data this class knows
+      # about will be applied to the compiler. Currently, it applies locks only
+      # for included policies.
+      #
+      # @param policyfile_lock [PolicyfileLock] contains the locked data to use
+      # @param policyfile_compiler [PolicyfileCompiler] the compiler to apply the locked data
       def initialize(policyfile_lock, policyfile_compiler)
         @policyfile_lock = policyfile_lock
         @policyfile_compiler = policyfile_compiler
         @unlocked_policies = []
       end
 
+      # Unlocks included policies
+      #
+      # @param policies [:all] Unconstrain all policies
+      # @param policies [Array<String>] Unconstrain a specific policy by name
       def with_unlocked_policies(policies)
         if policies == :all || unlocked_policies == :all
           @unlocked_policies = :all
@@ -24,7 +51,10 @@ module ChefDK
         self
       end
 
-      # No changes are applied until apply! is invoked
+      # Apply locks described in policyfile_lock allowing for the deviations asked
+      # for.
+      #
+      # @note No changes are applied until apply! is invoked
       def apply!
         prepare_constraints_for_policies
       end

--- a/lib/chef-dk/policyfile/null_cookbook_source.rb
+++ b/lib/chef-dk/policyfile/null_cookbook_source.rb
@@ -36,6 +36,10 @@ module ChefDK
         true
       end
 
+      def preferred_cookbooks
+        []
+      end
+
       def desc
         "null_cookbook_source"
       end

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -33,12 +33,15 @@ module ChefDK
       def policyfile_lock
         @policyfile_lock ||= begin
           ensure_cached
-          lock_data = FFI_Yajl::Parser.new.parse(content)
           PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(lock_data)
         end
       end
 
       private
+
+      def lock_data
+        FFI_Yajl::Parser.new.parse(content)
+      end
 
       def content
         IO.read(path)

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -1,0 +1,58 @@
+module ChefDK
+  module Policyfile
+    class PolicyfileLocationSpecification
+
+      attr_reader :name
+      attr_reader :source_options
+      attr_reader :storage_config
+      attr_reader :ui
+
+      def initialize(name, source_options, storage_config)
+        @name = name
+        @source_options = source_options
+        @storage_config = storage_config
+        @ui = nil
+      end
+
+      def installed?
+        true
+      end
+
+      def ensure_cached
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      def errors
+        error_messages = []
+        error_messages
+      end
+
+      def policyfile_lock
+        @policyfile_lock ||= begin
+          ensure_cached
+          lock_data = FFI_Yajl::Parser.new.parse(content)
+          PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(lock_data)
+        end
+      end
+
+      private
+
+      def content
+        IO.read(path)
+      end
+
+      def path
+        # TODO: Move to local fetcher implementation
+        path = Pathname.new(source_options[:local])
+        if !path.absolute?
+          path = Pathname.new(storage_config.relative_paths_root).join(path)
+        end
+        path
+      end
+    end
+  end
+end
+

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -1,3 +1,5 @@
+require 'chef-dk/policyfile_lock'
+
 module ChefDK
   module Policyfile
     class PolicyfileLocationSpecification

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -31,7 +31,7 @@ module ChefDK
                        if source_options[:server]
                          Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
                        elsif source_options[:local]
-                         Policyfile::LocalLockFetcher.new(name, source_options, chef_config)
+                         Policyfile::LocalLockFetcher.new(name, source_options, storage_config)
                        else
                          raise "Invalid policyfile lock location type"
                        end

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -65,6 +65,10 @@ module ChefDK
       def source_options_for_lock
         fetcher.source_options_for_lock
       end
+
+      def apply_locked_source_options(options_from_lock)
+        fetcher.apply_locked_source_options(options_from_lock)
+      end
     end
   end
 end

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -28,7 +28,7 @@ module ChefDK
 
       def fetcher
         @fetcher ||= begin
-                       if source_options[:path] 
+                       if source_options[:path]
                          Policyfile::LocalLockFetcher.new(name, source_options, storage_config)
                        elsif source_options[:server]
                          Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -22,6 +22,10 @@ module ChefDK
         @chef_config = chef_config
       end
 
+      def revision_id
+        fetcher.lock_data["revision_id"]
+      end
+
       def fetcher
         @fetcher ||= begin
                        if source_options[:server]
@@ -56,6 +60,10 @@ module ChefDK
         @policyfile_lock ||= begin
                                PolicyfileLock.new(storage_config, ui: ui).build_from_lock_data(fetcher.lock_data)
                              end
+      end
+
+      def source_options_for_lock
+        fetcher.source_options_for_lock
       end
     end
   end

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -12,7 +12,7 @@ module ChefDK
       attr_reader :chef_config
       attr_reader :ui
 
-      LOCATION_TYPES = [:git, :local, :server]
+      LOCATION_TYPES = [:path, :server]
 
       def initialize(name, source_options, storage_config, chef_config = nil)
         @name = name
@@ -28,10 +28,10 @@ module ChefDK
 
       def fetcher
         @fetcher ||= begin
-                       if source_options[:server]
-                         Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
-                       elsif source_options[:local]
+                       if source_options[:path] 
                          Policyfile::LocalLockFetcher.new(name, source_options, storage_config)
+                       elsif source_options[:server]
+                         Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
                        else
                          raise "Invalid policyfile lock location type"
                        end

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -1,6 +1,6 @@
-require 'chef-dk/policyfile_lock'
-require 'chef-dk/policyfile/local_lock_fetcher'
-require 'chef-dk/policyfile/chef_server_lock_fetcher'
+require "chef-dk/policyfile_lock"
+require "chef-dk/policyfile/local_lock_fetcher"
+require "chef-dk/policyfile/chef_server_lock_fetcher"
 
 module ChefDK
   module Policyfile
@@ -44,7 +44,7 @@ module ChefDK
         if LOCATION_TYPES.all? { |l| source_options[l].nil? }
           error_messages << "include_policy must use one of the following sources: #{LOCATION_TYPES.join(', ')}"
         else
-          if fetcher != nil
+          if !fetcher.nil?
             error_messages += fetcher.errors
           end
         end
@@ -60,4 +60,3 @@ module ChefDK
     end
   end
 end
-

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -1,6 +1,7 @@
 require "chef-dk/policyfile_lock"
 require "chef-dk/policyfile/local_lock_fetcher"
 require "chef-dk/policyfile/chef_server_lock_fetcher"
+require "chef-dk/exceptions"
 
 module ChefDK
   module Policyfile
@@ -33,7 +34,8 @@ module ChefDK
                        elsif source_options[:server]
                          Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
                        else
-                         raise "Invalid policyfile lock location type"
+                         raise ChefDK::InvalidPolicyfileLocation.new(
+                           "Invalid policyfile lock location type. The supported locations are: #{LOCATION_TYPES.join(", ")}")
                        end
                      end
       end

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -182,6 +182,7 @@ module ChefDK
 
       graph_solution.each do |cookbook_name, version|
         spec = cookbook_location_spec_for(cookbook_name)
+        # TODO: Make sure that included policy specs win
         if spec.nil? || !spec.version_fixed?
           spec = create_spec_for_cookbook(cookbook_name, version)
           install_report.installing_cookbook(spec)
@@ -290,6 +291,7 @@ module ChefDK
     end
 
     def artifacts_graph
+      # TODO: Should we include the included policies artifacts here?
       remote_artifacts_graph.merge(local_artifacts_graph)
     end
 
@@ -414,6 +416,7 @@ module ChefDK
     end
 
     def best_source_for(cookbook_name)
+      # TODO: we have a function that does this
       preferred = default_source.find { |s| s.preferred_source_for?(cookbook_name) }
       if preferred.nil?
         default_source.find do |s|
@@ -425,6 +428,8 @@ module ChefDK
     end
 
     def preferred_source_for_cookbook(conflicting_cb_name)
+      # TODO: Create a source for each included policy?
+      # TODO: Prefer the source from the included policy
       default_source.find { |s| s.preferred_source_for?(conflicting_cb_name) }
     end
 

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -70,14 +70,17 @@ module ChefDK
       @install_report = Policyfile::Reports::Install.new(ui: @ui, policyfile_compiler: self)
     end
 
-    def default_source
-      prepend_array = if included_policies.length > 0
-                        [included_policies_cookbook_source]
-                      else
-                        []
-                      end
-      prepend_array + dsl.default_source
-
+    def default_source(source_type = nil, source_argument = nil, &block)
+      if source_type == nil
+        prepend_array = if included_policies.length > 0
+                          [included_policies_cookbook_source]
+                        else
+                          []
+                        end
+        prepend_array + dsl.default_source
+      else
+        dsl.default_source(source_type, source_argument, &block)
+      end
     end
 
     def error!

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -130,6 +130,7 @@ module ChefDK
     end
 
     def default_attributes
+      check_for_default_attribute_conflicts!
       included_policies.map {|p| p.policyfile_lock }.inject(
         dsl.node_attributes.combined_default.to_hash) do |acc, lock|
           Chef::Mixin::DeepMerge.merge(acc, lock.default_attributes)
@@ -137,6 +138,7 @@ module ChefDK
     end
 
     def override_attributes
+      check_for_override_attribute_conflicts!
       included_policies.map {|p| p.policyfile_lock }.inject(
         dsl.node_attributes.combined_override.to_hash) do |acc, lock|
           Chef::Mixin::DeepMerge.merge(acc, lock.override_attributes)
@@ -161,11 +163,6 @@ module ChefDK
         checker.with_attributes(policy_spec.name, lock.override_attributes)
       end
       checker.check!
-    end
-
-    def check_for_attribute_conflicts!
-      check_for_default_attribute_conflicts!
-      check_for_override_attribute_conflicts!
     end
 
     def lock
@@ -211,8 +208,6 @@ module ChefDK
 
         raise CookbookDoesNotContainRequiredRecipe, message
       end
-
-      check_for_attribute_conflicts!
     end
 
     def create_spec_for_cookbook(cookbook_name, version)
@@ -271,9 +266,7 @@ module ChefDK
     def cookbook_demands_from_policies
       included_policies.map do |policy_spec|
         lock = policy_spec.policyfile_lock
-        lock.cookbook_locks.map do |ck_name, location_spec|
-          [ck_name, "= #{location_spec.version}"]
-        end
+        lock.solution_dependencies.to_lock["Policyfile"]
       end.flatten(1)
     end
 

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -471,8 +471,6 @@ module ChefDK
     end
 
     def preferred_source_for_cookbook(conflicting_cb_name)
-      # TODO: Create a source for each included policy?
-      # TODO: Prefer the source from the included policy
       default_source.find { |s| s.preferred_source_for?(conflicting_cb_name) }
     end
 

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -195,7 +195,6 @@ module ChefDK
 
       graph_solution.each do |cookbook_name, version|
         spec = cookbook_location_spec_for(cookbook_name)
-        # TODO: Make sure that included policy specs win
         if spec.nil? || !spec.version_fixed?
           spec = create_spec_for_cookbook(cookbook_name, version)
           install_report.installing_cookbook(spec)
@@ -459,7 +458,6 @@ module ChefDK
     end
 
     def best_source_for(cookbook_name)
-      # TODO: we have a function that does this
       preferred = default_source.find { |s| s.preferred_source_for?(cookbook_name) }
       if preferred.nil?
         default_source.find do |s|

--- a/lib/chef-dk/policyfile_compiler.rb
+++ b/lib/chef-dk/policyfile_compiler.rb
@@ -71,7 +71,7 @@ module ChefDK
     end
 
     def default_source(source_type = nil, source_argument = nil, &block)
-      if source_type == nil
+      if source_type.nil?
         prepend_array = if included_policies.length > 0
                           [included_policies_cookbook_source]
                         else
@@ -144,18 +144,18 @@ module ChefDK
 
     def default_attributes
       check_for_default_attribute_conflicts!
-      included_policies.map {|p| p.policyfile_lock }.inject(
+      included_policies.map { |p| p.policyfile_lock }.inject(
         dsl.node_attributes.combined_default.to_hash) do |acc, lock|
           Chef::Mixin::DeepMerge.merge(acc, lock.default_attributes)
-      end
+        end
     end
 
     def override_attributes
       check_for_override_attribute_conflicts!
-      included_policies.map {|p| p.policyfile_lock }.inject(
+      included_policies.map { |p| p.policyfile_lock }.inject(
         dsl.node_attributes.combined_override.to_hash) do |acc, lock|
           Chef::Mixin::DeepMerge.merge(acc, lock.override_attributes)
-      end
+        end
     end
 
     def check_for_default_attribute_conflicts!
@@ -278,10 +278,10 @@ module ChefDK
     end
 
     def cookbook_demands_from_policies
-      included_policies.map do |policy_spec|
+      included_policies.flat_map do |policy_spec|
         lock = policy_spec.policyfile_lock
         lock.solution_dependencies.to_lock["Policyfile"]
-      end.flatten(1)
+      end
     end
 
     def cookbook_demands_from_current
@@ -308,7 +308,7 @@ module ChefDK
     def handle_included_policies_preferred_cookbook_conflicts(included_policies_source)
       # All cookbooks in the included policies are preferred.
       conflicting_source_messages = []
-      dsl.default_source.reject {|s| s.null?}.each do |source_b|
+      dsl.default_source.reject { |s| s.null? }.each do |source_b|
         conflicting_preferences = included_policies_source.preferred_cookbooks & source_b.preferred_cookbooks
         next if conflicting_preferences.empty?
         next if conflicting_preferences.all? do |cookbook_name|
@@ -319,7 +319,7 @@ module ChefDK
             false
           end
         end
-        conflicting_source_messages  << "#{source_b.desc} sets a preferred for cookbook(s) #{conflicting_preferences.join(', ')}. This conflicts with an included policy."
+        conflicting_source_messages << "#{source_b.desc} sets a preferred for cookbook(s) #{conflicting_preferences.join(', ')}. This conflicts with an included policy."
       end
       unless conflicting_source_messages.empty?
         msg = "You may not override the cookbook sources for any cookbooks required by included policies.\n"
@@ -327,7 +327,6 @@ module ChefDK
         raise IncludePolicyCookbookSourceConflict.new(msg)
       end
     end
-
 
     def graph_demands
       ## TODO: By merging cookbooks from the current policyfile and included policies,

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -111,7 +111,7 @@ module ChefDK
 
       @solution_dependencies = Policyfile::SolutionDependencies.new
 
-      @included_policy_locks = {}
+      @included_policy_locks = []
 
       @install_report = InstallReport.new(ui: @ui, policyfile_lock: self)
     end
@@ -255,12 +255,12 @@ module ChefDK
 
       @solution_dependencies = compiler.solution_dependencies
 
-      @included_policy_locks = compiler.included_policies.inject({}) do |acc, policy|
-        acc[policy.name] = {
+      @included_policy_locks = compiler.included_policies.map do |policy|
+        {
+          name: policy.name,
           revision_id: policy.revision_id,
           source_options: policy.source_options_for_lock,
         }
-        acc
       end
 
       self

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -257,9 +257,9 @@ module ChefDK
 
       @included_policy_locks = compiler.included_policies.map do |policy|
         {
-          name: policy.name,
-          revision_id: policy.revision_id,
-          source_options: policy.source_options_for_lock,
+          "name" => policy.name,
+          "revision_id" => policy.revision_id,
+          "source_options" => policy.source_options_for_lock,
         }
       end
 

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -539,7 +539,7 @@ module ChefDK
         @included_policy_locks = []
       else
         locks.each do |lock_info|
-          if !(%w(revision_id name source_options).all? { |key| !lock_info[key].nil? })
+          if !(%w{revision_id name source_options}.all? { |key| !lock_info[key].nil? })
             raise InvalidLockfile, "lockfile included policy missing one of the required keys"
           end
         end

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -273,6 +273,7 @@ module ChefDK
       set_cookbook_locks_from_lock_data(lock_data)
       set_attributes_from_lock_data(lock_data)
       set_solution_dependencies_from_lock_data(lock_data)
+      set_included_policy_locks_from_lock_data(lock_data)
       self
     end
 
@@ -283,6 +284,7 @@ module ChefDK
       set_cookbook_locks_as_archives_from_lock_data(lock_data)
       set_attributes_from_lock_data(lock_data)
       set_solution_dependencies_from_lock_data(lock_data)
+      set_included_policy_locks_from_lock_data(lock_data)
       self
     end
 
@@ -529,6 +531,20 @@ module ChefDK
 
       s = Policyfile::SolutionDependencies.from_lock(lock_data["solution_dependencies"])
       @solution_dependencies = s
+    end
+
+    def set_included_policy_locks_from_lock_data(lock_data)
+      locks = lock_data["included_policy_locks"]
+      if locks.nil?
+        @included_policy_locks = []
+      else
+        locks.each do |lock_info|
+          if !(["revision_id", "name", "source_options"].all? { |key| !lock_info[key].nil? })
+            raise InvalidLockfile, "lockfile included policy without #{key}"
+          end
+        end
+        @included_policy_locks = locks
+      end
     end
 
     def build_cookbook_lock_from_lock_data(name, lock_info)

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -93,6 +93,8 @@ module ChefDK
 
     attr_reader :cookbook_locks
 
+    attr_reader :included_policy_locks
+
     attr_reader :install_report
 
     def initialize(storage_config, ui: nil)
@@ -108,6 +110,9 @@ module ChefDK
       @override_attributes = {}
 
       @solution_dependencies = Policyfile::SolutionDependencies.new
+
+      @included_policy_locks = {}
+
       @install_report = InstallReport.new(ui: @ui, policyfile_lock: self)
     end
 
@@ -141,6 +146,7 @@ module ChefDK
         lock["default_attributes"] = default_attributes
         lock["override_attributes"] = override_attributes
         lock["solution_dependencies"] = solution_dependencies.to_lock
+        lock["included_policy_locks"] = included_policy_locks
       end
     end
 
@@ -248,6 +254,14 @@ module ChefDK
       @override_attributes = compiler.override_attributes
 
       @solution_dependencies = compiler.solution_dependencies
+
+      @included_policy_locks = compiler.included_policies.inject({}) do |acc, policy|
+        acc[policy.name] = {
+          revision_id: policy.revision_id,
+          source_options: policy.source_options_for_lock,
+        }
+        acc
+      end
 
       self
     end

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -539,8 +539,8 @@ module ChefDK
         @included_policy_locks = []
       else
         locks.each do |lock_info|
-          if !(%w(revision_id, name, source_options).all? { |key| !lock_info[key].nil? })
-            raise InvalidLockfile, "lockfile included policy without #{key}"
+          if !(%w(revision_id name source_options).all? { |key| !lock_info[key].nil? })
+            raise InvalidLockfile, "lockfile included policy missing one of the required keys"
           end
         end
         @included_policy_locks = locks

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -142,11 +142,11 @@ module ChefDK
         lock["name"] = name
         lock["run_list"] = run_list
         lock["named_run_lists"] = named_run_lists unless named_run_lists.empty?
+        lock["included_policy_locks"] = included_policy_locks
         lock["cookbook_locks"] = cookbook_locks_for_lockfile
         lock["default_attributes"] = default_attributes
         lock["override_attributes"] = override_attributes
         lock["solution_dependencies"] = solution_dependencies.to_lock
-        lock["included_policy_locks"] = included_policy_locks
       end
     end
 

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -539,7 +539,7 @@ module ChefDK
         @included_policy_locks = []
       else
         locks.each do |lock_info|
-          if !(["revision_id", "name", "source_options"].all? { |key| !lock_info[key].nil? })
+          if !(%w(revision_id, name, source_options).all? { |key| !lock_info[key].nil? })
             raise InvalidLockfile, "lockfile included policy without #{key}"
           end
         end

--- a/lib/chef-dk/policyfile_services/install.rb
+++ b/lib/chef-dk/policyfile_services/install.rb
@@ -140,10 +140,9 @@ module ChefDK
       end
 
       def prepare_constraints_for_policies
-        policyfile_compiler.included_policies.each do |policy|
-          lock = policyfile_lock.included_policy_locks.find { |policy_lock| policy_lock["name"] == policy.name }
-          policy.apply_locked_source_options(lock["source_options"])
-        end
+        Policyfile::LockApplier.
+          new(policyfile_lock, policyfile_compiler).
+          apply!
       end
 
       def install_from_lock

--- a/lib/chef-dk/policyfile_services/install.rb
+++ b/lib/chef-dk/policyfile_services/install.rb
@@ -115,9 +115,9 @@ module ChefDK
 
       def update_lock_and_install(cookbooks_to_update)
         ui.msg "Updating #{cookbooks_to_update.join(',')} cookbooks"
-
         to_update = policyfile_lock.solution_dependencies.transitive_deps(cookbooks_to_update)
         prepare_constraints_for_update(to_update)
+        prepare_constraints_for_policies
         generate_lock_and_install
       end
 
@@ -136,6 +136,13 @@ module ChefDK
             location_spec.source_options,
             location_spec.storage_config
           )
+        end
+      end
+
+      def prepare_constraints_for_policies
+        policyfile_compiler.included_policies.each do |policy|
+          lock = policyfile_lock.included_policy_locks.find { |policy_lock| policy_lock["name"] == policy.name }
+          policy.apply_locked_source_options(lock["source_options"])
         end
       end
 

--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -44,6 +44,7 @@ module ChefDK
 
       def run
         assert_policy_and_lock_present!
+        prepare_constraints_for_policies
         #TODO: There is quite a major bug here in terms of how include_policy works
         #      include_policy requires the compiler to fetch the lock. The lock it fetches is not
         #      based on the lock data of the policy being updated. Thus, if the include_policy does
@@ -104,6 +105,14 @@ module ChefDK
           raise LockfileNotFound, "Policyfile lock not found at path #{policyfile_lock_expanded_path}"
         end
       end
+
+      def prepare_constraints_for_policies
+        policyfile_compiler.included_policies.each do |policy|
+          lock = policyfile_lock.included_policy_locks.find { |policy_lock| policy_lock["name"] == policy.name }
+          policy.apply_locked_source_options(lock["source_options"])
+        end
+      end
+
 
     end
   end

--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -112,8 +112,6 @@ module ChefDK
           policy.apply_locked_source_options(lock["source_options"])
         end
       end
-
-
     end
   end
 end

--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -44,7 +44,13 @@ module ChefDK
 
       def run
         assert_policy_and_lock_present!
-
+        #TODO: There is quite a major bug here in terms of how include_policy works
+        #      include_policy requires the compiler to fetch the lock. The lock it fetches is not
+        #      based on the lock data of the policy being updated. Thus, if the include_policy does
+        #      not use a hard pin (revision_id), this is going to pick up default attributes from there
+        #
+        #      To do this correctly, I think we need to ask the DSL for the attributes
+        #
         if policyfile_compiler.default_attributes != policyfile_lock.default_attributes
           policyfile_lock.default_attributes = policyfile_compiler.default_attributes
           @updated = true

--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -46,13 +46,7 @@ module ChefDK
       def run
         assert_policy_and_lock_present!
         prepare_constraints
-        #TODO: There is quite a major bug here in terms of how include_policy works
-        #      include_policy requires the compiler to fetch the lock. The lock it fetches is not
-        #      based on the lock data of the policy being updated. Thus, if the include_policy does
-        #      not use a hard pin (revision_id), this is going to pick up default attributes from there
-        #
-        #      To do this correctly, I think we need to ask the DSL for the attributes
-        #
+
         if policyfile_compiler.default_attributes != policyfile_lock.default_attributes
           policyfile_lock.default_attributes = policyfile_compiler.default_attributes
           @updated = true

--- a/lib/chef-dk/policyfile_services/update_attributes.rb
+++ b/lib/chef-dk/policyfile_services/update_attributes.rb
@@ -30,14 +30,16 @@ module ChefDK
 
       attr_reader :ui
       attr_reader :storage_config
+      attr_reader :chef_config
 
-      def initialize(policyfile: nil, ui: nil, root_dir: nil)
+      def initialize(policyfile: nil, ui: nil, root_dir: nil, chef_config: nil)
         @ui = ui
 
         policyfile_rel_path = policyfile || "Policyfile.rb"
         policyfile_full_path = File.expand_path(policyfile_rel_path, root_dir)
         @storage_config = Policyfile::StorageConfig.new.use_policyfile(policyfile_full_path)
         @updated = false
+        @chef_config = chef_config
       end
 
       def run
@@ -74,7 +76,7 @@ module ChefDK
       end
 
       def policyfile_compiler
-        @policyfile_compiler ||= ChefDK::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui: ui)
+        @policyfile_compiler ||= ChefDK::PolicyfileCompiler.evaluate(policyfile_content, policyfile_expanded_path, ui: ui, chef_config: chef_config)
       end
 
       def policyfile_lock_content

--- a/spec/unit/command/update_spec.rb
+++ b/spec/unit/command/update_spec.rb
@@ -82,7 +82,7 @@ describe ChefDK::Command::Update do
 
     it "creates an attributes update service object" do
       expect(ChefDK::PolicyfileServices::UpdateAttributes).to receive(:new).
-        with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd).
+        with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, chef_config: anything).
         and_return(update_attrs_service)
       expect(command.attributes_updater).to eq(update_attrs_service)
     end
@@ -133,7 +133,7 @@ describe ChefDK::Command::Update do
       before do
         expect(install_service).to receive(:run)
         expect(ChefDK::PolicyfileServices::UpdateAttributes).to receive(:new).
-          with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd).
+          with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, chef_config: anything).
           and_return(update_attrs_service)
         expect(update_attrs_service).to receive(:run)
       end
@@ -160,7 +160,7 @@ describe ChefDK::Command::Update do
       before do
         expect(install_service).to receive(:run).and_raise(exception)
         expect(ChefDK::PolicyfileServices::UpdateAttributes).to receive(:new).
-          with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd).
+          with(policyfile: nil, ui: command.ui, root_dir: Dir.pwd, chef_config: anything).
           and_return(update_attrs_service)
         expect(update_attrs_service).to receive(:run)
       end

--- a/spec/unit/policyfile/attribute_merge_checker_spec.rb
+++ b/spec/unit/policyfile/attribute_merge_checker_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "chef-dk/policyfile/attribute_merge_checker"
+
+describe ChefDK::Policyfile::AttributeMergeChecker do
+  let(:checker) { ChefDK::Policyfile::AttributeMergeChecker.new }
+
+  describe "when the same attribute is provided multiple times with the same value" do
+    describe "at the top level" do
+      before do
+        checker.with_attributes("foo", {"a" => "b"})
+        checker.with_attributes("bar", {"a" => "b", "c" => "d"})
+      end
+
+      it "does not raise an error" do
+        expect { checker.check!}.not_to raise_error
+      end
+    end
+    
+    describe "deeply nested" do
+      before do
+        checker.with_attributes("foo", {"a" => {"b" => "c"}})
+        checker.with_attributes("bar", {"a" => {"b" => "c"}})
+      end
+
+      it "does not raise an error" do
+        expect { checker.check!}.not_to raise_error
+      end
+    end
+  end
+
+  describe "when conflicts are present" do
+    describe "at the top level" do
+      before do
+        checker.with_attributes("foo", {"a" => "b"})
+        checker.with_attributes("bar", {"a" => "c", "c" => "d"})
+      end
+
+      it "raises an error" do
+        expect { checker.check!}.to raise_error(
+          ChefDK::Policyfile::AttributeMergeChecker::ConflictError) do |e|
+            expect(e.attribute_path).to eq("[a]")
+            expect(e.provided_by).to include("foo", "bar")
+        end
+      end
+    end
+
+    describe "deeply nested" do
+      before do
+        checker.with_attributes("foo", {"a" => {"b" => "c"}})
+        checker.with_attributes("bar", {"a" => {"b" => "d"}})
+      end
+
+      it "raises an error" do
+        expect { checker.check!}.to raise_error(
+          ChefDK::Policyfile::AttributeMergeChecker::ConflictError) do |e|
+            expect(e.attribute_path).to eq("[a][b]")
+            expect(e.provided_by).to include("foo", "bar")
+        end
+      end
+    end
+  end
+
+end

--- a/spec/unit/policyfile/attribute_merge_checker_spec.rb
+++ b/spec/unit/policyfile/attribute_merge_checker_spec.rb
@@ -1,3 +1,20 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "spec_helper"
 require "chef-dk/policyfile/attribute_merge_checker"
 

--- a/spec/unit/policyfile/attribute_merge_checker_spec.rb
+++ b/spec/unit/policyfile/attribute_merge_checker_spec.rb
@@ -7,23 +7,23 @@ describe ChefDK::Policyfile::AttributeMergeChecker do
   describe "when the same attribute is provided multiple times with the same value" do
     describe "at the top level" do
       before do
-        checker.with_attributes("foo", {"a" => "b"})
-        checker.with_attributes("bar", {"a" => "b", "c" => "d"})
+        checker.with_attributes("foo", { "a" => "b" })
+        checker.with_attributes("bar", { "a" => "b", "c" => "d" })
       end
 
       it "does not raise an error" do
-        expect { checker.check!}.not_to raise_error
+        expect { checker.check! }.not_to raise_error
       end
     end
-    
+
     describe "deeply nested" do
       before do
-        checker.with_attributes("foo", {"a" => {"b" => "c"}})
-        checker.with_attributes("bar", {"a" => {"b" => "c"}})
+        checker.with_attributes("foo", { "a" => { "b" => "c" } })
+        checker.with_attributes("bar", { "a" => { "b" => "c" } })
       end
 
       it "does not raise an error" do
-        expect { checker.check!}.not_to raise_error
+        expect { checker.check! }.not_to raise_error
       end
     end
   end
@@ -31,31 +31,31 @@ describe ChefDK::Policyfile::AttributeMergeChecker do
   describe "when conflicts are present" do
     describe "at the top level" do
       before do
-        checker.with_attributes("foo", {"a" => "b"})
-        checker.with_attributes("bar", {"a" => "c", "c" => "d"})
+        checker.with_attributes("foo", { "a" => "b" })
+        checker.with_attributes("bar", { "a" => "c", "c" => "d" })
       end
 
       it "raises an error" do
-        expect { checker.check!}.to raise_error(
+        expect { checker.check! }.to raise_error(
           ChefDK::Policyfile::AttributeMergeChecker::ConflictError) do |e|
             expect(e.attribute_path).to eq("[a]")
             expect(e.provided_by).to include("foo", "bar")
-        end
+          end
       end
     end
 
     describe "deeply nested" do
       before do
-        checker.with_attributes("foo", {"a" => {"b" => "c"}})
-        checker.with_attributes("bar", {"a" => {"b" => "d"}})
+        checker.with_attributes("foo", { "a" => { "b" => "c" } })
+        checker.with_attributes("bar", { "a" => { "b" => "d" } })
       end
 
       it "raises an error" do
-        expect { checker.check!}.to raise_error(
+        expect { checker.check! }.to raise_error(
           ChefDK::Policyfile::AttributeMergeChecker::ConflictError) do |e|
             expect(e.attribute_path).to eq("[a][b]")
             expect(e.provided_by).to include("foo", "bar")
-        end
+          end
       end
     end
   end

--- a/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
@@ -62,19 +62,18 @@ E
 
   let(:minimal_lockfile) { FFI_Yajl::Parser.parse(minimal_lockfile_json) }
 
-
   let(:policy_name) { "chatserver" }
   let(:policy_revision_id) { "somerevisionid" }
   let(:url) { "https://chef.example/organizations/monkeynews" }
-  let(:source_options) { 
+  let(:source_options) do
     {
       server: url,
       policy_name: policy_name,
       policy_revision_id: policy_revision_id,
     }
-  }
+  end
 
-  let(:chef_config) do 
+  let(:chef_config) do
     double("ChefConfig").tap do |double|
       allow(double).to receive(:client_key).and_return("key")
       allow(double).to receive(:node_name).and_return("node_name")

--- a/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
@@ -111,16 +111,16 @@ E
 
     context "and policy_name is not provided" do
       let(:source_options) do
-      {
-        server: url,
-        policy_revision_id: policy_revision_id,
-      }
+        {
+          server: url,
+          policy_revision_id: policy_revision_id,
+        }
       end
 
       it "calls the chef server to get the policy with the dsl name" do
         expect(http_client).to receive(:get).with("policies/#{policy_name}/revisions/#{policy_revision_id}").
           and_return(minimal_lockfile)
-          expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
+        expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
       end
     end
   end

--- a/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
@@ -134,11 +134,28 @@ E
       }
     end
 
+    let(:source_options_for_lock) do
+      source_options.merge({ policy_revision_id: revision_id })
+    end
+
     it "calls the chef server to get the policy" do
       expect(http_client).to receive(:get).with("policy_groups/#{policy_group}/policies/#{policy_name}").
         and_return(minimal_lockfile)
       expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
     end
-  end
 
+    it "includes the revision id in the source_options_for_lock" do
+      allow(http_client).to receive(:get).with(
+        "policy_groups/#{policy_group}/policies/#{policy_name}").and_return(minimal_lockfile)
+
+      expect(fetcher.source_options_for_lock).to eq(source_options_for_lock)
+    end
+
+    it "correctly applies source_options that were included in the lock" do
+      fetcher.apply_locked_source_options(source_options_for_lock)
+      expect(http_client).to receive(:get).with(
+        "policies/#{policy_name}/revisions/#{revision_id}").and_return(minimal_lockfile)
+      fetcher.lock_data
+    end
+  end
 end

--- a/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
@@ -108,6 +108,21 @@ E
         and_return(minimal_lockfile)
       expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
     end
+
+    context "and policy_name is not provided" do
+      let(:source_options) do
+      {
+        server: url,
+        policy_revision_id: policy_revision_id,
+      }
+      end
+
+      it "calls the chef server to get the policy with the dsl name" do
+        expect(http_client).to receive(:get).with("policies/#{policy_name}/revisions/#{policy_revision_id}").
+          and_return(minimal_lockfile)
+          expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
+      end
+    end
   end
 
   context "when using policy group" do

--- a/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/chef_server_lock_fetcher_spec.rb
@@ -1,0 +1,97 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile/chef_server_lock_fetcher"
+
+describe ChefDK::Policyfile::ChefServerLockFetcher do
+
+  let(:minimal_lockfile_json) do
+    <<-E
+{
+  "revision_id": "6fe753184c8946052d3231bb4212116df28d89a3a5f7ae52832ad408419dd5eb",
+  "name": "install-example",
+  "run_list": [
+    "recipe[local-cookbook::default]"
+  ],
+  "cookbook_locks": {
+    "local-cookbook": {
+      "version": "2.3.4",
+      "identifier": "fab501cfaf747901bd82c1bc706beae7dc3a350c",
+      "dotted_decimal_identifier": "70567763561641081.489844270461035.258281553147148",
+      "source": "cookbooks/local-cookbook",
+      "cache_key": null,
+      "scm_info": null,
+      "source_options": {
+        "path": "cookbooks/local-cookbook"
+      }
+    }
+  },
+  "default_attributes": {},
+  "override_attributes": {},
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "local-cookbook",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "local-cookbook (2.3.4)": [
+
+      ]
+    }
+  }
+}
+E
+  end
+
+  let(:minimal_lockfile) { FFI_Yajl::Parser.parse(minimal_lockfile_json) }
+
+
+  let(:policy_name) { "chatserver" }
+  let(:policy_revision_id) { "somerevisionid" }
+  let(:url) { "https://chef.example/organizations/monkeynews" }
+  let(:source_options) { 
+    {
+      server: url,
+      policy_name: policy_name,
+      policy_revision_id: policy_revision_id,
+    }
+  }
+
+  let(:chef_config) do 
+    double("ChefConfig").tap do |double|
+      allow(double).to receive(:client_key).and_return("key")
+      allow(double).to receive(:node_name).and_return("node_name")
+    end
+  end
+  let(:http_client) { instance_double("Chef::ServerAPI", url: url ) }
+
+  subject(:fetcher) { described_class.new(policy_name, source_options, chef_config) }
+
+  before do
+    allow(Chef::ServerAPI).to receive(:new).with(url, anything).and_return(http_client)
+  end
+
+  it "calls the chef server to get the policy" do
+    expect(http_client).to receive(:get).with("policies/#{policy_name}/revisions/#{policy_revision_id}").
+      and_return(minimal_lockfile)
+    expect(fetcher.lock_data).to eq(minimal_lockfile)
+  end
+
+end

--- a/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
@@ -1,0 +1,227 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile/included_policies_cookbook_source"
+require "chef-dk/policyfile/policyfile_location_specification"
+
+describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
+
+
+  let(:external_cookbook_universe) {
+    {
+      "cookbookA" => {
+        "1.0.0" => [ ],
+        "2.0.0" => [ ["cookbookB", "= 1.0.0" ] ],
+      },
+      "cookbookB" => {
+        "1.0.0" => [ ],
+      },
+      "cookbookC" => {
+        "1.0.0" => [ ],
+        "2.0.0" => [ ],
+      },
+    }
+  }
+
+  let(:policy1_cookbooks) {
+    [
+      {
+        name: "cookbookA",
+        version: "2.0.0"
+      },
+      # cookbookB because cookbookA depends on it
+      {
+        name: "cookbookB",
+        version: "1.0.0"
+      }
+    ]
+  }
+
+  let(:randomize_sources) { false }
+  let(:add_random_cookbook) { false }
+
+  def build_lockdata(cookbooks)
+    nonce = Random.rand if randomize_sources else nil
+    cookbook_locks = cookbooks.inject({}) do |acc, cookbook_info|
+      acc[cookbook_info[:name]] = {
+        "version" => cookbook_info[:version],
+        "identifier" => "identifier",
+        "dotted_decimal_identifier" => "dotted_decimal_identifier",
+        "cache_key" => "#{cookbook_info[:name]}-#{cookbook_info[:version]}",
+        "origin" => "uri",
+        "source_options" => {"version" => cookbook_info[:version]}.tap do |so|
+          so["nonce"] = nonce if !nonce.nil?
+        end
+      }
+      acc
+    end
+
+    solution_dependencies_lock = cookbooks.map do |cookbook_info|
+      [cookbook_info[:name], cookbook_info[:version]]
+    end
+
+    solution_dependencies_cookbooks = cookbooks.inject({}) do |acc, cookbook_info|
+      acc["#{cookbook_info[:name]} (#{cookbook_info[:version]})"] = external_cookbook_universe[cookbook_info[:name]][cookbook_info[:version]]
+      acc
+    end
+
+    {
+      "name" => "included_policyfile",
+      "revision_id" => "myrevisionid",
+      "run_list" => ["recipe[myrunlist::default]"],
+      "cookbook_locks" => cookbook_locks,
+      "default_attributes" => {},
+      "override_attributes" => {},
+      "solution_dependencies" => {
+        "Policyfile"=> solution_dependencies_lock,
+        ## We dont use dependencies, no need to fill it out
+        "dependencies" => solution_dependencies_cookbooks
+      }
+    }
+
+  end
+
+  let(:policy1_lockdata) do
+    build_lockdata(policy1_cookbooks)
+  end
+
+  let(:policy2_lockdata) do
+    build_lockdata(policy2_cookbooks)
+  end
+
+  let(:policy1_location_spec) do
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy1", {:local => "somelocation"}, nil).tap do |spec|
+      allow(spec).to receive(:valid?).and_return(true)
+      allow(spec).to receive(:ensure_cached)
+      allow(spec).to receive(:lock_data).and_return(policy1_lockdata)
+    end
+  end
+
+  let(:policy2_location_spec) do
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy2", {:local => "somelocation"}, nil).tap do |spec|
+      allow(spec).to receive(:valid?).and_return(true)
+      allow(spec).to receive(:ensure_cached)
+      allow(spec).to receive(:lock_data).and_return(policy2_lockdata)
+    end
+  end
+
+  let(:policies) { [] }
+
+  let(:cookbook_source) { ChefDK::Policyfile::IncludedPoliciesCookbookSource.new(policies) }
+
+  context "when no policies are included" do
+    it "returns false for preferred_source_for" do
+      expect(cookbook_source.preferred_source_for?("foo")).to eq(false)
+    end
+
+    it "has an empty universe" do
+      expect(cookbook_source.universe_graph).to eq({})
+    end
+  end
+
+  context "when a single policy is to be included" do
+    let(:policies) { [policy1_location_spec] }
+
+    it "does not have a preferred source for unlocked cookbooks" do
+      expect(cookbook_source.preferred_source_for?("cookbookC")).to eq(false)
+    end
+
+    it "has a preferred source for the included cookbooks" do
+      expect(cookbook_source.preferred_source_for?("cookbookA")).to eq(true)
+      expect(cookbook_source.preferred_source_for?("cookbookB")).to eq(true)
+    end
+
+    it "returns nil for the source options versions not included" do
+      expect(cookbook_source.source_options_for("cookbookA", "1.0.0")).to eq(nil)
+    end
+
+    it "returns the correct source options when the cookbook is included" do
+      expect(cookbook_source.source_options_for("cookbookA", "2.0.0")).to eq({:version => "2.0.0"})
+      expect(cookbook_source.source_options_for("cookbookB", "1.0.0")).to eq({:version => "1.0.0"})
+    end
+
+    it "has a universe with the used cookbooks" do
+      expect(cookbook_source.universe_graph).to eq({
+        "cookbookA" => {
+          "2.0.0" => external_cookbook_universe["cookbookA"]["2.0.0"]
+        },
+        "cookbookB" => {
+          "1.0.0" => external_cookbook_universe["cookbookB"]["1.0.0"]
+        },
+      })
+    end
+  end
+
+  context "when multiple policies are to be included" do
+    let(:policies) { [policy1_location_spec, policy2_location_spec] }
+
+    context "when the policies use the same cookbooks with the same versions and sources" do
+      let(:policy2_cookbooks) { policy1_cookbooks + [{name: "cookbookC", version: "2.0.0"}] }
+
+      it "has a preferred source for the included cookbooks" do
+        expect(cookbook_source.preferred_source_for?("cookbookA")).to eq(true)
+        expect(cookbook_source.preferred_source_for?("cookbookB")).to eq(true)
+        expect(cookbook_source.preferred_source_for?("cookbookC")).to eq(true)
+      end
+
+      it "returns the correct source options when the cookbook is included" do
+        expect(cookbook_source.source_options_for("cookbookA", "2.0.0")).to eq({:version => "2.0.0"})
+        expect(cookbook_source.source_options_for("cookbookB", "1.0.0")).to eq({:version => "1.0.0"})
+      end
+
+      it "has a universe with the used cookbooks" do
+        expect(cookbook_source.universe_graph).to eq({
+          "cookbookA" => {
+            "2.0.0" => external_cookbook_universe["cookbookA"]["2.0.0"]
+          },
+          "cookbookB" => {
+            "1.0.0" => external_cookbook_universe["cookbookB"]["1.0.0"]
+          },
+          "cookbookC" => {
+            "2.0.0" => external_cookbook_universe["cookbookC"]["2.0.0"]
+          }
+        })
+      end
+
+    end
+
+    context "when the policies have the same versions with conflicting sources" do
+      let(:randomize_sources) { true }
+      let(:policy2_cookbooks) { policy1_cookbooks }
+
+      it "raises an error when check_for_conflicts! is called" do
+        expect{cookbook_source.check_for_conflicts!}.to raise_error(
+          ChefDK::Policyfile::IncludedPoliciesCookbookSource::ConflictingCookbookSources)
+      end
+    end
+
+    context "when the policies have conflicting versions" do
+      let(:policy2_cookbooks) { [{name: "cookbookA", version: "1.0.0"}] }
+
+      it "raises an error when check_for_conflicts! is called" do
+        expect{cookbook_source.check_for_conflicts!}.to raise_error(
+          ChefDK::Policyfile::IncludedPoliciesCookbookSource::ConflictingCookbookVersions)
+      end
+    end
+
+    context "when the policies have conflicting dependencies" do
+      it "raises an error when check_for_conflicts! is called"
+    end
+  end
+
+end

--- a/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
@@ -21,8 +21,7 @@ require "chef-dk/policyfile/policyfile_location_specification"
 
 describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
 
-
-  let(:external_cookbook_universe) {
+  let(:external_cookbook_universe) do
     {
       "cookbookA" => {
         "1.0.0" => [ ],
@@ -36,27 +35,32 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
         "2.0.0" => [ ],
       },
     }
-  }
+  end
 
-  let(:policy1_cookbooks) {
+  let(:policy1_cookbooks) do
     [
       {
         name: "cookbookA",
-        version: "2.0.0"
+        version: "2.0.0",
       },
       # cookbookB because cookbookA depends on it
       {
         name: "cookbookB",
-        version: "1.0.0"
-      }
+        version: "1.0.0",
+      },
     ]
-  }
+  end
 
   let(:randomize_sources) { false }
   let(:add_random_cookbook) { false }
 
   def build_lockdata(cookbooks)
-    nonce = Random.rand if randomize_sources else nil
+    nonce = if randomize_sources
+              Random.rand
+            else
+              nil
+            end
+
     cookbook_locks = cookbooks.inject({}) do |acc, cookbook_info|
       acc[cookbook_info[:name]] = {
         "version" => cookbook_info[:version],
@@ -64,9 +68,9 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
         "dotted_decimal_identifier" => "dotted_decimal_identifier",
         "cache_key" => "#{cookbook_info[:name]}-#{cookbook_info[:version]}",
         "origin" => "uri",
-        "source_options" => {"version" => cookbook_info[:version]}.tap do |so|
+        "source_options" => { "version" => cookbook_info[:version] }.tap do |so|
           so["nonce"] = nonce if !nonce.nil?
-        end
+        end,
       }
       acc
     end
@@ -88,12 +92,11 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
       "default_attributes" => {},
       "override_attributes" => {},
       "solution_dependencies" => {
-        "Policyfile"=> solution_dependencies_lock,
+        "Policyfile" => solution_dependencies_lock,
         ## We dont use dependencies, no need to fill it out
-        "dependencies" => solution_dependencies_cookbooks
-      }
+        "dependencies" => solution_dependencies_cookbooks,
+      },
     }
-
   end
 
   let(:policy1_lockdata) do
@@ -104,19 +107,33 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
     build_lockdata(policy2_cookbooks)
   end
 
+  let(:policy1_fetcher) do
+    instance_double("ChefDK::Policyfile::LocalLockFetcher").tap do |double|
+      allow(double).to receive(:lock_data).and_return(policy1_lockdata)
+      allow(double).to receive(:valid?).and_return(true)
+      allow(double).to receive(:errors).and_return([])
+    end
+  end
+
+  let(:policy2_fetcher) do
+    instance_double("ChefDK::Policyfile::LocalLockFetcher").tap do |double|
+      allow(double).to receive(:lock_data).and_return(policy2_lockdata)
+      allow(double).to receive(:valid?).and_return(true)
+      allow(double).to receive(:errors).and_return([])
+    end
+  end
+
   let(:policy1_location_spec) do
-    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy1", {:local => "somelocation"}, nil).tap do |spec|
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy1", { :local => "somelocation" }, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
-      allow(spec).to receive(:ensure_cached)
-      allow(spec).to receive(:lock_data).and_return(policy1_lockdata)
+      allow(spec).to receive(:fetcher).and_return(policy1_fetcher)
     end
   end
 
   let(:policy2_location_spec) do
-    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy2", {:local => "somelocation"}, nil).tap do |spec|
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy2", { :local => "somelocation" }, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
-      allow(spec).to receive(:ensure_cached)
-      allow(spec).to receive(:lock_data).and_return(policy2_lockdata)
+      allow(spec).to receive(:fetcher).and_return(policy2_fetcher)
     end
   end
 
@@ -151,17 +168,17 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
     end
 
     it "returns the correct source options when the cookbook is included" do
-      expect(cookbook_source.source_options_for("cookbookA", "2.0.0")).to eq({:version => "2.0.0"})
-      expect(cookbook_source.source_options_for("cookbookB", "1.0.0")).to eq({:version => "1.0.0"})
+      expect(cookbook_source.source_options_for("cookbookA", "2.0.0")).to eq({ :version => "2.0.0" })
+      expect(cookbook_source.source_options_for("cookbookB", "1.0.0")).to eq({ :version => "1.0.0" })
     end
 
     it "has a universe with the used cookbooks" do
       expect(cookbook_source.universe_graph).to eq({
         "cookbookA" => {
-          "2.0.0" => external_cookbook_universe["cookbookA"]["2.0.0"]
+          "2.0.0" => external_cookbook_universe["cookbookA"]["2.0.0"],
         },
         "cookbookB" => {
-          "1.0.0" => external_cookbook_universe["cookbookB"]["1.0.0"]
+          "1.0.0" => external_cookbook_universe["cookbookB"]["1.0.0"],
         },
       })
     end
@@ -171,7 +188,7 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
     let(:policies) { [policy1_location_spec, policy2_location_spec] }
 
     context "when the policies use the same cookbooks with the same versions and sources" do
-      let(:policy2_cookbooks) { policy1_cookbooks + [{name: "cookbookC", version: "2.0.0"}] }
+      let(:policy2_cookbooks) { policy1_cookbooks + [{ name: "cookbookC", version: "2.0.0" }] }
 
       it "has a preferred source for the included cookbooks" do
         expect(cookbook_source.preferred_source_for?("cookbookA")).to eq(true)
@@ -180,24 +197,23 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
       end
 
       it "returns the correct source options when the cookbook is included" do
-        expect(cookbook_source.source_options_for("cookbookA", "2.0.0")).to eq({:version => "2.0.0"})
-        expect(cookbook_source.source_options_for("cookbookB", "1.0.0")).to eq({:version => "1.0.0"})
+        expect(cookbook_source.source_options_for("cookbookA", "2.0.0")).to eq({ :version => "2.0.0" })
+        expect(cookbook_source.source_options_for("cookbookB", "1.0.0")).to eq({ :version => "1.0.0" })
       end
 
       it "has a universe with the used cookbooks" do
         expect(cookbook_source.universe_graph).to eq({
           "cookbookA" => {
-            "2.0.0" => external_cookbook_universe["cookbookA"]["2.0.0"]
+            "2.0.0" => external_cookbook_universe["cookbookA"]["2.0.0"],
           },
           "cookbookB" => {
-            "1.0.0" => external_cookbook_universe["cookbookB"]["1.0.0"]
+            "1.0.0" => external_cookbook_universe["cookbookB"]["1.0.0"],
           },
           "cookbookC" => {
-            "2.0.0" => external_cookbook_universe["cookbookC"]["2.0.0"]
-          }
+            "2.0.0" => external_cookbook_universe["cookbookC"]["2.0.0"],
+          },
         })
       end
-
     end
 
     context "when the policies have the same versions with conflicting sources" do
@@ -205,16 +221,16 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
       let(:policy2_cookbooks) { policy1_cookbooks }
 
       it "raises an error when check_for_conflicts! is called" do
-        expect{cookbook_source.check_for_conflicts!}.to raise_error(
+        expect { cookbook_source.check_for_conflicts! }.to raise_error(
           ChefDK::Policyfile::IncludedPoliciesCookbookSource::ConflictingCookbookSources)
       end
     end
 
     context "when the policies have conflicting versions" do
-      let(:policy2_cookbooks) { [{name: "cookbookA", version: "1.0.0"}] }
+      let(:policy2_cookbooks) { [{ name: "cookbookA", version: "1.0.0" }] }
 
       it "raises an error when check_for_conflicts! is called" do
-        expect{cookbook_source.check_for_conflicts!}.to raise_error(
+        expect { cookbook_source.check_for_conflicts! }.to raise_error(
           ChefDK::Policyfile::IncludedPoliciesCookbookSource::ConflictingCookbookVersions)
       end
     end
@@ -223,5 +239,4 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
       it "raises an error when check_for_conflicts! is called"
     end
   end
-
 end

--- a/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
@@ -124,14 +124,14 @@ describe ChefDK::Policyfile::IncludedPoliciesCookbookSource do
   end
 
   let(:policy1_location_spec) do
-    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy1", { :local => "somelocation" }, nil).tap do |spec|
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy1", { :path => "somelocation" }, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
       allow(spec).to receive(:fetcher).and_return(policy1_fetcher)
     end
   end
 
   let(:policy2_location_spec) do
-    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy2", { :local => "somelocation" }, nil).tap do |spec|
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new("policy2", { :path => "somelocation" }, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
       allow(spec).to receive(:fetcher).and_return(policy2_fetcher)
     end

--- a/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
+++ b/spec/unit/policyfile/included_policies_cookbook_source_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/unit/policyfile/local_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/local_lock_fetcher_spec.rb
@@ -64,26 +64,24 @@ E
 
   before do
     reset_tempdir
-    File.open(lock_file_path, 'w') { |file| file.write(minimal_lockfile_json) }
+    File.open(lock_file_path, "w") { |file| file.write(minimal_lockfile_json) }
   end
 
   after do
     reset_tempdir
   end
 
-
   let(:minimal_lockfile) { FFI_Yajl::Parser.parse(minimal_lockfile_json) }
 
-  let(:source_options) { 
+  let(:source_options) do
     {
-      local: lock_file_path, 
+      local: lock_file_path,
     }
-  }
+  end
 
   subject(:fetcher) { described_class.new("foo", source_options) }
 
   it "loads the policy from disk" do
     expect(fetcher.lock_data).to eq(minimal_lockfile)
   end
-
 end

--- a/spec/unit/policyfile/local_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/local_lock_fetcher_spec.rb
@@ -89,9 +89,20 @@ E
     }
   end
 
+  let(:source_options_for_lock) { source_options }
+
   subject(:fetcher) { described_class.new("foo", source_options, storage_config) }
 
   it "loads the policy from disk" do
+    expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
+  end
+
+  it "returns source_options_for_lock" do
+    expect(fetcher.source_options).to eq(source_options)
+  end
+
+  it "applies can apply source options from the lock" do
+    fetcher.apply_locked_source_options(source_options_for_lock)
     expect(fetcher.lock_data).to eq(minimal_lockfile_modified)
   end
 end

--- a/spec/unit/policyfile/local_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/local_lock_fetcher_spec.rb
@@ -1,0 +1,89 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile/local_lock_fetcher"
+
+describe ChefDK::Policyfile::LocalLockFetcher do
+
+  let(:minimal_lockfile_json) do
+    <<-E
+{
+  "revision_id": "6fe753184c8946052d3231bb4212116df28d89a3a5f7ae52832ad408419dd5eb",
+  "name": "install-example",
+  "run_list": [
+    "recipe[local-cookbook::default]"
+  ],
+  "cookbook_locks": {
+    "local-cookbook": {
+      "version": "2.3.4",
+      "identifier": "fab501cfaf747901bd82c1bc706beae7dc3a350c",
+      "dotted_decimal_identifier": "70567763561641081.489844270461035.258281553147148",
+      "source": "cookbooks/local-cookbook",
+      "cache_key": null,
+      "scm_info": null,
+      "source_options": {
+        "path": "cookbooks/local-cookbook"
+      }
+    }
+  },
+  "default_attributes": {},
+  "override_attributes": {},
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "local-cookbook",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "local-cookbook (2.3.4)": [
+
+      ]
+    }
+  }
+}
+E
+  end
+
+  let(:lock_file_path) { "#{tempdir}/foo.lock.json" }
+
+  before do
+    reset_tempdir
+    File.open(lock_file_path, 'w') { |file| file.write(minimal_lockfile_json) }
+  end
+
+  after do
+    reset_tempdir
+  end
+
+
+  let(:minimal_lockfile) { FFI_Yajl::Parser.parse(minimal_lockfile_json) }
+
+  let(:source_options) { 
+    {
+      local: lock_file_path, 
+    }
+  }
+
+  subject(:fetcher) { described_class.new("foo", source_options) }
+
+  it "loads the policy from disk" do
+    expect(fetcher.lock_data).to eq(minimal_lockfile)
+  end
+
+end

--- a/spec/unit/policyfile/local_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/local_lock_fetcher_spec.rb
@@ -73,7 +73,7 @@ E
     reset_tempdir
   end
 
-  def minimal_lockfile 
+  def minimal_lockfile
     FFI_Yajl::Parser.parse(minimal_lockfile_json)
   end
 

--- a/spec/unit/policyfile/local_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/local_lock_fetcher_spec.rb
@@ -85,7 +85,7 @@ E
 
   let(:source_options) do
     {
-      local: lock_file_path,
+      path: lock_file_path,
     }
   end
 

--- a/spec/unit/policyfile/lock_applier_spec.rb
+++ b/spec/unit/policyfile/lock_applier_spec.rb
@@ -1,0 +1,100 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile/lock_applier"
+require "chef-dk/policyfile_compiler"
+require "chef-dk/policyfile_lock"
+
+describe ChefDK::Policyfile::LockApplier do
+  let(:lock) { instance_double("ChefDK::Policyfile::PolicyfileLock") }
+  let(:compiler) { instance_double("ChefDK::Policyfile::PolicyfileCompiler") }
+  let(:lock_applier) { ChefDK::Policyfile::LockApplier.new(lock, compiler) }
+
+  let(:included_policy_1) do
+    instance_double("ChefDK::Policyfile::PolicyfileLocationSpec",
+                    name: "policy1")
+  end
+
+  let(:included_policy_2) do
+    instance_double("ChefDK::Policyfile::PolicyfileLocationSpec",
+                    name: "policy2")
+  end
+
+  let(:included_policy_lock_1) do
+    {
+      "name" => "policy1",
+      "source_options" => {
+        "some_name" => "policy1_name",
+      },
+    }
+  end
+
+  let(:included_policy_lock_2) do
+    {
+      "name" => "policy2",
+      "source_options" => {
+        "some_name" => "policy2_name",
+      },
+    }
+  end
+
+  let(:lock_location_specs) { [] }
+  let(:included_policy_locks) { [] }
+
+  before do
+    allow(compiler).to receive(:included_policies).and_return(lock_location_specs)
+    allow(lock).to receive(:included_policy_locks).and_return(included_policy_locks)
+  end
+
+  context "when no included policies are unlocked" do
+    let(:lock_location_specs) { [included_policy_1, included_policy_2] }
+    let(:included_policy_locks) { [included_policy_lock_1, included_policy_lock_2] }
+
+    it "provides the locked source options for all policies" do
+      expect(included_policy_1).to receive(:apply_locked_source_options).with(included_policy_lock_1["source_options"])
+      expect(included_policy_2).to receive(:apply_locked_source_options).with(included_policy_lock_2["source_options"])
+      lock_applier.apply!
+    end
+  end
+
+  context "when a included policy is unlocked" do
+    let(:lock_location_specs) { [included_policy_1, included_policy_2] }
+    let(:included_policy_locks) { [included_policy_lock_1, included_policy_lock_2] }
+
+    it "does not provide the locked source options for that policy" do
+      expect(included_policy_1).not_to receive(:apply_locked_source_options)
+      expect(included_policy_2).to receive(:apply_locked_source_options).with(included_policy_lock_2["source_options"])
+      lock_applier.
+        with_unlocked_policies(["policy1"]).
+        apply!
+    end
+  end
+
+  context "when all included policies are unlocked" do
+    let(:lock_location_specs) { [included_policy_1, included_policy_2] }
+    let(:included_policy_locks) { [included_policy_lock_1, included_policy_lock_2] }
+
+    it "does not provide locked source options for any policies" do
+      expect(included_policy_1).not_to receive(:apply_locked_source_options)
+      expect(included_policy_2).not_to receive(:apply_locked_source_options).with(included_policy_lock_2["source_options"])
+      lock_applier.
+        with_unlocked_policies(:all).
+        apply!
+    end
+  end
+end

--- a/spec/unit/policyfile_demands_spec.rb
+++ b/spec/unit/policyfile_demands_spec.rb
@@ -215,7 +215,7 @@ describe ChefDK::PolicyfileCompiler, "when expressing the Policyfile graph deman
     end
 
     before do
-      policyfile.default_source.replace([ default_source_obj ])
+      allow(policyfile).to receive(:default_source).and_return([default_source_obj])
 
       allow(default_source_obj).to receive(:universe_graph).
         and_return(trimmed_cookbook_universe)

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -70,7 +70,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
           expect(policyfile.included_policies.length).to eq(1)
         end
 
-        it "uses a local fetcher" do
+        it "uses a server fetcher" do
           expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::ChefServerLockFetcher)
         end
 
@@ -94,7 +94,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
         expect(policyfile.included_policies.length).to eq(1)
       end
 
-      it "uses a local fetcher" do
+      it "uses a server fetcher" do
         expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::ChefServerLockFetcher)
       end
 

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -54,9 +54,8 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
     describe "and the policy name is missing" do
       let(:included_policies) { [["foo", { server: "http://example.com", policy_revision_id: "bar" }]] }
-      it "has a dsl with errors" do
-        expect(policyfile.dsl.errors.length).to eq(1)
-        expect(policyfile.dsl.errors[0]).to match(/missing key policy_name/)
+      it "has no errors" do
+        expect(policyfile.dsl.errors.length).to eq(0)
       end
     end
 

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -119,6 +119,10 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
       expect(policyfile.dsl.errors.length).to eq(1)
       expect(policyfile.dsl.errors[0]).to match(/include_policy must use one of the following/)
     end
+
+    it "errors when trying to get the fetcher" do
+      expect { policyfile.included_policies[0].fetcher }.to raise_error(ChefDK::InvalidPolicyfileLocation)
+    end
   end
 
   describe "when a policy with the same name is specified multiple times" do

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -21,7 +21,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
   describe "when include_policy specifies a policy on disk" do
     describe "and the included policy is correctly configured" do
-      let(:included_policies) { [["foo", { local: "./foo.lock.json" }]] }
+      let(:included_policies) { [["foo", { path: "./foo.lock.json" }]] }
 
       it "has a included policy" do
         expect(policyfile.included_policies.length).to eq(1)
@@ -124,8 +124,8 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
   describe "when a policy with the same name is specified multiple times" do
     let(:included_policies) do
       [
-        ["foo", { local: "./foo.lock.json" }],
-        ["foo", { local: "./foo.lock.json" }],
+        ["foo", { path: "./foo.lock.json" }],
+        ["foo", { path: "./foo.lock.json" }],
       ]
     end
 

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -1,3 +1,20 @@
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "spec_helper"
 require "chef-dk/policyfile_compiler"
 require "chef-dk/exceptions"

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -21,7 +21,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
   describe "when include_policy specifies a policy on disk" do
     describe "and the included policy is correctly configured" do
-      let(:included_policies) { [["foo", {local: "./foo.lock.json"}]] }
+      let(:included_policies) { [["foo", { local: "./foo.lock.json" }]] }
 
       it "has a included policy" do
         expect(policyfile.included_policies.length).to eq(1)
@@ -43,7 +43,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
   end
 
   describe "when include_policy specifies a policy on a chef server" do
-    let(:included_policies) { [["foo", {server: "http://example.com", policy_name: "foo"}]] }
+    let(:included_policies) { [["foo", { server: "http://example.com", policy_name: "foo" }]] }
     describe "and policy_revision_id is missing" do
       it "has a dsl with errors" do
         expect(policyfile.dsl.errors.length).to eq(1)
@@ -52,7 +52,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
     describe "and the policy name is missing" do
-      let(:included_policies) { [["foo", {server: "http://example.com", policy_revision_id: "bar"}]] }
+      let(:included_policies) { [["foo", { server: "http://example.com", policy_revision_id: "bar" }]] }
       it "has a dsl with errors" do
         expect(policyfile.dsl.errors.length).to eq(1)
         expect(policyfile.dsl.errors[0]).to match(/missing key policy_name/)
@@ -60,7 +60,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
     describe "and everything is correctly configured" do
-      let(:included_policies) { [["foo", {server: "http://example.com", policy_name: "foo", policy_revision_id: "bar"}]] }
+      let(:included_policies) { [["foo", { server: "http://example.com", policy_name: "foo", policy_revision_id: "bar" }]] }
       it "has a dsl with no errors" do
         expect(policyfile.dsl.errors.length).to eq(0)
       end
@@ -84,7 +84,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
   end
 
   describe "when include_policy specifies a policy fetched with an unknown method" do
-    let(:included_policies) { [["foo", {foofetch: "bar"}]] }
+    let(:included_policies) { [["foo", { foofetch: "bar" }]] }
 
     it "has a included policy" do
       expect(policyfile.included_policies.length).to eq(1)
@@ -97,12 +97,13 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
   end
 
   describe "when a policy with the same name is specified multiple times" do
-    let(:included_policies) { 
+    let(:included_policies) do
       [
-        ["foo", {local: "./foo.lock.json"}],
-        ["foo", {local: "./foo.lock.json"}],
-      ] 
-    }
+        ["foo", { local: "./foo.lock.json" }],
+        ["foo", { local: "./foo.lock.json" }],
+      ]
+    end
+
     it "has a dsl with errors" do
       expect(policyfile.dsl.errors.length).to eq(1)
       expect(policyfile.dsl.errors[0]).to match(/assigned conflicting locations/)

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+require "chef-dk/policyfile_compiler"
+require "chef-dk/exceptions"
+
+describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
+
+  let(:run_list) { ["local::default"] }
+  let(:included_policies) { [] }
+
+  let(:policyfile) do
+    policyfile = ChefDK::PolicyfileCompiler.new.build do |p|
+
+      p.run_list(*run_list)
+      included_policies.each do |policy|
+        p.include_policy(policy[0], policy[1])
+      end
+    end
+
+    policyfile
+  end
+
+  describe "when include_policy specifies a policy on disk" do
+    describe "and the included policy is correctly configured" do
+      let(:included_policies) { [["foo", {local: "./foo.lock.json"}]] }
+
+      it "has a included policy" do
+        expect(policyfile.included_policies.length).to eq(1)
+      end
+
+      it "uses a local fetcher" do
+        expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::LocalLockFetcher)
+      end
+
+      it "has a fetcher with no errors" do
+        expect(policyfile.included_policies[0].fetcher.errors).to eq([])
+      end
+
+      it "has a fetcher that is valid" do
+        expect(policyfile.included_policies[0].fetcher.valid?).to eq(true)
+      end
+    end
+
+  end
+
+  describe "when include_policy specifies a policy on a chef server" do
+    let(:included_policies) { [["foo", {server: "http://example.com", policy_name: "foo"}]] }
+    describe "and policy_revision_id is missing" do
+      it "has a dsl with errors" do
+        expect(policyfile.dsl.errors.length).to eq(1)
+        expect(policyfile.dsl.errors[0]).to match(/missing key policy_revision_id/)
+      end
+    end
+
+    describe "and the policy name is missing" do
+      let(:included_policies) { [["foo", {server: "http://example.com", policy_revision_id: "bar"}]] }
+      it "has a dsl with errors" do
+        expect(policyfile.dsl.errors.length).to eq(1)
+        expect(policyfile.dsl.errors[0]).to match(/missing key policy_name/)
+      end
+    end
+
+    describe "and everything is correctly configured" do
+      let(:included_policies) { [["foo", {server: "http://example.com", policy_name: "foo", policy_revision_id: "bar"}]] }
+      it "has a dsl with no errors" do
+        expect(policyfile.dsl.errors.length).to eq(0)
+      end
+
+      it "has a included policy" do
+        expect(policyfile.included_policies.length).to eq(1)
+      end
+
+      it "uses a local fetcher" do
+        expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::ChefServerLockFetcher)
+      end
+
+      it "has a fetcher with no errors" do
+        expect(policyfile.included_policies[0].fetcher.errors).to eq([])
+      end
+
+      it "has a fetcher that is valid" do
+        expect(policyfile.included_policies[0].fetcher.valid?).to eq(true)
+      end
+    end
+  end
+
+  describe "when include_policy specifies a policy fetched with an unknown method" do
+    let(:included_policies) { [["foo", {foofetch: "bar"}]] }
+
+    it "has a included policy" do
+      expect(policyfile.included_policies.length).to eq(1)
+    end
+
+    it "has a dsl with an errors" do
+      expect(policyfile.dsl.errors.length).to eq(1)
+      expect(policyfile.dsl.errors[0]).to match(/include_policy must use one of the following/)
+    end
+  end
+
+  describe "when a policy with the same name is specified multiple times" do
+    let(:included_policies) { 
+      [
+        ["foo", {local: "./foo.lock.json"}],
+        ["foo", {local: "./foo.lock.json"}],
+      ] 
+    }
+    it "has a dsl with errors" do
+      expect(policyfile.dsl.errors.length).to eq(1)
+      expect(policyfile.dsl.errors[0]).to match(/assigned conflicting locations/)
+    end
+  end
+
+end

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -1,0 +1,161 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright:: Copyright (c) 2014 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile_compiler"
+
+describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
+
+  context "when no policies are included" do
+
+    # TODO: an empty array here is probably fine?
+    it "does not emit included policies information in the lockfile"
+
+  end
+
+  context "when one policy is included" do
+
+    it "emits a lockfile describing the source of the included policy"
+
+    # currently you must have a run list in a policyfile, but it should now
+    # become possible to make a combo-policy just by combining other policies
+    context "when the including policy does not have a run list" do
+
+      it "emits a lockfile with an identical run list as the included policy"
+
+    end
+
+    context "when the including policy has a run list" do
+
+      it "appends run list items from the including policy to the included policy's run list, removing duplicates"
+
+    end
+
+    context "when the policies have named run lists" do
+
+      context "and no named run lists are shared between the including and included policy" do
+
+        it "preserves the named run lists as given in both policies"
+
+      end
+
+      context "and some named run lists are shared between the including and included policy" do
+
+        it "appends run lists items from the including policy's run lists to the included policy's run lists, removing duplicates"
+
+      end
+
+    end
+
+    context "when no cookbooks are shared as dependencies or transitive dependencies" do
+
+      it "does not raise a have conflicting dependency requirements error"
+
+      it "emits a lockfile where cookbooks pulled from the upstream are at identical versions"
+
+      it "solves the dependencies added by the top-level policyfile and emits them in the lockfile"
+
+    end
+
+    context "when some cookbooks are shared as dependencies or transitive dependencies" do
+
+      context "and the including policy's dependencies can be solved with the included policy's locks" do
+
+        it "solves the dependencies added by the top-level policyfile and emits them in the lockfile"
+
+      end
+
+      context "and the including policy's dependencies cannot be solved with the included policy's locks" do
+
+        it "raises an error describing the conflict"
+
+        it "includes the name and location of the included policy in the error message"
+
+        it "includes the source of the conflicting dependency constraint from the including policy"
+
+      end
+
+    end
+
+    context "when the included policy does not have attributes that conflict with the including policy" do
+
+      it "emits a lockfile with the attributes from both merged"
+
+    end
+
+    context "when the included policy has attributes that conflict with the including policy's attributes" do
+
+      it "raises an error describing all attribute conflicts"
+
+      it "includes the name and location of the included policy in the error message"
+
+      it "includes the source location of the conflicting attribute in the including policy"
+
+    end
+
+  end
+
+  context "when several policies are included" do
+
+    context "when no cookbooks are shared as dependencies or transitive dependencies by included policies" do
+
+      it "does not raise a have conflicting dependency requirements error"
+
+      it "emits a lockfile where cookbooks pulled from the upstreams are at identical versions"
+
+      it "solves the dependencies added by the top-level policyfile"
+
+    end
+
+    context "when some cookbooks appear as dependencies or transitive dependencies of some included policies" do
+
+      context "and the locked versions of the cookbooks match" do
+
+        it "solves the dependencies with the matching versions"
+
+      end
+
+      context "and the locked versions of the cookbooks do not match" do
+
+        it "raises an error describing the conflict"
+
+        it "includes the name and location of the conflicting included policies in the error message"
+
+      end
+
+    end
+
+    context "when the included policies do not have conflicting attributes" do
+
+      it "emits a lockfile with the included policies' attributes merged"
+
+    end
+
+    context "when the included policies have conflicting attributes" do
+
+      it "raises an error describing the conflict"
+
+      it "includes the name an location of the conflicting included policies in the error message"
+
+    end
+
+  end
+
+end
+
+

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -125,10 +125,12 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
   end
 
+  let(:lock_source_options) { { :local => "somelocation" } }
   let(:included_policy_lock_spec) do
-    ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, { :local => "somelocation" }, nil).tap do |spec|
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, lock_source_options, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
       allow(spec).to receive(:fetcher).and_return(included_policy_fetcher)
+      allow(spec).to receive(:source_options_for_lock).and_return(lock_source_options)
     end
   end
 

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -42,7 +42,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
   let(:default_source) { nil }
 
-  let(:external_cookbook_universe) {
+  let(:external_cookbook_universe) do
     {
       "cookbookA" => {
         "1.0.0" => [ ],
@@ -61,22 +61,22 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
       },
       "local_easy" => {
         "1.0.0" => [ ["cookbookC", "= 2.0.0" ] ],
-      }
+      },
     }
-  }
-  
+  end
+
   let(:included_policy_default_attributes) { {} }
   let(:included_policy_override_attributes) { {} }
   let(:included_policy_expanded_named_runlist) { nil }
   let(:included_policy_expanded_runlist) { ["recipe[cookbookA::default]"] }
-  let(:included_policy_cookbooks) {
+  let(:included_policy_cookbooks) do
     [
       {
         name: "cookbookA",
-        version: "2.0.0"
-      }
+        version: "2.0.0",
+      },
     ]
-  }
+  end
 
   let(:included_policy_lock_data) do
     cookbook_locks = included_policy_cookbooks.inject({}) do |acc, cookbook_info|
@@ -86,7 +86,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
         "dotted_decimal_identifier" => "dotted_decimal_identifier",
         "cache_key" => "#{cookbook_info[:name]}-#{cookbook_info[:version]}",
         "origin" => "uri",
-        "source_options" => {}
+        "source_options" => {},
       }
       acc
     end
@@ -108,11 +108,11 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
       "default_attributes" => included_policy_default_attributes,
       "override_attributes" => included_policy_override_attributes,
       "solution_dependencies" => {
-        "Policyfile"=> solution_dependencies_lock,
-        "dependencies" => solution_dependencies_cookbooks
-      }
+        "Policyfile" => solution_dependencies_lock,
+        "dependencies" => solution_dependencies_cookbooks,
+      },
     }.tap do |core|
-      core["named_run_lists"] = included_policy_expanded_named_runlist if included_policy_expanded_named_runlist 
+      core["named_run_lists"] = included_policy_expanded_named_runlist if included_policy_expanded_named_runlist
     end
   end
 
@@ -121,12 +121,12 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     instance_double("ChefDK::Policyfile::LocalLockFetcher").tap do |double|
       allow(double).to receive(:lock_data).and_return(included_policy_lock_data)
       allow(double).to receive(:valid?).and_return(true)
-      allow(double).to receive(:errors?).and_return([])
+      allow(double).to receive(:errors).and_return([])
     end
   end
 
   let(:included_policy_lock_spec) do
-    ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, {:local => "somelocation"}, nil).tap do |spec|
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, { :local => "somelocation" }, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
       allow(spec).to receive(:fetcher).and_return(included_policy_fetcher)
     end
@@ -203,7 +203,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
       let(:included_policy_expanded_named_runlist) do
         {
-          "shared" => ["recipe[cookbookA::included]"]
+          "shared" => ["recipe[cookbookA::included]"],
         }
       end
 
@@ -211,7 +211,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
         let(:named_run_list) do
           {
-            "local" => ["local::foo"]
+            "local" => ["local::foo"],
           }
         end
 
@@ -225,7 +225,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
         let(:named_run_list) do
           {
-            "shared" => ["local::foo"]
+            "shared" => ["local::foo"],
           }
         end
 
@@ -249,14 +249,14 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
     context "when some cookbooks are shared as dependencies or transitive dependencies" do
       let(:included_policy_expanded_runlist) { ["recipe[cookbookC::default]"] }
-      let(:included_policy_cookbooks) {
+      let(:included_policy_cookbooks) do
         [
           {
             name: "cookbookC",
-            version: "2.0.0"
-          }
+            version: "2.0.0",
+          },
         ]
-      }
+      end
 
       context "and the including policy does not specify any sources" do
         let(:run_list) { [] }
@@ -279,7 +279,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
         end
 
         it "it defaults to those provided in the included policy lock" do
-          expect{policyfile_lock.to_lock}.not_to raise_error
+          expect { policyfile_lock.to_lock }.not_to raise_error
         end
       end
 
@@ -289,14 +289,14 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
         before do
           allow(default_source).to receive(:preferred_cookbooks).and_return(["cookbookC"])
-          allow(default_source).to receive(:source_options_for).with("cookbookC", "2.0.0").and_return({"foo"=>"bar"})
+          allow(default_source).to receive(:source_options_for).with("cookbookC", "2.0.0").and_return({ "foo" => "bar" })
           allow(default_source).to receive(:null?).and_return(false)
           allow(default_source).to receive(:universe_graph).and_return(external_cookbook_universe)
           allow(default_source).to receive(:desc).and_return("source double")
         end
 
         it "it raises an error" do
-          expect{policyfile_lock.to_lock}.to raise_error(ChefDK::IncludePolicyCookbookSourceConflict)
+          expect { policyfile_lock.to_lock }.to raise_error(ChefDK::IncludePolicyCookbookSourceConflict)
         end
       end
 
@@ -314,19 +314,19 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
         let(:run_list) { ["local::default"] }
 
         it "raises an error describing the conflict" do
-          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError)
+          expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError)
         end
 
         it "includes the name and location of the included policy in the error message" do
           pending("Not implemented")
-          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError) do |e|
+          expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError) do |e|
             expect(e.to_s).to match(/#{included_policy_lock_name}/)
           end
 
         end
 
         it "includes the source of the conflicting dependency constraint from the including policy" do
-          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError) do |e|
+          expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError) do |e|
             expect(e.to_s).to match(/`cookbookC \(= 2.0.0\)`/) # This one comes from the included policy
             expect(e.to_s).to match(/`cookbookC \(= 1.0.0\)` required by `local-1.0.0`/) # This one comes from the included policy
           end
@@ -334,7 +334,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
         it "should not have an open constraint on cookbookC" do
           pending("I think this is a bug")
-          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError) do |e|
+          expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError) do |e|
             expect(e.to_s).not_to match(/`cookbookC \(>= 0.0.0\)`/)
           end
         end
@@ -352,21 +352,22 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
     context "when default attributes are specified" do
-      let(:default_attributes) {
+      let(:default_attributes) do
         {
           "shared" => {
-            "foo" => "bar"
-          }
+            "foo" => "bar",
+          },
         }
-      }
+      end
+
       context "when the included policy does not have attributes that conflict with the including policy" do
-        let(:included_policy_default_attributes) {
+        let(:included_policy_default_attributes) do
           {
             "not_shared" => {
-              "foo" => "bar"
-            }
+              "foo" => "bar",
+            },
           }
-        }
+        end
 
         it "emits a lockfile with the attributes from both merged" do
           expect(policyfile_lock.to_lock["default_attributes"]).to include(included_policy_default_attributes, default_attributes)
@@ -384,16 +385,16 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
       end
 
       context "when the included policy has attributes that conflict with the including policy's attributes" do
-        let(:included_policy_default_attributes) {
+        let(:included_policy_default_attributes) do
           {
             "shared" => {
-              "foo" => "not_bar"
-            }
+              "foo" => "not_bar",
+            },
           }
-        }
+        end
 
         it "raises an error describing all attribute conflicts" do
-          expect{policyfile_lock.to_lock}.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
+          expect { policyfile_lock.to_lock }.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
         end
 
         it "includes the name and location of the included policy in the error message"
@@ -404,21 +405,22 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
     context "when override attributes are specified" do
-      let(:override_attributes) {
+      let(:override_attributes) do
         {
           "shared" => {
-            "foo" => "bar"
-          }
+            "foo" => "bar",
+          },
         }
-      }
+      end
+
       context "when the included policy does not have attributes that conflict with the including policy" do
-        let(:included_policy_override_attributes) {
+        let(:included_policy_override_attributes) do
           {
             "not_shared" => {
-              "foo" => "bar"
-            }
+              "foo" => "bar",
+            },
           }
-        }
+        end
 
         it "emits a lockfile with the attributes from both merged" do
           expect(policyfile_lock.to_lock["override_attributes"]).to include(included_policy_override_attributes, override_attributes)
@@ -436,16 +438,16 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
       end
 
       context "when the included policy has attributes that conflict with the including policy's attributes" do
-        let(:included_policy_override_attributes) {
+        let(:included_policy_override_attributes) do
           {
             "shared" => {
-              "foo" => "not_bar"
-            }
+              "foo" => "not_bar",
+            },
           }
-        }
+        end
 
         it "raises an error describing all attribute conflicts" do
-          expect{policyfile_lock.to_lock}.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
+          expect { policyfile_lock.to_lock }.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
         end
 
         it "includes the name and location of the included policy in the error message"
@@ -454,8 +456,6 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
       end
     end
-
-
   end
 
   context "when several policies are included" do
@@ -503,7 +503,4 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
   end
-
 end
-
-

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -117,12 +117,18 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
   end
 
   let(:included_policy_lock_name) { "included" }
+  let(:included_policy_fetcher) do
+    instance_double("ChefDK::Policyfile::LocalLockFetcher").tap do |double|
+      allow(double).to receive(:lock_data).and_return(included_policy_lock_data)
+      allow(double).to receive(:valid?).and_return(true)
+      allow(double).to receive(:errors?).and_return([])
+    end
+  end
 
   let(:included_policy_lock_spec) do
     ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, {:local => "somelocation"}, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)
-      allow(spec).to receive(:ensure_cached)
-      allow(spec).to receive(:lock_data).and_return(included_policy_lock_data)
+      allow(spec).to receive(:fetcher).and_return(included_policy_fetcher)
     end
   end
 

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -240,13 +240,17 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
     context "when no cookbooks are shared as dependencies or transitive dependencies" do
+      let(:included_policy_expanded_runlist) { ["recipe[cookbookC::default]"] }
+      let(:run_list) { ["cookbookA::default"] }
 
-      it "does not raise a have conflicting dependency requirements error"
+      it "does not raise a have conflicting dependency requirements error" do
+        expect { policyfile_lock.to_lock }.not_to raise_error
+      end
 
-      it "emits a lockfile where cookbooks pulled from the upstream are at identical versions"
-
-      it "solves the dependencies added by the top-level policyfile and emits them in the lockfile"
-
+      it "emits a lockfile where cookbooks pulled from the upstream are at identical versions" do
+        expect(policyfile_lock.to_lock["solution_dependencies"]["dependencies"]).to(
+          have_key("cookbookC (2.0.0)"))
+      end
     end
 
     context "when some cookbooks are shared as dependencies or transitive dependencies" do

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -180,8 +180,6 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
     let(:included_policies) { [included_policy_lock_spec] }
 
-    it "emits a lockfile describing the source of the included policy"
-
     # currently you must have a run list in a policyfile, but it should now
     # become possible to make a combo-policy just by combining other policies
     context "when the including policy does not have a run list" do
@@ -323,38 +321,13 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
           expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError)
         end
 
-        it "includes the name and location of the included policy in the error message" do
-          pending("Not implemented")
-          expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError) do |e|
-            expect(e.to_s).to match(/#{included_policy_lock_name}/)
-          end
-
-        end
-
         it "includes the source of the conflicting dependency constraint from the including policy" do
           expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError) do |e|
             expect(e.to_s).to match(/`cookbookC \(= 2.0.0\)`/) # This one comes from the included policy
             expect(e.to_s).to match(/`cookbookC \(= 1.0.0\)` required by `local-1.0.0`/) # This one comes from the included policy
           end
         end
-
-        it "should not have an open constraint on cookbookC" do
-          pending("I think this is a bug")
-          expect { policyfile_lock.to_lock }.to raise_error(Solve::Errors::NoSolutionError) do |e|
-            expect(e.to_s).not_to match(/`cookbookC \(>= 0.0.0\)`/)
-          end
-        end
-
       end
-
-      context "and the including policy explicitly sets the source for a cookbook which conflicts with the source in the included policy" do
-
-        it "raises an error describing the conflict"
-
-        it "includes the name and location of the included policy in the error message"
-
-      end
-
     end
 
     context "when default attributes are specified" do
@@ -454,11 +427,6 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
             ChefDK::Policyfile::AttributeMergeChecker::ConflictError,
             "Attribute '[shared][foo]' provided conflicting values by the following sources [\"user-specified\", \"included\"]")
         end
-
-        it "includes the name and location of the included policy in the error message"
-
-        it "includes the source location of the conflicting attribute in the including policy"
-
       end
     end
   end

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -125,7 +125,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
   end
 
-  let(:lock_source_options) { { :local => "somelocation" } }
+  let(:lock_source_options) { { :path => "somelocation" } }
   let(:included_policy_lock_spec) do
     ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, lock_source_options, nil).tap do |spec|
       allow(spec).to receive(:valid?).and_return(true)

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -400,13 +400,10 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
         end
 
         it "raises an error describing all attribute conflicts" do
-          expect { policyfile_lock.to_lock }.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
+          expect { policyfile_lock.to_lock }.to raise_error(
+            ChefDK::Policyfile::AttributeMergeChecker::ConflictError,
+            "Attribute '[shared][foo]' provided conflicting values by the following sources [\"user-specified\", \"included\"]")
         end
-
-        it "includes the name and location of the included policy in the error message"
-
-        it "includes the source location of the conflicting attribute in the including policy"
-
       end
     end
 
@@ -453,7 +450,9 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
         end
 
         it "raises an error describing all attribute conflicts" do
-          expect { policyfile_lock.to_lock }.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
+          expect { policyfile_lock.to_lock }.to raise_error(
+            ChefDK::Policyfile::AttributeMergeChecker::ConflictError,
+            "Attribute '[shared][foo]' provided conflicting values by the following sources [\"user-specified\", \"included\"]")
         end
 
         it "includes the name and location of the included policy in the error message"

--- a/spec/unit/policyfile_includes_spec.rb
+++ b/spec/unit/policyfile_includes_spec.rb
@@ -21,42 +21,203 @@ require "chef-dk/policyfile_compiler"
 
 describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
 
+  def expand_run_list(r)
+    r.map do |item|
+      "recipe[#{item}]"
+    end
+  end
+
+  let(:run_list) { ["local::default"] }
+  let(:run_list_expanded) { expand_run_list(run_list) }
+  let(:named_run_list) { {} }
+  let(:named_run_list_expanded) do
+    named_run_list.inject({}) do |acc, (key, val)|
+      acc[key] = expand_run_list(val)
+      acc
+    end
+  end
+  let(:default_attributes) { {} }
+  let(:override_attributes) { {} }
+
+  let(:default_source) { nil }
+
+  let(:external_cookbook_universe) {
+    {
+      "cookbookA" => {
+        "1.0.0" => [ ],
+        "2.0.0" => [ ],
+      },
+      "cookbookB" => {
+        "1.0.0" => [ ],
+        "2.0.0" => [ ],
+      },
+      "cookbookC" => {
+        "1.0.0" => [ ],
+        "2.0.0" => [ ],
+      },
+      "local" => {
+        "1.0.0" => [ ["cookbookC", "= 1.0.0" ] ],
+      },
+      "local_easy" => {
+        "1.0.0" => [ ["cookbookC", "= 2.0.0" ] ],
+      }
+    }
+  }
+  
+  let(:included_policy_default_attributes) { {} }
+  let(:included_policy_override_attributes) { {} }
+  let(:included_policy_expanded_named_runlist) { nil }
+  let(:included_policy_expanded_runlist) { ["recipe[cookbookA::default]"] }
+  let(:included_policy_cookbooks) {
+    [
+      {
+        name: "cookbookA",
+        version: "2.0.0"
+      }
+    ]
+  }
+
+  let(:included_policy_lock_data) do
+    cookbook_locks = included_policy_cookbooks.inject({}) do |acc, cookbook_info|
+      acc[cookbook_info[:name]] = {
+        "version" => cookbook_info[:version],
+        "identifier" => "identifier",
+        "dotted_decimal_identifier" => "dotted_decimal_identifier",
+        "cache_key" => "#{cookbook_info[:name]}-#{cookbook_info[:version]}",
+        "origin" => "uri",
+        "source_options" => {}
+      }
+      acc
+    end
+
+    solution_dependencies_lock = included_policy_cookbooks.map do |cookbook_info|
+      [cookbook_info[:name], cookbook_info[:version]]
+    end
+
+    {
+      "name" => "included_policyfile",
+      "revision_id" => "myrevisionid",
+      "run_list" => included_policy_expanded_runlist,
+      "cookbook_locks" => cookbook_locks,
+      "default_attributes" => included_policy_default_attributes,
+      "override_attributes" => included_policy_override_attributes,
+      "solution_dependencies" => {
+        "Policyfile"=> solution_dependencies_lock,
+        ## We dont use dependencies, no need to fill it out
+        "dependencies" => {}
+      }
+    }.tap do |core|
+      core["named_run_lists"] = included_policy_expanded_named_runlist if included_policy_expanded_named_runlist 
+    end
+  end
+
+  let(:included_policy_lock_name) { "included" }
+
+  let(:included_policy_lock_spec) do
+    ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, {:local => "somelocation"}, nil).tap do |spec|
+      allow(spec).to receive(:valid?).and_return(true)
+      allow(spec).to receive(:ensure_cached)
+      allow(spec).to receive(:lock_data).and_return(included_policy_lock_data)
+    end
+  end
+
+  let (:included_policies) { [] }
+
+  let(:policyfile) do
+    policyfile = ChefDK::PolicyfileCompiler.new.build do |p|
+
+      p.default_source.replace([default_source]) if default_source
+      p.run_list(*run_list)
+
+      named_run_list.each do |name, run_list|
+        p.named_run_list(name, *run_list)
+      end
+
+      default_attributes.each do |(name, value)|
+        p.default[name] = value
+      end
+
+      override_attributes.each do |(name, value)|
+        p.override[name] = value
+      end
+
+      allow(p).to receive(:included_policies).and_return(included_policies)
+      allow(p.default_source.first).to receive(:universe_graph).and_return(external_cookbook_universe)
+    end
+
+    policyfile
+  end
+
+  let(:policyfile_lock) do
+    policyfile.lock
+  end
+
   context "when no policies are included" do
 
-    # TODO: an empty array here is probably fine?
-    it "does not emit included policies information in the lockfile"
+    it "does not emit included policies information in the lockfile" do
+      expect(policyfile_lock.to_lock["included_policies"]).to eq(nil)
+    end
 
   end
 
   context "when one policy is included" do
+
+    let(:included_policies) { [included_policy_lock_spec] }
 
     it "emits a lockfile describing the source of the included policy"
 
     # currently you must have a run list in a policyfile, but it should now
     # become possible to make a combo-policy just by combining other policies
     context "when the including policy does not have a run list" do
+      let(:run_list) { [] }
 
-      it "emits a lockfile with an identical run list as the included policy"
+      it "emits a lockfile with an identical run list as the included policy" do
+        expect(policyfile_lock.to_lock["run_list"]).to eq(included_policy_expanded_runlist)
+      end
 
     end
 
     context "when the including policy has a run list" do
 
-      it "appends run list items from the including policy to the included policy's run list, removing duplicates"
+      it "appends run list items from the including policy to the included policy's run list, removing duplicates" do
+        expect(policyfile_lock.to_lock["run_list"]).to eq(included_policy_expanded_runlist + run_list_expanded)
+      end
 
     end
 
     context "when the policies have named run lists" do
 
+      let(:included_policy_expanded_named_runlist) do
+        {
+          "shared" => ["recipe[cookbookA::included]"]
+        }
+      end
+
       context "and no named run lists are shared between the including and included policy" do
 
-        it "preserves the named run lists as given in both policies"
+        let(:named_run_list) do
+          {
+            "local" => ["local::foo"]
+          }
+        end
+
+        it "preserves the named run lists as given in both policies" do
+          expect(policyfile_lock.to_lock["named_run_lists"]).to include(included_policy_expanded_named_runlist, named_run_list_expanded)
+        end
 
       end
 
       context "and some named run lists are shared between the including and included policy" do
 
-        it "appends run lists items from the including policy's run lists to the included policy's run lists, removing duplicates"
+        let(:named_run_list) do
+          {
+            "shared" => ["local::foo"]
+          }
+        end
+
+        it "appends run lists items from the including policy's run lists to the included policy's run lists" do
+          expect(policyfile_lock.to_lock["named_run_lists"]["shared"]).to eq(included_policy_expanded_named_runlist["shared"] + named_run_list_expanded["shared"])
+        end
 
       end
 
@@ -73,40 +234,171 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
 
     context "when some cookbooks are shared as dependencies or transitive dependencies" do
+      let(:included_policy_expanded_runlist) { ["recipe[cookbookC::default]"] }
+      let(:included_policy_cookbooks) {
+        [
+          {
+            name: "cookbookC",
+            version: "2.0.0"
+          }
+        ]
+      }
 
       context "and the including policy's dependencies can be solved with the included policy's locks" do
+        let(:run_list) { ["local_easy::default"] }
 
-        it "solves the dependencies added by the top-level policyfile and emits them in the lockfile"
+        it "solves the dependencies added by the top-level policyfile and emits them in the lockfile" do
+          expect(policyfile_lock.to_lock["solution_dependencies"]["dependencies"]).to(
+            have_key("cookbookC (2.0.0)"))
+        end
 
       end
 
       context "and the including policy's dependencies cannot be solved with the included policy's locks" do
+        let(:run_list) { ["local::default"] }
+
+        it "raises an error describing the conflict" do
+          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError)
+        end
+
+        it "includes the name and location of the included policy in the error message" do
+          pending("Not implemented")
+          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError) do |e|
+            expect(e.to_s).to match(/#{included_policy_lock_name}/)
+          end
+
+        end
+
+        it "includes the source of the conflicting dependency constraint from the including policy" do
+          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError) do |e|
+            expect(e.to_s).to match(/`cookbookC \(= 2.0.0\)`/) # This one comes from the included policy
+            expect(e.to_s).to match(/`cookbookC \(= 1.0.0\)` required by `local-1.0.0`/) # This one comes from the included policy
+          end
+        end
+
+        it "should not have an open constraint on cookbookC" do
+          pending("I think this is a bug")
+          expect{policyfile_lock.to_lock}.to raise_error(Solve::Errors::NoSolutionError) do |e|
+            expect(e.to_s).not_to match(/`cookbookC \(>= 0.0.0\)`/)
+          end
+        end
+
+      end
+
+      context "and the including policy explicitly sets the source for a cookbook which conflicts with the source in the included policy" do
 
         it "raises an error describing the conflict"
 
         it "includes the name and location of the included policy in the error message"
 
-        it "includes the source of the conflicting dependency constraint from the including policy"
-
       end
 
     end
 
-    context "when the included policy does not have attributes that conflict with the including policy" do
+    context "when default attributes are specified" do
+      let(:default_attributes) {
+        {
+          "shared" => {
+            "foo" => "bar"
+          }
+        }
+      }
+      context "when the included policy does not have attributes that conflict with the including policy" do
+        let(:included_policy_default_attributes) {
+          {
+            "not_shared" => {
+              "foo" => "bar"
+            }
+          }
+        }
 
-      it "emits a lockfile with the attributes from both merged"
+        it "emits a lockfile with the attributes from both merged" do
+          expect(policyfile_lock.to_lock["default_attributes"]).to include(included_policy_default_attributes, default_attributes)
+        end
 
+      end
+
+      context "when the included policy has attributes that conflict with the including policy, but provide the same value" do
+        let(:included_policy_default_attributes) { default_attributes }
+
+        it "emits a lockfile with the attributes from both merged" do
+          expect(policyfile_lock.to_lock["default_attributes"]).to eq(default_attributes)
+        end
+
+      end
+
+      context "when the included policy has attributes that conflict with the including policy's attributes" do
+        let(:included_policy_default_attributes) {
+          {
+            "shared" => {
+              "foo" => "not_bar"
+            }
+          }
+        }
+
+        it "raises an error describing all attribute conflicts" do
+          expect{policyfile_lock.to_lock}.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
+        end
+
+        it "includes the name and location of the included policy in the error message"
+
+        it "includes the source location of the conflicting attribute in the including policy"
+
+      end
     end
 
-    context "when the included policy has attributes that conflict with the including policy's attributes" do
+    context "when override attributes are specified" do
+      let(:override_attributes) {
+        {
+          "shared" => {
+            "foo" => "bar"
+          }
+        }
+      }
+      context "when the included policy does not have attributes that conflict with the including policy" do
+        let(:included_policy_override_attributes) {
+          {
+            "not_shared" => {
+              "foo" => "bar"
+            }
+          }
+        }
 
-      it "raises an error describing all attribute conflicts"
+        it "emits a lockfile with the attributes from both merged" do
+          expect(policyfile_lock.to_lock["override_attributes"]).to include(included_policy_override_attributes, override_attributes)
+        end
 
-      it "includes the name and location of the included policy in the error message"
+      end
 
-      it "includes the source location of the conflicting attribute in the including policy"
+      context "when the included policy has attributes that conflict with the including policy, but provide the same value" do
+        let(:included_policy_override_attributes) { override_attributes }
 
+        it "emits a lockfile with the attributes from both merged" do
+          expect(policyfile_lock.to_lock["override_attributes"]).to eq(override_attributes)
+        end
+
+      end
+
+      context "when the included policy has attributes that conflict with the including policy's attributes" do
+        let(:included_policy_override_attributes) {
+          {
+            "shared" => {
+              "foo" => "not_bar"
+            }
+          }
+        }
+
+        it "raises an error describing all attribute conflicts" do
+          expect{policyfile_lock.to_lock}.to raise_error(ChefDK::Policyfile::AttributeMergeChecker::ConflictError)
+        end
+
+        it "includes the name and location of the included policy in the error message"
+
+        it "includes the source location of the conflicting attribute in the including policy"
+
+      end
     end
+
 
   end
 

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -1,0 +1,128 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright:: Copyright (c) 2017 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile_lock.rb"
+
+describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" do
+
+  context "when a policy is included from local disk" do
+
+    it "maintains source locations for remote cookbooks (i.e., from github or supermarket)"
+
+    it "maintains identifiers for remote cookbooks"
+
+    context "and the included policy sources cookbooks from local disk" do
+      # For example, imagine a directory layout like:
+      #
+      #    policies/
+      #      - policy_that_includes_shared_policy_a.rb
+      #      - shared_policy_folder/
+      #        - shared_policy_a.rb
+      #        - shared_policy_a.lock.json
+      #        - shared_policy_b.rb
+      #        - shared_policy_b.lock.json
+      #    cookbooks/
+      #      - webserver_cookbook/
+      #        <etc.>
+      #
+      # In `policies/shared_policy_folder/shared_policy_a.rb`, a cookbook may be
+      # sourced from local path with code like:
+      #
+      #     cookbook "webserver_cookbook", path: "../../cookbooks/webserver_cookbook"
+      #
+      # In the lockfile
+      # `policies/shared_policy_folder/shared_policy_a.lock.json`, we'd have some
+      # data like:
+      #
+      #     "cookbook_locks": {
+      #       "webserver_cookbook": {
+      #         "version": "0.1.0",
+      #         "identifier": "ea96c99da079db9ff3cb22601638fabd5df49599",
+      #         "source": "../../cookbooks/webserver_cookbook",
+      #
+      # However, when we want to `chef install` cookbooks for
+      # `policy_that_includes_shared_policy_a.rb`, we are one directory higher
+      # and the path needs to be adjusted to `../cookbooks/webserver_cookbook` (only one set of `..`s)
+      it "adjusts relative paths for local path cookbooks"
+
+      # counter-example to above, if the filesystem path is absolute, leave it as-is
+      it "does not adjust non-relative paths for local path cookbooks"
+
+      context "and the local path cookbook content is unchanged" do
+
+        it "does not raise an error when installing"
+
+      end
+
+      context "and the local path cookbook is modified so the identifier doesn't match" do
+
+        it "raises an error when installing"
+
+        it "suggests that the error may be resolved by updating the included policy"
+
+      end
+
+      context "and the local path cookbook does not exist" do
+
+        it "raises an error when installing"
+
+        it "includes the name and source location of the included policy"
+
+      end
+
+    end
+  end
+
+  context "when a policy is included from a Chef Server" do
+
+    it "maintains source locations for remote cookbooks (i.e., from github or supermarket)"
+
+    it "maintains identifiers for remote cookbooks"
+
+    context "and the included policy sources cookbooks from local disk" do
+
+      # NOTE: this will need to be a new kind of source in CookbookOmnifetch.
+      # We have support for "regular" cookbooks in Chef Server, but for this
+      # case we need to get the actual cookbook artifact at the specified revision_id
+      it "adjusts the source location for the cookbook to the Chef Server's cookbook artifact store"
+
+      it "maintains the identifier for the cookbooks"
+
+      context "and the cookbook_artifact has been removed from the chef server" do
+
+        # If the user is correctly using `chef clean-policy-revisions` and
+        # `chef clean-policy-cookbooks`, this case shouldn't occur, but should
+        # still have a clean and informative error
+        it "raises an error explaining that the included policy depends on a cookbook artifact that has been deleted"
+
+      end
+
+    end
+  end
+
+  context "when a policy is included from a remote git repo" do
+
+    context "and the included policy sources cookbooks from local disk" do
+
+      # ¯\_(ツ)_/¯
+      it "raises an error explaining that local path cookbooks cannot be used in policies included from git repos"
+
+    end
+  end
+end

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -26,7 +26,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
 
   let(:default_source) { [:community] }
 
-  let(:external_cookbook_universe) {
+  let(:external_cookbook_universe) do
     {
       "cookbookA" => {
         "1.0.0" => [ ],
@@ -45,9 +45,9 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
       },
       "local_easy" => {
         "1.0.0" => [ ["cookbookC", "= 2.0.0" ] ],
-      }
+      },
     }
-  }
+  end
 
   let(:included_policy_cookbook_universe) { external_cookbook_universe }
 
@@ -55,29 +55,28 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
   let(:included_policy_override_attributes) { {} }
   let(:included_policy_expanded_named_runlist) { nil }
   let(:included_policy_expanded_runlist) { ["recipe[cookbookA::default]"] }
-  let(:included_policy_cookbooks) {
+  let(:included_policy_cookbooks) do
     [
       {
         name: "cookbookA",
-        version: "2.0.0"
+        version: "2.0.0",
       },
       # We need to manually specify the dependencies of cookbookA
       {
         name: "cookbookB",
-        version: "2.0.0"
-      }
-
+        version: "2.0.0",
+      },
     ]
-  }
+  end
 
   let(:included_policy_source_options) do
     {
       "cookbookA" => {
-        "2.0.0" => {artifactserver: "https://supermarket.example/c/cookbookA/2.0.0/download", version: "2.0.0", somekey: "withavalue"}
+        "2.0.0" => { artifactserver: "https://supermarket.example/c/cookbookA/2.0.0/download", version: "2.0.0", somekey: "withavalue" },
       },
       "cookbookB" => {
-        "2.0.0" => {artifactserver: "https://supermarket.example/c/cookbookB/2.0.0/download", version: "2.0.0", somekey: "withavalue"}
-      }
+        "2.0.0" => { artifactserver: "https://supermarket.example/c/cookbookB/2.0.0/download", version: "2.0.0", somekey: "withavalue" },
+      },
     }
   end
 
@@ -89,7 +88,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
         "dotted_decimal_identifier" => "dotted_decimal_identifier",
         "cache_key" => "#{cookbook_info[:name]}-#{cookbook_info[:version]}",
         "origin" => "uri",
-        "source_options" => included_policy_source_options[cookbook_info[:name]][cookbook_info[:version]]
+        "source_options" => included_policy_source_options[cookbook_info[:name]][cookbook_info[:version]],
       }
       acc
     end
@@ -111,11 +110,11 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
       "default_attributes" => included_policy_default_attributes,
       "override_attributes" => included_policy_override_attributes,
       "solution_dependencies" => {
-        "Policyfile"=> solution_dependencies_lock,
-        "dependencies" => solution_dependencies_cookbooks
-      }
+        "Policyfile" => solution_dependencies_lock,
+        "dependencies" => solution_dependencies_cookbooks,
+      },
     }.tap do |core|
-      core["named_run_lists"] = included_policy_expanded_named_runlist if included_policy_expanded_named_runlist 
+      core["named_run_lists"] = included_policy_expanded_named_runlist if included_policy_expanded_named_runlist
     end
   end
 
@@ -125,7 +124,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
     instance_double("ChefDK::Policyfile::LocalLockFetcher").tap do |double|
       allow(double).to receive(:lock_data).and_return(included_policy_lock_data)
       allow(double).to receive(:valid?).and_return(true)
-      allow(double).to receive(:errors?).and_return([])
+      allow(double).to receive(:errors).and_return([])
     end
   end
 
@@ -168,8 +167,8 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
       allow(double).to receive(:cookbook_has_recipe?).and_return(true)
       allow(double).to receive(:installed?).and_return(true)
       allow(double).to receive(:mirrors_canonical_upstream?).and_return(true)
-      allow(double).to receive(:cache_key).and_return("#{cookbook_name}-#{version_constraint}-#{source_opts.to_s}")
-      allow(double).to receive(:uri).and_return("uri://#{cookbook_name}-#{version_constraint}-#{source_opts.to_s}")
+      allow(double).to receive(:cache_key).and_return("#{cookbook_name}-#{version_constraint}-#{source_opts}")
+      allow(double).to receive(:uri).and_return("uri://#{cookbook_name}-#{version_constraint}-#{source_opts}")
       allow(double).to receive(:source_options_for_lock).and_return(source_opts)
       double
     end
@@ -177,7 +176,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
 
   context "when a policy is included from local disk" do
     let(:included_policy_lock_spec) do
-      ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, {:local => "somelocation"}, nil).tap do |spec|
+      ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, { :local => "somelocation" }, nil).tap do |spec|
         allow(spec).to receive(:valid?).and_return(true)
         allow(spec).to receive(:fetcher).and_return(included_policy_fetcher)
       end

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -212,7 +212,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
             "name" => included_policy_lock_name,
             "revision_id" => "myrevisionid",
             "source_options" => lock_source_options,
-          }
+          },
         ])
     end
 

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -206,7 +206,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
     it "emits the included policy in the lock file" do
       lock = policyfile.lock
       allow(lock).to receive(:cookbook_locks_for_lockfile).and_return({})
-      expect(lock.to_lock["included_policy_locks"]).to eq({included_policy_lock_name => { revision_id: "myrevisionid", source_options: lock_source_options } })
+      expect(lock.to_lock["included_policy_locks"]).to eq([{ name: included_policy_lock_name, revision_id: "myrevisionid", source_options: lock_source_options }])
     end
 
     context "and the included policy sources cookbooks from local disk" do

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -176,7 +176,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
     end
   end
 
-  context "when a policy is included from local disk" do
+  context "when a policy is included" do
     let(:included_policy_lock_spec) do
       ChefDK::Policyfile::PolicyfileLocationSpecification.new(included_policy_lock_name, lock_source_options, nil).tap do |spec|
         allow(spec).to receive(:valid?).and_return(true)
@@ -199,7 +199,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
       expect(policyfile.lock.cookbook_locks["cookbookC"].source_options).to eq(default_source_obj.source_options_for("cookbookC", "1.0.0"))
     end
 
-    it "maintains identifiers for remote cookbooks", :focus do
+    it "maintains identifiers for remote cookbooks" do
       allow(ChefDK::Policyfile::CachedCookbook).to receive(:new) do |name, storage_config|
         mock = ChefDK::Policyfile::CachedCookbook.allocate
         mock.send(:initialize, name, storage_config)
@@ -216,7 +216,6 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
       expect(policyfile.lock.to_lock["cookbook_locks"]["cookbookB"]["source_options"]).to eq(included_policy_source_options["cookbookB"]["2.0.0"])
     end
 
-    # TODO: Sicne the PolicyfileLocationSpecification is a mock, this isn't really testing anything about a local lockfile
     it "emits the included policy in the lock file" do
       lock = policyfile.lock
       allow(lock).to receive(:cookbook_locks_for_lockfile).and_return({})
@@ -228,104 +227,6 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
             "source_options" => lock_source_options,
           },
         ])
-    end
-
-    context "and the included policy sources cookbooks from local disk" do
-      # For example, imagine a directory layout like:
-      #
-      #    policies/
-      #      - policy_that_includes_shared_policy_a.rb
-      #      - shared_policy_folder/
-      #        - shared_policy_a.rb
-      #        - shared_policy_a.lock.json
-      #        - shared_policy_b.rb
-      #        - shared_policy_b.lock.json
-      #    cookbooks/
-      #      - webserver_cookbook/
-      #        <etc.>
-      #
-      # In `policies/shared_policy_folder/shared_policy_a.rb`, a cookbook may be
-      # sourced from local path with code like:
-      #
-      #     cookbook "webserver_cookbook", path: "../../cookbooks/webserver_cookbook"
-      #
-      # In the lockfile
-      # `policies/shared_policy_folder/shared_policy_a.lock.json`, we'd have some
-      # data like:
-      #
-      #     "cookbook_locks": {
-      #       "webserver_cookbook": {
-      #         "version": "0.1.0",
-      #         "identifier": "ea96c99da079db9ff3cb22601638fabd5df49599",
-      #         "source": "../../cookbooks/webserver_cookbook",
-      #
-      # However, when we want to `chef install` cookbooks for
-      # `policy_that_includes_shared_policy_a.rb`, we are one directory higher
-      # and the path needs to be adjusted to `../cookbooks/webserver_cookbook` (only one set of `..`s)
-      it "adjusts relative paths for local path cookbooks"
-
-      # counter-example to above, if the filesystem path is absolute, leave it as-is
-      it "does not adjust non-relative paths for local path cookbooks"
-
-      context "and the local path cookbook content is unchanged" do
-
-        it "does not raise an error when installing"
-
-      end
-
-      context "and the local path cookbook is modified so the identifier doesn't match" do
-
-        it "raises an error when installing"
-
-        it "suggests that the error may be resolved by updating the included policy"
-
-      end
-
-      context "and the local path cookbook does not exist" do
-
-        it "raises an error when installing"
-
-        it "includes the name and source location of the included policy"
-
-      end
-
-    end
-  end
-
-  context "when a policy is included from a Chef Server" do
-
-    it "maintains source locations for remote cookbooks (i.e., from github or supermarket)"
-
-    it "maintains identifiers for remote cookbooks"
-
-    context "and the included policy sources cookbooks from local disk" do
-
-      # NOTE: this will need to be a new kind of source in CookbookOmnifetch.
-      # We have support for "regular" cookbooks in Chef Server, but for this
-      # case we need to get the actual cookbook artifact at the specified revision_id
-      it "adjusts the source location for the cookbook to the Chef Server's cookbook artifact store"
-
-      it "maintains the identifier for the cookbooks"
-
-      context "and the cookbook_artifact has been removed from the chef server" do
-
-        # If the user is correctly using `chef clean-policy-revisions` and
-        # `chef clean-policy-cookbooks`, this case shouldn't occur, but should
-        # still have a clean and informative error
-        it "raises an error explaining that the included policy depends on a cookbook artifact that has been deleted"
-
-      end
-
-    end
-  end
-
-  context "when a policy is included from a remote git repo" do
-
-    context "and the included policy sources cookbooks from local disk" do
-
-      # ¯\_(ツ)_/¯
-      it "raises an error explaining that local path cookbooks cannot be used in policies included from git repos"
-
     end
   end
 end

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -118,7 +118,7 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
     end
   end
 
-  let(:lock_source_options) { { :local => "somelocation" } }
+  let(:lock_source_options) { { :path => "somelocation" } }
 
   let(:included_policy_lock_name) { "included" }
 

--- a/spec/unit/policyfile_install_with_includes_spec.rb
+++ b/spec/unit/policyfile_install_with_includes_spec.rb
@@ -206,7 +206,14 @@ describe ChefDK::PolicyfileLock, "installing cookbooks from included policies" d
     it "emits the included policy in the lock file" do
       lock = policyfile.lock
       allow(lock).to receive(:cookbook_locks_for_lockfile).and_return({})
-      expect(lock.to_lock["included_policy_locks"]).to eq([{ name: included_policy_lock_name, revision_id: "myrevisionid", source_options: lock_source_options }])
+      expect(lock.to_lock["included_policy_locks"]).to eq(
+        [
+          {
+            "name" => included_policy_lock_name,
+            "revision_id" => "myrevisionid",
+            "source_options" => lock_source_options,
+          }
+        ])
     end
 
     context "and the included policy sources cookbooks from local disk" do

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -238,6 +238,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
+        "included_policy_locks" => {},
       }
     end
 
@@ -334,6 +335,7 @@ REVISION_STRING
         "override_attributes" => { "foo2" => "baz" },
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
+        "included_policy_locks" => {},
       }
     end
 
@@ -424,6 +426,7 @@ REVISION_STRING
         "default_attributes" => {},
         "override_attributes" => {},
 
+        "included_policy_locks" => {},
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
       }
     end
@@ -535,6 +538,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
+        "included_policy_locks" => {},
       }
     end
 
@@ -680,7 +684,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
-
+        "included_policy_locks" => {},
       }
     end
 
@@ -772,6 +776,7 @@ REVISION_STRING
           "Policyfile" => [],
           "dependencies" => { "foo (1.0.0)" => [] },
         },
+        "included_policy_locks" => {},
       }
     end
 
@@ -841,6 +846,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
+        "included_policy_locks" => {},
       }
     end
 
@@ -933,7 +939,9 @@ REVISION_STRING
               all_cookbook_location_specs: { "foo" => cached_location_spec, "bar" => local_location_spec },
               solution_dependencies: policyfile_solution_dependencies,
               default_attributes: policyfile_default_attrs,
-              override_attributes: policyfile_override_attrs )
+              override_attributes: policyfile_override_attrs,
+              included_policies: []
+            )
     end
 
     let(:policyfile_lock) do
@@ -1019,6 +1027,7 @@ REVISION_STRING
           "Policyfile" => [ [ "foo", "~> 1.0" ] ],
           "dependencies" => { "foo (1.0.0)" => [], "bar (0.1.0)" => [] },
         },
+        "included_policy_locks" => {},
       }
     end
 

--- a/spec/unit/policyfile_lock_build_spec.rb
+++ b/spec/unit/policyfile_lock_build_spec.rb
@@ -238,7 +238,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 
@@ -335,7 +335,7 @@ REVISION_STRING
         "override_attributes" => { "foo2" => "baz" },
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 
@@ -426,8 +426,8 @@ REVISION_STRING
         "default_attributes" => {},
         "override_attributes" => {},
 
-        "included_policy_locks" => {},
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
+        "included_policy_locks" => [],
       }
     end
 
@@ -538,7 +538,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 
@@ -684,7 +684,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 
@@ -776,7 +776,7 @@ REVISION_STRING
           "Policyfile" => [],
           "dependencies" => { "foo (1.0.0)" => [] },
         },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 
@@ -846,7 +846,7 @@ REVISION_STRING
         "override_attributes" => {},
 
         "solution_dependencies" => { "Policyfile" => [], "dependencies" => {} },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 
@@ -1027,7 +1027,7 @@ REVISION_STRING
           "Policyfile" => [ [ "foo", "~> 1.0" ] ],
           "dependencies" => { "foo (1.0.0)" => [], "bar (0.1.0)" => [] },
         },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 

--- a/spec/unit/policyfile_services/update_attributes_spec.rb
+++ b/spec/unit/policyfile_services/update_attributes_spec.rb
@@ -134,6 +134,7 @@ E
           "Policyfile" => [["local-cookbook", ">= 0.0.0"]],
           "dependencies" => { "local-cookbook (2.3.4)" => [] },
         },
+        "included_policy_locks" => {},
       }
     end
 

--- a/spec/unit/policyfile_services/update_attributes_spec.rb
+++ b/spec/unit/policyfile_services/update_attributes_spec.rb
@@ -169,6 +169,18 @@ E
         expect(ui.output).to include(message)
       end
 
+      context "when a policyfile is included" do
+        let(:lock_applier) { instance_double("ChefDK::Policyfile::LockApplier") }
+
+        it "locks the included policyfile" do
+          expect(ChefDK::Policyfile::LockApplier).to receive(:new).with(
+            update_attrs_service.policyfile_lock, update_attrs_service.policyfile_compiler).and_return(lock_applier)
+          expect(lock_applier).not_to receive(:with_unlocked_policies)
+          expect(lock_applier).to receive(:apply!)
+
+          update_attrs_service.run
+        end
+      end
     end
 
     context "when the Policyfile.rb has different attributes than the lockfile" do

--- a/spec/unit/policyfile_services/update_attributes_spec.rb
+++ b/spec/unit/policyfile_services/update_attributes_spec.rb
@@ -134,7 +134,7 @@ E
           "Policyfile" => [["local-cookbook", ">= 0.0.0"]],
           "dependencies" => { "local-cookbook (2.3.4)" => [] },
         },
-        "included_policy_locks" => {},
+        "included_policy_locks" => [],
       }
     end
 


### PR DESCRIPTION
Implements [rfc097](https://github.com/chef/chef-rfc/pull/280)

This adds `include_policy` to the dsl, allowing the ability to specify
a lock file to include. It currently supports `:path` and `:server` as a location
specification.

Example usage:
```ruby
include_policy "motd", path: "./motd.lock.json"
```

Things that work:
- Merging of cookbook dependencies works
- Detecting cookbook conflicts
- Merging of run lists
- Merging of named run lists
- Merging of attributes
- Detecting conflicting attributes
- Fetching locks from a chef server

Things that are not implemented:
- Fetching policies from git

Things that aren't great:
- No way to specify we want to update just a policy
- The error message you get from conflicting cookbooks tells you that
  the source is a user defined dependency instead of a policyfile lock

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
