### PR TITLE
get omnibus tracking back on master

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "lcg/improve-appbundling"
-gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "lcg/appbundle-0.11-without"
+gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
+gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 71f7f900cddf62c3c1260ec3885a029e1f2193d9
-  branch: lcg/appbundle-0.11-without
+  revision: 0cb3a8dfb6cebd56684c1d4609a676959389e4c5
+  branch: master
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 5bc3a48f9210c19f9b84371d6037447739c96bd8
-  branch: lcg/improve-appbundling
+  revision: 7e9c9a6a71c1ada2d7f42484f13074e1ec6b7cd3
+  branch: master
   specs:
-    omnibus (5.6.11)
+    omnibus (5.6.12)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
@@ -188,7 +188,7 @@ GEM
     minitar (0.6.1)
     mixlib-archive (0.4.1)
       mixlib-log
-    mixlib-authentication (1.4.3)
+    mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
     mixlib-config (2.2.6)
       tomlrb

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -56,13 +56,13 @@ build do
 
   env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
 
-  appbundle "chef", lockdir: project_dir, without: %w{integration docgen maintenance ci travis}, env: env
-  appbundle "foodcritic", lockdir: project_dir, without: %w{development}, env: env
-  appbundle "test-kitchen", lockdir: project_dir, without: %w{changelog debug docs provisioning}, env: env
-  appbundle "inspec", lockdir: project_dir, without: %w{deploy tools maintenance}, env: env
+  appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{integration docgen maintenance ci travis}, env: env
+  appbundle "foodcritic", lockdir: project_dir, gem: "foodcritic", without: %w{development}, env: env
+  appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs provisioning}, env: env
+  appbundle "inspec", lockdir: project_dir, gem: "inspec", without: %w{deploy tools maintenance}, env: env
 
   %w{chef-dk chef-vault ohai opscode-pushy-client cookstyle dco berkshelf}.each do |gem|
-    appbundle gem, lockdir: project_dir, without: %w{changelog}, env: env
+    appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 
   # Clear the now-unnecessary git caches, cached gems, and git-checked-out gems


### PR DESCRIPTION
the appbundler invocation here is slightly odd now that I look at it,
but its necessary.  this is the way to properly do the ChefDK magic.

tested in CI
