### PR TITLE
powershell_exec mixin support for ChefDK MSI installer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.reg text eol=crlf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ branches:
 install:
   - systeminfo
   - winrm quickconfig -q
+  - regedit /s c:\projects\chef\appveyor_registry.reg
   - SET FORCE_FFI_YAJL=ext
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ branches:
 install:
   - systeminfo
   - winrm quickconfig -q
-  - regedit /s c:\projects\chef\appveyor_registry.reg
+  - regedit /s c:\projects\chefdk\appveyor_registry.reg
   - SET FORCE_FFI_YAJL=ext
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - echo %PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ cache:
 environment:
   matrix:
     - ruby_version: "24-x64"
-    - ruby_version: "24"
 
 clone_folder: c:\projects\chefdk
 clone_depth: 1

--- a/appveyor_registry.reg
+++ b/appveyor_registry.reg
@@ -1,0 +1,29 @@
+REGEDIT4
+
+[HKEY_CLASSES_ROOT\Chef.PowerShell]
+@="Chef.PowerShell"
+
+[HKEY_CLASSES_ROOT\Chef.PowerShell\CLSID]
+@="{9008CA83-83E4-41FF-9C07-696E2CC47B52}"
+
+[HKEY_CLASSES_ROOT\CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}]
+@="Chef.PowerShell"
+
+[HKEY_CLASSES_ROOT\CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32]
+@="c:\\windows\\system32\\mscoree.dll"
+"ThreadingModel"="Both"
+"Class"="Chef.PowerShell"
+"Assembly"="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95"
+"RuntimeVersion"="v4.0.30319"
+"CodeBase"="file:///C:/projects/chefdk/distro/powershell/chef/Chef.PowerShell.dll"
+
+[HKEY_CLASSES_ROOT\CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32\1.0.0.0]
+"Class"="Chef.PowerShell"
+"Assembly"="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95"
+"RuntimeVersion"="v4.0.30319"
+"CodeBase"="file:///C:/projects/chefdk/distro/powershell/chef/Chef.PowerShell.dll"
+
+[HKEY_CLASSES_ROOT\CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\ProgId]
+@="Chef.PowerShell"
+
+[HKEY_CLASSES_ROOT\CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}]

--- a/omnibus/resources/chefdk/msi/source.wxs.erb
+++ b/omnibus/resources/chefdk/msi/source.wxs.erb
@@ -89,6 +89,35 @@
                 <Environment Id="ChefPSModulePathEnvironment"
                              Name="PSModulePath" Action="set" Part="last" System="yes" Value="[PSMODULES]" />
               </Component>
+              <Component Id="ChefPowerShellRegistryEntries" Guid="{6D33C736-DA7F-415C-AE19-375CDDD8A40A}">
+                <RegistryKey Root="HKCR" Key="Chef.PowerShell">
+                  <RegistryValue Type="string" Value="Chef.PowerShell" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="Chef.PowerShell\CLSID">
+                  <RegistryValue Type="string" Value="{9008CA83-83E4-41FF-9C07-696E2CC47B52}" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}">
+                  <RegistryValue Type="string" Value="Chef.PowerShell" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32">
+                  <RegistryValue Type="string" Value="[System64Folder]mscoree.dll" />
+                  <RegistryValue Type="string" Name="ThreadingModel" Value="Both" />
+                  <RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
+                  <RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
+                  <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
+                  <RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\InprocServer32\1.0.0.0">
+                  <RegistryValue Type="string" Name="Class" Value="Chef.PowerShell" />
+                  <RegistryValue Type="string" Name="Assembly" Value="Chef.PowerShell, Version=1.0.14.0, Culture=neutral, PublicKeyToken=7def9f799d039a95" />
+                  <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319" />
+                  <RegistryValue Type="string" Name="CodeBase" Value="[PSMODULES]chef\Chef.PowerShell.dll" />
+                </RegistryKey>                  
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\ProgId">
+                  <RegistryValue Type="string" Value="Chef.PowerShell" />
+                </RegistryKey>
+                <RegistryKey Root="HKCR" Key="CLSID\{9008CA83-83E4-41FF-9C07-696E2CC47B52}\Implemented Categories\{62C8FE65-4EBB-45E7-B440-6E39B2CDBF29}" />
+              </Component>
             </Directory>
             <Directory Id="EMBEDDED" Name="embedded" >
               <Directory Id="EMBEDDEDBIN" Name="bin" >
@@ -132,6 +161,7 @@
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="ChefDkPath" />
       <ComponentRef Id="ChefPSModulePath" />
+      <ComponentRef Id="ChefPowerShellRegistryEntries" />
     </Feature>
 
     <Feature Id="ChefDkStartMenuShortcutFeature" Title="!(loc.FeatureChefDkStartMenuShortcut)" Description="!(loc.FeatureChefDkStartMenuShortcutDescription)" Level="1" AllowAdvertise="no" >


### PR DESCRIPTION
### Description

This change incorporates the Appveyor CI and installer changes that are present in https://github.com/chef/chef/pull/6941 so that ChefDK users on Windows will be able to use powershell_exec locally on their workstations via Chef Client if they so choose.

These files are required to be duplicated to the chef-dk project because installer source files are maintained separately for each project.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
