### PR TITLE
Update `chef` command help for granular updates

### DIFF
--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -29,16 +29,16 @@ module ChefDK
       include Configurable
 
       banner(<<-BANNER)
-Usage: chef update [ POLICY_FILE ] [options]
+Usage: chef update [ POLICY_FILE ] [options] [cookbook_1] [...]
 
 `chef update` reads your `Policyfile.rb`, applies any changes, re-solves the
 dependencies and emits an updated `Policyfile.lock.json`. The new locked policy
 will reflect any changes to the `run_list` and pull in any cookbook updates
 that are compatible with the version constraints stated in your `Policyfile.rb`.
 
-NOTE: `chef update` does not yet support granular updates (e.g., just updating
-the `run_list` or a specific cookbook version). Support will be added in a
-future version.
+Individual dependent cookbooks (and their dependencies) may be updated by
+passing their names after the POLICY_FILE. The POLICY_FILE parameter is
+mandatory if you want to update individual cookbooks.
 
 See our detailed README for more information:
 


### PR DESCRIPTION
Granular updates have been supported since 2.0.14. Updating the command
help to reflect current capabilities and behaviour

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
