### PR TITLE
Pull in Foodcritic 12.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
-    foodcritic (12.2.0)
+    foodcritic (12.2.1)
       cucumber-core (>= 1.3)
       erubis
       ffi-yajl (~> 2.0)


### PR DESCRIPTION
There was a pretty large regression introduced in 12.2 that I had to
push a fix out for. I noticed it thanks to ChefDK current testing out
cookbooks so the process worked, even though it's PR loud.

Signed-off-by: Tim Smith <tsmith@chef.io>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
