### PR TITLE
Fix link in example cookbook to point to the correct docs site URL

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/repo/cookbooks/example/attributes/default.rb
+++ b/lib/chef-dk/skeletons/code_generator/files/default/repo/cookbooks/example/attributes/default.rb
@@ -5,4 +5,4 @@
 # Set a default name
 default['example']['name'] = 'Sam Doe'
 
-# For further information, see the Chef documentation (https://docs.chef.io/essentials_cookbook_attribute_files.html).
+# For further information, see the Chef documentation (https://docs.chef.io/attributes.html).


### PR DESCRIPTION
This page has moved.

Signed-off-by: Tim Smith <tsmith@chef.io>