### PR TITLE
Cookbook artifact source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
-    cookbook-omnifetch (0.7.0)
+    cookbook-omnifetch (0.8.0)
       mixlib-archive (~> 0.4)
     cookstyle (2.1.0)
       rubocop (= 0.49.1)
@@ -239,9 +239,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     diffy (3.2.0)
-    docker-api (1.33.6)
-      excon (>= 0.38.0)
-      json
+    docker-api (1.34.0)
+      excon (>= 0.47.0)
+      multi_json
     droplet_kit (2.2.1)
       activesupport (> 3.0, < 6)
       faraday (~> 0.9)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,22 @@ Server's API requires each file in a cookbook to be downloaded
 separately; ChefDK will now download the files in parallel.
 Additionally, HTTP keepalives are enabled to reduce connection overhead.
 
+## Cookbook Artifact Source for Policyfiles
+
+Policyfile users may now source cookbooks from the Chef Server's
+cookbook artifact store. This is mainly intended to support the upcoming
+`include_policy` feature, but could be useful in some situations.
+
+Given a cookbook that has been uploaded to the Chef Server via `chef push`,
+it can be used in another policy by adding code like the following to
+the ruby policyfile:
+
+```
+cookbook "runit",
+  chef_server_artifact: "https://chef.example/organizations/myorg",
+  identifier: "09d43fad354b3efcc5b5836fef5137131f60f974"
+```
+
 # ChefDK 2.3 Release Notes
 
 ChefDK 2.3 includes Ruby 2.4.2 to fix the following CVEs:

--- a/lib/chef-dk/configurable.rb
+++ b/lib/chef-dk/configurable.rb
@@ -18,6 +18,9 @@
 require "chef/config"
 require "chef/workstation_config_loader"
 
+require "chef-dk/cookbook_omnifetch"
+require "chef-dk/chef_server_api_multi"
+
 # Define a config context for ChefDK
 class Chef::Config
 
@@ -48,6 +51,8 @@ module ChefDK
       return @chef_config if @chef_config
       config_loader.load
       @chef_config = Chef::Config
+      CookbookOmnifetch.integration.default_chef_server_http_client = default_chef_server_http_client
+      @chef_config
     end
 
     def chefdk_config
@@ -65,5 +70,19 @@ module ChefDK
     def knife_config
       chef_config.knife
     end
+
+    def reset_config!
+      @chef_config = nil
+      @config_loader = nil
+    end
+
+    def default_chef_server_http_client
+      lambda do
+        ChefServerAPIMulti.new(@chef_config.chef_server_url,
+                               signing_key_filename: @chef_config.client_key,
+                               client_name: @chef_config.node_name)
+      end
+    end
+
   end
 end

--- a/lib/chef-dk/policyfile/cookbook_location_specification.rb
+++ b/lib/chef-dk/policyfile/cookbook_location_specification.rb
@@ -29,7 +29,7 @@ module ChefDK
       # API contract
       include StorageConfigDelegation
 
-      SOURCE_TYPES = [:git, :github, :path, :artifactserver, :chef_server, :artifactory]
+      SOURCE_TYPES = [:git, :github, :path, :artifactserver, :chef_server, :chef_server_artifact, :artifactory]
 
       #--
       # Required by CookbookOmnifetch API contract
@@ -69,7 +69,7 @@ module ChefDK
       end
 
       def mirrors_canonical_upstream?
-        [:git, :github, :artifactserver, :chef_server, :artifactory].include?(source_type)
+        [:git, :github, :artifactserver, :chef_server, :chef_server_artifact, :artifactory].include?(source_type)
       end
 
       def installed?
@@ -112,7 +112,7 @@ module ChefDK
       end
 
       def version_fixed?
-        [:git, :github, :path].include?(@source_type)
+        [:git, :github, :path, :chef_server_artifact].include?(@source_type)
       end
 
       def version

