### PR TITLE
Require Chef 12.14+ in the skeleton cookbook 

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/build_cookbook/metadata.rb.erb
@@ -3,7 +3,7 @@ maintainer '<%= copyright_holder %>'
 maintainer_email '<%= email %>'
 license '<%= license %>'
 version '0.1.0'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 12.14' if respond_to?(:chef_version)
 <% if build_cookbook_parent_is_cookbook -%>
 
 depends 'delivery-truck'

--- a/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/metadata.rb.erb
@@ -5,7 +5,7 @@ license '<%= @spdx_license %>'
 description 'Installs/Configures <%= cookbook_name %>'
 long_description 'Installs/Configures <%= cookbook_name %>'
 version '0.1.0'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 12.14' if respond_to?(:chef_version)
 
 # The `issues_url` points to the location where issues for this cookbook are
 # tracked.  A `View Issues` link will be displayed on this cookbook's page when

--- a/spec/unit/command/generator_commands/build_cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/build_cookbook_spec.rb
@@ -198,7 +198,7 @@ maintainer 'The Authors'
 maintainer_email 'you@example.com'
 license 'all_rights'
 version '0.1.0'
-chef_version '>= 12.1' if respond_to?(:chef_version)
+chef_version '>= 12.14' if respond_to?(:chef_version)
 
 depends 'delivery-truck'
 METADATA


### PR DESCRIPTION

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
