### PR TITLE
update minitar dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       cookbook-omnifetch (~> 0.5)
       diff-lcs (~> 1.0)
       ffi-yajl (>= 1.0, < 3.0)
-      minitar (~> 0.5.4)
+      minitar (~> 0.6)
       mixlib-cli (~> 1.7)
       mixlib-shellout (~> 2.0)
       paint (~> 1.0)
@@ -452,7 +452,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
-    minitar (0.5.4)
+    minitar (0.6.1)
     minitest (5.11.3)
     mixlib-archive (0.4.1)
       mixlib-log

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-cli", "~> 1.7"
   gem.add_dependency "mixlib-shellout", "~> 2.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
-  gem.add_dependency "minitar", "~> 0.5.4"
+  gem.add_dependency "minitar", "~> 0.6"
   gem.add_dependency "chef", "~> 13.0"
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.6"


### PR DESCRIPTION
Signed-off-by: Sean Zachariasen <thewyzard@hotmail.com>

### Description
Updates minitar version to `~> 0.6` to allow version 0.6.1

* chef-dk, itself, depends on minitar.  Updating does not introduce test failures in rspec.
* berkshelf also depends on minitar, but has been passing their own tests with 0.6.1

### Issues Resolved

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10173

### Check List

- [ ] New functionality includes tests
- [x] All tests pass (except the 2 failed rspec tests presently failing on master)
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
