### PR TITLE
Add Git support for include_policy.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
       t.options = {
         fail_tags: ["any"],
-        tags: ["~FC071", "~supermarket"],
+        tags: ["~FC071", "~supermarket", "~FC031"],
         cookbook_paths: ["lib/chef-dk/skeletons/code_generator"],
         progress: true,
       }

--- a/lib/chef-dk/cookbook_profiler/git.rb
+++ b/lib/chef-dk/cookbook_profiler/git.rb
@@ -31,6 +31,7 @@ module ChefDK
         @unborn_branch_ref = nil
       end
 
+      # @return [Hash] Hashed used for pinning cookbook versions within a Policfile.lock
       def profile_data
         {
           "scm" => "git",

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -64,9 +64,9 @@ module ChefDK
 
   class InvalidPolicyfileSourceURI < StandardError
     def initialize(url, reason = nil)
-      @url = url
+      @url    = url
       @reason = reason
-      msg = "'#{@url}' is not a valid Policy File Source URI"
+      msg     = "'#{@url}' is not a valid Policy File Source URI"
       msg << " #{@reason}." unless @reason.nil?
       super(msg)
     end
@@ -107,7 +107,7 @@ module ChefDK
 
     def initialize(conflicting_cookbooks, cookbook_sources)
       @conflicting_cookbooks = conflicting_cookbooks
-      @cookbook_sources = cookbook_sources
+      @cookbook_sources      = cookbook_sources
       super(compute_message)
     end
 
@@ -126,7 +126,7 @@ module ChefDK
     end
 
     def resolution_message(overlapping_cookbooks)
-      example_source = cookbook_sources.first
+      example_source       = cookbook_sources.first
       source_key, location = example_source.default_source_args
       <<-EXAMPLE
 You can set a preferred source to resolve this issue with code like:
@@ -134,7 +134,7 @@ You can set a preferred source to resolve this issue with code like:
 default_source :#{source_key}, "#{location}" do |s|
   s.preferred_for "#{overlapping_cookbooks.join('", "')}"
 end
-EXAMPLE
+      EXAMPLE
     end
 
   end
@@ -147,4 +147,5 @@ EXAMPLE
 
   class InvalidPolicyfileLocation < StandardError
   end
+
 end

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -34,7 +34,7 @@ module ChefDK
       # @param source_options [Hash] A hash with a :server key pointing at the chef server,
       # along with :policy_name and either :policy_group or :policy_revision_id. If :policy_name
       # is not provided, name is used.
-      # @param storage_config [StorageConfig]
+      # @param chef_config [Chef::Config, ChefConfig::Config]
       #
       # @example ChefServerLockFetcher for a policyfile with a specific revision id
       #   ChefServerLockFetcher.new("foo",
@@ -46,7 +46,7 @@ module ChefDK
       #     chef_config)
       #
       # @example ChefServerLockFetcher for a policyfile with the latest revision_id for a policy group
-       #   ChefServerLockFetcher.new("foo",
+      #   ChefServerLockFetcher.new("foo",
       #     {server: "http://example.com", policy_group: "dev"},
       #     chef_config)
       #
@@ -153,6 +153,9 @@ module ChefDK
         source_options[:server]
       end
 
+      # @see Chef:ServerAPI
+      # @see Chef::HTTP::JSONInput#get
+      # @return [Hash] Returns a parsed JSON object... I think.
       def http_client
         @http_client ||= Chef::ServerAPI.new(source_options[:server],
                                              signing_key_filename: chef_config.client_key,

--- a/lib/chef-dk/policyfile/git_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/git_lock_fetcher.rb
@@ -1,0 +1,239 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef-dk/policyfile_lock"
+require "chef-dk/exceptions"
+require "chef-dk/helpers"
+require "mixlib/shellout"
+require "tmpdir"
+
+module ChefDK
+  module Policyfile
+
+    # A Policyfile lock fetcher that can read a lock file from a git repository.
+    #
+    # @author Ryan Hass
+    # @author Daniel DeLeo
+    #
+    # @since 3.1.0
+    #
+    class GitLockFetcher
+      attr_accessor :name
+      attr_accessor :source_options
+      attr_accessor :storage_config
+
+      attr_reader :uri
+      attr_reader :branch
+      attr_reader :tag
+      attr_reader :ref
+      attr_reader :revision
+      attr_reader :path
+
+      # Initialize a GitLockFetcher
+      #
+      # @param name [String] The name of the policyfile
+      # @param source_options [Hash] A hash with a :path key pointing at the location
+      #                              of the lock
+      def initialize(name, source_options, storage_config)
+        @name           = name
+        @storage_config = storage_config
+        @source_options = source_options
+
+        @uri      = source_options[:git]
+        @branch   = source_options[:branch]
+        @tag      = source_options[:tag]
+        @ref      = source_options[:ref]
+        @revision = source_options[:revision]
+        @path     = source_options[:path] || source_options[:rel]
+
+        # The revision to parse
+        @rev_parse = source_options[:ref] || source_options[:branch] || source_options[:tag] || "master"
+      end
+
+      # @return [True] if there were no errors with the provided source_options
+      # @return [False] if there were errors with the provided source_options
+      def valid?
+        errors.empty?
+      end
+
+      # Check the options provided when craeting this class for errors
+      #
+      # @return [Array<String>] A list of errors found
+      def errors
+        error_messages = []
+        [:git].each do |key|
+          error_messages << "include_policy for #{name} is missing key #{key}" unless source_options[key]
+        end
+
+        error_messages
+      end
+
+      # @return [Hash] The source_options that describe how to fetch this exact lock again
+      def source_options_for_lock
+        source_options.merge({
+                               revision:  revision,
+                             })
+      end
+
+      # Applies source options from a lock file. This is used to make sure that the same
+      # policyfile lock is loaded that was locked
+      #
+      # @param options_from_lock [Hash] The source options loaded from a policyfile lock
+      def apply_locked_source_options(options_from_lock)
+        # There are no options the lock could provide
+      end
+
+      # @return [String] of the policyfile lock data
+      def lock_data
+        @lock_data ||= fetch_lock_data.tap do |data|
+          data["cookbook_locks"].each do |cookbook_name, cookbook_lock|
+            cookbook_path = cookbook_lock["source_options"]["path"]
+            cookbook_lock["source_options"].tap do |opt|
+              if cookbook_lock.has_key?("scm_info")
+                opt["rel"] = opt["path"] unless opt["path"] == "."
+                opt.delete("path")
+                opt["git"] = cookbook_lock["scm_info"]["remote"]
+                # Note: In instances where the Policyfile.lock is being
+                # consumed from a cookbook, the cookbook from which it will be
+                # consumed will always be one git revision behind. This is due
+                # to the fact that one must generate a lock file which will
+                # contain the git ref from the working copy and then commit
+                # the resulting lock file artifact which will in turn create a
+                # new git ref. However, this may be the incorrect behavior for
+                # some users whom wish to commit the lock file along with any
+                # changes in the same commit, and will require a different way
+                # of generating the locks.
+                opt["revision"] = cookbook_lock["scm_info"]["revision"]
+              end
+            end
+          end
+        end
+
+        @lock_data
+      end
+
+      private
+
+      def fetch_lock_data
+        install unless installed?
+        FFI_Yajl::Parser.new.parse(
+          show_file(@rev_parse, lockfile_path)
+        )
+      end
+
+      # COPYPASTA from CookbookOmnifetch
+      def installed?
+        !!(revision && cache_path.exist?)
+      end
+
+      # COPYPASTA from CookbookOmnifetch::GitLocation and Berkshelf::GitLocation
+      # then munged since we do not have Policyfile validation in scope.
+      # Install into the chefdk cookbook store. This method leverages a cached
+      # git copy.
+      def install
+        if cached?
+          Dir.chdir(cache_path) do
+            git %{fetch --force --tags #{uri} "refs/heads/*:refs/heads/*"}
+          end
+        else
+          git %{clone #{uri} "#{cache_path}" --bare --no-hardlinks}
+        end
+
+        Dir.chdir(cache_path) do
+          @revision ||= git %{rev-parse #{@rev_parse}}
+        end
+      end
+
+      # Shows contents of a file from a shallow or full clone repository for a
+      # given git version.
+      #
+      # This method was originally made before I slammed a bunch of copypasta
+      # code in which is generally more tied to a specific git ref.
+      #
+      # @param version Git version as a tag, branch, or ref.
+      # @param file Full path to file including filename in repository
+      #
+      # @return [String] Content of specified file for a given revision.
+      def show_file(version, file)
+        git("show #{version}:#{file}", cwd: cache_path)
+      end
+
+      # COPYPASTA from CookbookOmnifetch
+      # Location an executable in the current user's $PATH
+      #
+      # @return [String, nil]
+      #   the path to the executable, or +nil+ if not present
+      def which(executable)
+        if File.file?(executable) && File.executable?(executable)
+          executable
+        elsif ENV["PATH"]
+          path = ENV["PATH"].split(File::PATH_SEPARATOR).find do |p|
+            File.executable?(File.join(p, executable))
+          end
+          path && File.expand_path(executable, path)
+        end
+      end
+
+      # COPYPASTA from CookbookOmnifetch::Git
+      # Perform a git command.
+      #
+      # @param [String] command
+      #   the command to run
+      # @param [Boolean] error
+      #   whether to raise error if the command fails
+      #
+      # @raise [String]
+      #   the +$stdout+ from the command
+      def git(command, options = {})
+        error = options[:error] || true
+        unless which("git") || which("git.exe") || which("git.bat")
+          raise GitNotInstalled
+        end
+
+        response = Mixlib::ShellOut.new(%{git #{command}}, options)
+        response.run_command
+
+        if error && response.error?
+          raise GitError.new "#{command} #{cache_path}: #{response.stderr}"
+        end
+
+        response.stdout.strip
+      end
+
+      # COPYPASTA from CookbookOmnifetch::Git (then munged by me)
+      # The path where this git repository is cached.
+      #
+      # @return [Pathname]
+      def cache_path
+        Pathname.new(File.expand_path(File.join(ChefDK::Helpers.chefdk_home, "cache")))
+          .join(".cache", "git", Digest::SHA1.hexdigest(uri))
+      end
+
+      # COPYPASTA from CookbookOmnifetch::Git
+      # Determine if this git repo has already been downloaded.
+      #
+      # @return [Boolean]
+      def cached?
+        cache_path.exist?
+      end
+
+      def lockfile_path
+        @path.nil? ? "Policyfile.lock.json" : @path
+      end
+    end
+  end
+end

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -86,6 +86,12 @@ module ChefDK
 
       private
 
+      # Transforms cookbook paths to a path relative to the current
+      # cookbook for which we are generating a new lock file.
+      # Eg: '../cookbooks/base_cookbook'
+      #
+      # @param path_to_transform [String] Path to dependent cookbook.
+      # @return [Pathname] Path to dependent cookbook relative to the current cookbook/Policyfile.
       def transform_path(path_to_transform)
         cur_path = Pathname.new(storage_config.relative_paths_root)
         include_path = Pathname.new(path).dirname

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -21,7 +21,6 @@ require "chef-dk/policyfile/chef_server_lock_fetcher"
 require "chef-dk/policyfile/git_lock_fetcher"
 require "chef-dk/exceptions"
 
-
 module ChefDK
   module Policyfile
     # A PolicyfileLocationSpecification specifies where a policyfile lock is to be fetched from.

--- a/lib/chef-dk/policyfile/source_uri.rb
+++ b/lib/chef-dk/policyfile/source_uri.rb
@@ -40,7 +40,7 @@ module ChefDK
         end
       end
 
-      VALID_SCHEMES = %w{ https http }.freeze
+      VALID_SCHEMES = %w{ https http git }.freeze
 
       # @raise [ChefDK::InvalidPolicyfileSourceURI]
       def validate

--- a/lib/chef-dk/policyfile/source_uri.rb
+++ b/lib/chef-dk/policyfile/source_uri.rb
@@ -40,7 +40,7 @@ module ChefDK
         end
       end
 
-      VALID_SCHEMES = %w{ https http git }.freeze
+      VALID_SCHEMES = %w{ https http }.freeze
 
       # @raise [ChefDK::InvalidPolicyfileSourceURI]
       def validate

--- a/lib/chef-dk/policyfile/storage_config.rb
+++ b/lib/chef-dk/policyfile/storage_config.rb
@@ -21,6 +21,16 @@ require "chef-dk/exceptions"
 module ChefDK
   module Policyfile
 
+    # Provides handling of relative paths, such as on disk cookbooks which
+    # are specified relative to the Policyfile and local caching of compiled
+    # Policyfile artifacts.
+    #
+    # @author Dan DeLeo
+    # @since 0.11.0
+    # @attr_accessor [String] relative_paths_root Root path relative to the named Policyfile
+    # @attr_accessor [String] cache_path Local cache directory for
+    # @attr_reader [String] policyfile_filename Uncompiled Policyfile filename.
+    # @attr_reader [String] policyfile_lock_filename Filename of compiled Policyfile.
     class StorageConfig
 
       attr_accessor :relative_paths_root

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -53,7 +53,7 @@ dependency "libzmq"
 # ruby and bundler and friends
 dependency "ruby"
 dependency "rubygems"
-dependency "bundler"  # technically a gem, but we gotta solve the chicken-egg problem here
+dependency "bundler" # technically a gem, but we gotta solve the chicken-egg problem here
 
 # for train
 dependency "google-protobuf"

--- a/spec/unit/policyfile/git_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/git_lock_fetcher_spec.rb
@@ -24,8 +24,8 @@ describe ChefDK::Policyfile::GitLockFetcher do
   let(:identifier) { "fab501cfaf747901bd82c1bc706beae7dc3a350c" }
   let(:git_revision) { "8404a9e0b5c27c55d529e61222e14f950b6e4171" }
   let(:rel) { "cookbooks/nested_cookbook" }
-  let(:cookbook_name) {"git-cookbook"}
-  let(:nested_cookbook_name) {"cookbooks/nested-cookbook"}
+  let(:cookbook_name) { "git-cookbook" }
+  let(:nested_cookbook_name) { "cookbooks/nested-cookbook" }
   let(:repo) { "https://github.com/monkeynews/bananas" }
 
   let(:minimal_lockfile_json) do
@@ -64,7 +64,7 @@ describe ChefDK::Policyfile::GitLockFetcher do
     }
   }
 }
-E
+    E
   end
 
   def minimal_lockfile
@@ -78,7 +78,7 @@ E
   let(:minimal_lockfile_modified) do
     minimal_lockfile.tap do |lockfile|
       lockfile["cookbook_locks"][cookbook_name]["source_options"] = {
-        "git" => repo,
+        "git"      => repo,
         "revision" => git_revision,
       }
     end
@@ -87,13 +87,13 @@ E
   let(:minimal_lockfile_with_scm_info) do
     minimal_lockfile_modified.tap do |lockfile|
       lockfile["cookbook_locks"][cookbook_name]["scm_info"] = {
-        "scm" => "git",
-        "remote" => repo,
-        "revision" => git_revision,
-        "working_tree_clean" => true,
-        "published" => true,
+        "scm"                          => "git",
+        "remote"                       => repo,
+        "revision"                     => git_revision,
+        "working_tree_clean"           => true,
+        "published"                    => true,
         "synchronized_remote_branches" => [
-          "origin/master"
+          "origin/master",
         ],
       }
     end
@@ -101,13 +101,12 @@ E
 
   let(:source_options) do
     {
-      git: repo,
-      revision: git_revision
+      git:      repo,
+      revision: git_revision,
     }
   end
 
   let(:shellout) { instance_double("Mixlib::ShellOut", run_command: "git") }
-
 
   describe "#lock_data" do
     subject(:lock_data) { described_class.new(policy_name, source_options, storage_config).lock_data }
@@ -123,12 +122,12 @@ E
 
     context "when using a relative path for the policyfile" do
       let(:source_options_rel) do
-        source_options.collect{|k,v| [k.to_s, v]}.to_h.merge({"rel" => rel})
+        source_options.collect { |k, v| [k.to_s, v] }.to_h.merge({ "rel" => rel })
       end
 
       subject(:relative_path_fetcher) { described_class.new(policy_name, source_options_rel, storage_config) }
 
-      it "omits the relative of the policyfile from the source_options" do
+      it "omits the relative path of the policyfile from the source_options" do
         subject { described_class.new(policy_name, source_options_rel, storage_config) }
 
         expect(Mixlib::ShellOut).to receive(:new).and_return(shellout)
@@ -142,68 +141,15 @@ E
         expect(
           relative_path_fetcher.lock_data["cookbook_locks"][cookbook_name]["source_options"]
         ).to match(
-                   {
-                     "git" => repo,
-                     "revision" => git_revision,
-                   }
-                 )
+               {
+                 "git"      => repo,
+                 "revision" => git_revision,
+               }
+             )
         expect(
           relative_path_fetcher.lock_data["cookbook_locks"][cookbook_name]["source_options"]
         ).not_to match(source_options_rel)
-      end
-
-    end
-
-    context "when a cookbook dependency uses a relative git path" do
-      let(:source_options_with_scm_info) { source_options.collect{|k,v| [k.to_s, v]}.to_h.merge(minimal_lockfile_with_scm_info) }
-
-      context "when the path is '.'" do
-        let(:source_options_with_rel_path_scm_info) do
-          source_options_with_scm_info["cookbook_locks"][cookbook_name]["scm_info"].tap do |scm_info|
-            scm_info["path"] = "/foo/bar"
-          end
-        end
-
-        subject(:foobar) { described_class.new(policy_name, source_options_with_rel_path_scm_info, storage_config) }
-
-        it "removes the 'path' key from the source_options" do
-          expect(Mixlib::ShellOut).to receive(:new).and_return(shellout)
-          allow(shellout).to receive(:error?).and_return(false)
-          allow(shellout).to receive(:stdout).and_return(minimal_lockfile_json)
-          allow(Dir).to receive(:chdir).and_return(0)
-          allow_any_instance_of(described_class).to receive(:cache_path).and_return(
-            Pathname.new(subject.storage_config.relative_paths_root)
-          )
-
-          require 'pry';binding.pry
-          expect(
-            foobar.lock_data["cookbook_locks"][cookbook_name]["source_options"]
-          ).to match(source_options_with_rel_path_scm_info)
-        end
-      end
-
-      context "when the path is prefixed with './'" do
-        let(:source_options) do
-          {
-            path: Pathname.new(lock_file_path).dirname.join("dne.json.lock").to_s,
-          }
-        end
-        it "raises a GitError"
-      end # context "when the path is prefixed with './'" do
-
-      context "and the lock file does not exist" do
-        let(:source_options) do
-          {
-            path: Pathname.new(lock_file_path).dirname.join("dne.json.lock").to_s,
-          }
-        end
-        it "raises a GitError"
-      end # context "and the lock file does not exist"
-    end # context "when a cookbook dependency uses a relative git path"
-  end
-
-  describe "#source_options_for_lock" do
-    it "adds the git commit hash"
-  end
-
+      end # it "omits the relative path of the policyfile from the source_options"
+    end # context "when using a relative path for the policyfile"
+  end # describe "#lock_data"
 end # describe ChefDK::Policyfile::GitLockFetcher

--- a/spec/unit/policyfile/git_lock_fetcher_spec.rb
+++ b/spec/unit/policyfile/git_lock_fetcher_spec.rb
@@ -1,0 +1,209 @@
+#
+# Copyright:: Copyright (c) 2018 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef-dk/policyfile/git_lock_fetcher"
+
+describe ChefDK::Policyfile::GitLockFetcher do
+
+  let(:revision_id) { "6fe753184c8946052d3231bb4212116df28d89a3a5f7ae52832ad408419dd5eb" }
+  let(:identifier) { "fab501cfaf747901bd82c1bc706beae7dc3a350c" }
+  let(:git_revision) { "8404a9e0b5c27c55d529e61222e14f950b6e4171" }
+  let(:rel) { "cookbooks/nested_cookbook" }
+  let(:cookbook_name) {"git-cookbook"}
+  let(:nested_cookbook_name) {"cookbooks/nested-cookbook"}
+  let(:repo) { "https://github.com/monkeynews/bananas" }
+
+  let(:minimal_lockfile_json) do
+    <<-E
+{
+  "revision_id": "#{revision_id}",
+  "name": "install-example",
+  "run_list": [
+    "recipe[#{cookbook_name}::default]"
+  ],
+  "cookbook_locks": {
+    "#{cookbook_name}": {
+      "version": "2.3.4",
+      "identifier": "#{identifier}",
+      "dotted_decimal_identifier": "70567763561641081.489844270461035.258281553147148",
+      "cache_key": "#{cookbook_name}-#{git_revision}",
+      "source_options": {
+        "git": "#{repo}",
+        "revision": "#{git_revision}"
+      }
+    }
+  },
+  "default_attributes": {},
+  "override_attributes": {},
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "#{cookbook_name}",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "#{cookbook_name} (2.3.4)": [
+
+      ]
+    }
+  }
+}
+E
+  end
+
+  def minimal_lockfile
+    FFI_Yajl::Parser.parse(minimal_lockfile_json)
+  end
+
+  let(:policy_name) { "git_fetcher" }
+  let(:policy_group) { "somegroup" }
+  let(:storage_config) { ChefDK::Policyfile::StorageConfig.new.use_policyfile("#{tempdir}/Policyfile.rb") }
+
+  let(:minimal_lockfile_modified) do
+    minimal_lockfile.tap do |lockfile|
+      lockfile["cookbook_locks"][cookbook_name]["source_options"] = {
+        "git" => repo,
+        "revision" => git_revision,
+      }
+    end
+  end
+
+  let(:minimal_lockfile_with_scm_info) do
+    minimal_lockfile_modified.tap do |lockfile|
+      lockfile["cookbook_locks"][cookbook_name]["scm_info"] = {
+        "scm" => "git",
+        "remote" => repo,
+        "revision" => git_revision,
+        "working_tree_clean" => true,
+        "published" => true,
+        "synchronized_remote_branches" => [
+          "origin/master"
+        ],
+      }
+    end
+  end
+
+  let(:source_options) do
+    {
+      git: repo,
+      revision: git_revision
+    }
+  end
+
+  let(:shellout) { instance_double("Mixlib::ShellOut", run_command: "git") }
+
+
+  describe "#lock_data" do
+    subject(:lock_data) { described_class.new(policy_name, source_options, storage_config).lock_data }
+
+    it "sets the source_options for dependencies" do
+      expect(Mixlib::ShellOut).to receive(:new).and_return(shellout).at_least(:twice)
+      allow(shellout).to receive(:error?).and_return(false)
+      allow(shellout).to receive(:stdout).and_return(minimal_lockfile_json)
+      allow(Dir).to receive(:chdir).and_return(0)
+
+      expect(lock_data).to include(minimal_lockfile_modified)
+    end
+
+    context "when using a relative path for the policyfile" do
+      let(:source_options_rel) do
+        source_options.collect{|k,v| [k.to_s, v]}.to_h.merge({"rel" => rel})
+      end
+
+      subject(:relative_path_fetcher) { described_class.new(policy_name, source_options_rel, storage_config) }
+
+      it "omits the relative of the policyfile from the source_options" do
+        subject { described_class.new(policy_name, source_options_rel, storage_config) }
+
+        expect(Mixlib::ShellOut).to receive(:new).and_return(shellout)
+        allow(shellout).to receive(:error?).and_return(false)
+        allow(shellout).to receive(:stdout).and_return(minimal_lockfile_json)
+        allow(Dir).to receive(:chdir).and_return(0)
+        allow_any_instance_of(described_class).to receive(:cache_path).and_return(
+          Pathname.new(relative_path_fetcher.storage_config.relative_paths_root)
+        )
+
+        expect(
+          relative_path_fetcher.lock_data["cookbook_locks"][cookbook_name]["source_options"]
+        ).to match(
+                   {
+                     "git" => repo,
+                     "revision" => git_revision,
+                   }
+                 )
+        expect(
+          relative_path_fetcher.lock_data["cookbook_locks"][cookbook_name]["source_options"]
+        ).not_to match(source_options_rel)
+      end
+
+    end
+
+    context "when a cookbook dependency uses a relative git path" do
+      let(:source_options_with_scm_info) { source_options.collect{|k,v| [k.to_s, v]}.to_h.merge(minimal_lockfile_with_scm_info) }
+
+      context "when the path is '.'" do
+        let(:source_options_with_rel_path_scm_info) do
+          source_options_with_scm_info["cookbook_locks"][cookbook_name]["scm_info"].tap do |scm_info|
+            scm_info["path"] = "/foo/bar"
+          end
+        end
+
+        subject(:foobar) { described_class.new(policy_name, source_options_with_rel_path_scm_info, storage_config) }
+
+        it "removes the 'path' key from the source_options" do
+          expect(Mixlib::ShellOut).to receive(:new).and_return(shellout)
+          allow(shellout).to receive(:error?).and_return(false)
+          allow(shellout).to receive(:stdout).and_return(minimal_lockfile_json)
+          allow(Dir).to receive(:chdir).and_return(0)
+          allow_any_instance_of(described_class).to receive(:cache_path).and_return(
+            Pathname.new(subject.storage_config.relative_paths_root)
+          )
+
+          require 'pry';binding.pry
+          expect(
+            foobar.lock_data["cookbook_locks"][cookbook_name]["source_options"]
+          ).to match(source_options_with_rel_path_scm_info)
+        end
+      end
+
+      context "when the path is prefixed with './'" do
+        let(:source_options) do
+          {
+            path: Pathname.new(lock_file_path).dirname.join("dne.json.lock").to_s,
+          }
+        end
+        it "raises a GitError"
+      end # context "when the path is prefixed with './'" do
+
+      context "and the lock file does not exist" do
+        let(:source_options) do
+          {
+            path: Pathname.new(lock_file_path).dirname.join("dne.json.lock").to_s,
+          }
+        end
+        it "raises a GitError"
+      end # context "and the lock file does not exist"
+    end # context "when a cookbook dependency uses a relative git path"
+  end
+
+  describe "#source_options_for_lock" do
+    it "adds the git commit hash"
+  end
+
+end # describe ChefDK::Policyfile::GitLockFetcher


### PR DESCRIPTION
### Description

This completes the specification as defined by RFC-097 by adding Git support for Policyfile Includes.

Example Usage:
```
name 'delightful_policy'

default_source :supermarket

run_list 'delightful_example::default'

include_policy 'base_policy',
               git: 'https://github.com/happycustomer/chef-repo.git',
               branch: master,
               path: 'cookbooks/base/Policyfile.lock.json'

cookbook 'delightful_example', path: './'
```
 - Implements [RFC-097](https://github.com/chef/chef-rfc/blob/master/rfc097-policyfile-includes.md)
 - Fixes [SUSTAIN-897]

### Issues Resolved

 - Internal issue SUSTAIN-897

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
