### PR TITLE
Removing chef-provisioning-azure and bundled dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ group(:omnibus_package) do
   gem "berkshelf", ">= 6.3.1"
   gem "chef-provisioning", ">= 2.4.0", group: :provisioning
   gem "chef-provisioning-aws", ">= 3.0.0", group: :provisioning
-  gem "chef-provisioning-azure", ">= 0.6.0", group: :provisioning
   gem "chef-provisioning-fog", ">= 0.26.0", group: :provisioning
   gem "chef-vault", ">= 3.3.0"
   gem "chef", "= 13.6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,9 +169,6 @@ GEM
       chef-provisioning (>= 1.0, < 3.0)
       retryable (~> 2.0, >= 2.0.1)
       ubuntu_ami (~> 0.4, >= 0.4.1)
-    chef-provisioning-azure (0.6.0)
-      chef-provisioning (>= 1.0, < 3.0)
-      stuartpreston-azure-sdk-for-ruby (~> 0.7)
     chef-provisioning-fog (0.26.0)
       chef-provisioning (>= 1.0, < 3.0)
       cheffish (>= 13.1.0, < 14.0)
@@ -744,7 +741,6 @@ DEPENDENCIES
   chef-dk!
   chef-provisioning (>= 2.4.0)
   chef-provisioning-aws (>= 3.0.0)
-  chef-provisioning-azure (>= 0.6.0)
   chef-provisioning-fog (>= 0.26.0)
   chef-sugar
   chef-vault (>= 3.3.0)


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

On 8 January 2018, [the Azure "classic" portal was closed down](https://azure.microsoft.com/en-gb/updates/azure-portal-updates-for-classic-portal-users/).  All API access to create VMs in Azure should now be via the Azure Resource Manager (ARM) method, for which separate drivers already exist (not currently bundled with the ChefDK).

Accordingly, this PR removes the old **chef-provisioning-azure** driver and the bundled fork of the Azure SDK **stuartpreston-azure-sdk-for-ruby** that enabled it to work.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
