### PR TITLE
Bump openssl and rubygems to latest

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 65a9bed9e37e0b6ba7c8aae0b588f11ce5fc399a
+  revision: 0f8723f83627b40dcf73052ac066baf8f643cce4
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -30,13 +30,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.10.75)
-      aws-sdk-resources (= 2.10.75)
-    aws-sdk-core (2.10.75)
+    aws-sdk (2.10.78)
+      aws-sdk-resources (= 2.10.78)
+    aws-sdk-core (2.10.78)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.75)
-      aws-sdk-core (= 2.10.75)
+    aws-sdk-resources (2.10.78)
+      aws-sdk-core (= 2.10.78)
     aws-sigv4 (1.0.2)
     berkshelf (6.3.1)
       buff-config (~> 2.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,7 +1,7 @@
 # THIS IS NOW HAND MANAGED, JUST EDIT THE THING
 # .travis.yml and appveyor.yml consume this,
 # try to keep it machine-parsable.
-override :rubygems, version: "2.6.13"
+override :rubygems, version: "2.6.14"
 override :bundler, version: "1.15.4"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
@@ -19,4 +19,4 @@ override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
 override "zlib", version: "1.2.11"
 override "libzmq", version: "4.0.7"
-override "openssl", version: "1.0.2l"
+override "openssl", version: "1.0.2m"


### PR DESCRIPTION
openssl:

CVE-2017-3736 (OpenSSL advisory)  [Moderate severity] 2nd November 2017:
There is a carry propagating bug in the x86_64 Montgomery squaring procedure. No EC algorithms are affected. Analysis suggests that attacks against RSA and DSA as a result of this defect would be very difficult to perform and are not believed likely. Attacks against DH are considered just feasible (although very difficult) because most of the work necessary to deduce information about a private key may be performed offline. The amount of resources required for such an attack would be very significant and likely only accessible to a limited number of attackers. An attacker would additionally need online access to an unpatched system using the target private key in a scenario with persistent DH parameters and a private key that is shared between multiple clients. This only affects processors that support the BMI1, BMI2 and ADX extensions like Intel Broadwell (5th generation) and later or AMD Ryzen. Reported by Google OSS-Fuzz.

CVE-2017-3735 (OpenSSL advisory)  [Low severity] 28th August 2017:
While parsing an IPAdressFamily extension in an X.509 certificate, it is possible to do a one-byte overread. This would result in an incorrect text display of the certificate. Reported by Google OSS-Fuzz.

rubygems:

Whitelist classes and symbols that are in loaded YAML. See CVE-2017-0903 for full details. Fix by Aaron Patterson.

Signed-off-by: Tim Smith <tsmith@chef.io>