### PR TITLE
Adds a kitchen flag that gives options for different kitchen configs

### DIFF
--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -42,6 +42,11 @@ module ChefDK
           boolean:     true,
           default:     nil
 
+        option :kitchen,
+          long:        "--kitchen CONFIGURATION",
+          description: "Generate cookbooks with a specific kitchen configuration (dokken|vagrant) - defaults to vagrant",
+          default:     "vagrant"
+
         option :policy,
           short:        "-P",
           long:         "--policy",
@@ -131,6 +136,11 @@ module ChefDK
 
           Generator.add_attr_to_context(:use_berkshelf, berks_mode?)
           Generator.add_attr_to_context(:pipeline, pipeline)
+          Generator.add_attr_to_context(:kitchen, kitchen)
+        end
+
+        def kitchen
+          config[:kitchen]
         end
 
         def pipeline

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -72,7 +72,10 @@ end
 
 # Test Kitchen
 template "#{cookbook_dir}/.kitchen.yml" do
-  if context.use_berkshelf
+  if context.kitchen == 'dokken'
+    # kitchen-dokken configuration works with berkshelf and policyfiles
+    source 'kitchen_dokken.yml.erb'
+  elsif context.use_berkshelf
     source 'kitchen.yml.erb'
   else
     source 'kitchen_policyfile.yml.erb'

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
@@ -1,0 +1,31 @@
+---
+driver:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+transport:
+  name: dokken
+
+verifier:
+  name: inspec
+
+platforms:
+  # @see https://github.com/someara/dokken-images
+  # @see https://hub.docker.com/r/dokken/
+  - name: ubuntu-16.04
+    driver:
+      image: dokken/ubuntu-16.04
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[<%= cookbook_name %>::default]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+    attributes:


### PR DESCRIPTION
To provide support out-of-the-box for `kitchen-dokken` there is a flag now to specify which base kitchen configuration to use.

> By default a chef cookbook will generate a kitchen configuration using vagrant as the driver. You may find that you want to use `kitchen-dokken` as your default kitchen environment when generating your cookbooks. 
>
>     $ chef generate cookbook COOKBOOKNAME --kitchen dokken
>
> That plugin requires a little more setup as it is a `driver`, `provisioner`, and `transport`. It also requires special considerations with the platforms that it uses for testing.
>
> To learn more about the benefits of `kitchen-dokken` take a look at this blog post: https://blog.chef.io/2018/03/06/kitchen-docker-or-kitchen-dokken-using-test-kitchen-and-docker-for-fast-cookbook-testing/



Signed-off-by: Franklin Webber <franklin@chef.io>