### PR TITLE
Fixes the spec file as it should display the recipe name and not default

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: <%= cookbook_name %>
-# Spec:: default
+# Spec:: <%= recipe_name %>
 #
 <%= license_description('#') %>
 


### PR DESCRIPTION
Signed-off-by: Franklin Webber <franklin@chef.io>

### Description

The chef recipe generator creates a recipe file and a matching spec file. This spec file should be named after the recipe it is spec'ing.