### PR TITLE
Fix incorrect path value in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chef Software, Inc. <docker@chef.io>
 ARG CHANNEL=stable
 ARG VERSION=2.5.3
 ENV DEBIAN_FRONTEND=noninteractive \
-    PATH=PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:/root/.chefdk/gem/ruby/2.4.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:/root/.chefdk/gem/ruby/2.4.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN apt-get update && \
     apt-get install -y wget ssh && \


### PR DESCRIPTION
### Description

Corrects the path for the docker image as described in #1438.

There is an extra `PATH=` in the value of the path

### Issues Resolved

#1438

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