--- a/spec/unit/configurable_spec.rb
+++ b/spec/unit/configurable_spec.rb
@@ -23,6 +23,8 @@ describe ChefDK::Configurable do
 
   let(:includer) { TestConfigurable.new }
 
+  before { includer.reset_config! }
+
   it "provides chef_config" do
     expect(includer.chef_config).to eq Chef::Config
   end
@@ -37,5 +39,30 @@ describe ChefDK::Configurable do
 
   it "provides generator_config" do
     expect(includer.generator_config).to eq Chef::Config.chefdk.generator
+  end
+
+  describe "loading Chef Config" do
+
+    let(:url) { "https://chef.example/organizations/myorg" }
+
+    let(:key_path) { "/path/to/my/key.pem" }
+
+    let(:username) { "my-username" }
+
+    before do
+      Chef::Config.chef_server_url(url)
+      Chef::Config.client_key(key_path)
+      Chef::Config.node_name(username)
+      includer.chef_config
+    end
+
+    it "creates a default chef server HTTP client for Omnifetch" do
+      client = CookbookOmnifetch.default_chef_server_http_client
+      expect(client).to be_a_kind_of(ChefDK::ChefServerAPIMulti)
+      expect(client.url).to eq(url)
+      expect(client.opts[:signing_key_filename]).to eq(key_path)
+      expect(client.opts[:client_name]).to eq(username)
+    end
+
   end
 end

--- a/spec/unit/policyfile/cookbook_location_specification_spec.rb
+++ b/spec/unit/policyfile/cookbook_location_specification_spec.rb
@@ -278,6 +278,16 @@ describe ChefDK::Policyfile::CookbookLocationSpecification do
 
     let(:source_options) { { chef_server: "https://api.opscode.com/organizations/chef-oss-dev/cookbooks/my_cookbook/versions/2.0.0/download" } }
 
+    let(:http_client) { instance_double("ChefDK::ChefServerAPIMulti") }
+
+    before do
+      CookbookOmnifetch.integration.default_chef_server_http_client = http_client
+    end
+
+    after do
+      CookbookOmnifetch.integration.default_chef_server_http_client = nil
+    end
+
     it "has a chef_server installer" do
       expect(cookbook_location_spec.installer).to be_a_kind_of(CookbookOmnifetch::ChefServerLocation)
     end
@@ -288,6 +298,44 @@ describe ChefDK::Policyfile::CookbookLocationSpecification do
 
     it "is a mirror of a canonical upstream" do
       expect(cookbook_location_spec.mirrors_canonical_upstream?).to be true
+    end
+
+    it "is valid" do
+      expect(cookbook_location_spec.errors.size).to eq(0)
+      expect(cookbook_location_spec).to be_valid
+    end
+
+  end
+
+  describe "when created with a chef_server_artifact source" do
+
+    let(:source_options) do
+      {
+        chef_server_artifact: "https://api.opscode.com/organizations/chef-oss-dev/",
+        identifier: "09d43fad354b3efcc5b5836fef5137131f60f974",
+      }
+    end
+
+    let(:http_client) { instance_double("ChefDK::ChefServerAPIMulti") }
+
+    before do
+      CookbookOmnifetch.integration.default_chef_server_http_client = http_client
+    end
+
+    after do
+      CookbookOmnifetch.integration.default_chef_server_http_client = nil
+    end
+
+    it "has a chef_server_artifact installer" do
+      expect(cookbook_location_spec.installer).to be_a_kind_of(CookbookOmnifetch::ChefServerArtifactLocation)
+    end
+
+    it "does has a fixed version" do
+      expect(cookbook_location_spec.version_fixed?).to be(true)
+    end
+
+    it "is a mirror of a canonical upstream" do
+      expect(cookbook_location_spec.mirrors_canonical_upstream?).to be(true)
     end
 
     it "is valid" do


### PR DESCRIPTION
### Description

Enables use of `chef_server_artifact` cookbook sources as recently implemented in cookbook-omnifetch

Includes https://github.com/chef/cookbook-omnifetch/pull/20 via cookbook-omnifetch 0.8.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>