### PR TITLE
Remove strainer from the generated chefignore file

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -92,14 +92,6 @@ Policyfile.lock.json
 CONTRIBUTING*
 CHANGELOG*
 TESTING*
-MAINTAINERS.toml
-
-# Strainer #
-############
-Colanderfile
-Strainerfile
-.colander
-.strainer
 
 # Vagrant #
 ###########


### PR DESCRIPTION
This isn't something we advocate for and it doesn't make much sense for us to ship it. Also remove the maintainers.toml file since only we were doing that and we've removed them all.

Signed-off-by: Tim Smith <tsmith@chef.io>

