### PR TITLE
Attempt to unzip files if MSI repair selected

### DIFF
--- a/omnibus/resources/chefdk/msi/source.wxs.erb
+++ b/omnibus/resources/chefdk/msi/source.wxs.erb
@@ -59,7 +59,7 @@
                   Return="ignore" />
 
     <InstallExecuteSequence>
-      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
     </InstallExecuteSequence>
 


### PR DESCRIPTION
Chef DK also suffers from the same issue as https://github.com/chef/chef/issues/7103 where the zip file does not unzip in the case of MSI repair.  This PR fixes that.

Signed-off-by: Stuart Preston <stuart@chef.io>

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
