### PR TITLE
Fix bug causing relative paths to not work correctly in local_lock_fetcher

### DIFF
--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -116,12 +116,7 @@ module ChefDK
       end
 
       def abs_path
-        source_path = Pathname.new(source_options[:path])
-        if !source_path.absolute?
-          Pathname.new(storage_config.relative_paths_root).join(source_path)
-        else
-          source_path
-        end
+        Pathname.new(source_options[:path]).expand_path(storage_config.relative_paths_root)
       end
     end
   end

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -98,7 +98,7 @@ module ChefDK
 
       def path
         @path ||= begin
-          path = Pathname.new(source_options[:path])
+          path = abs_path
           if path.directory?
             path = path.join("#{name}.lock.json")
             if !path.file?
@@ -111,10 +111,16 @@ module ChefDK
                 "The provided path #{source_options[:path]} does not exist.")
             end
           end
-          if !path.absolute?
-            path = Pathname.new(storage_config.relative_paths_root).join(path)
-          end
           path
+        end
+      end
+
+      def abs_path
+        source_path = Pathname.new(source_options[:path])
+        if !source_path.absolute?
+          Pathname.new(storage_config.relative_paths_root).join(source_path)
+        else
+          source_path
         end
       end
     end


### PR DESCRIPTION
### Description

Fixes a bug where including a policy with a relative path would fail because it was not validating the correct file existed.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
