### PR TITLE
Generate a `CHANGELOG.md` for cookbooks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,11 @@
-# ChefDK 3.0.24 Release Notes
-
-## Cookbook generator creates a CHANGELOG.md
-
-`chef cookbook generate [cookbook_name]` now creates a `CHANGELOG.md` file.
-
 # ChefDK 3.0 Release Notes
 
 ## Platform Deprecation
 ChefDK is no longer is built or tested on OS X 10.10 in accordance with Chef's EOL policy.
 
+## Cookbook generator creates a CHANGELOG.md
+
+`chef cookbook generate [cookbook_name]` now creates a `CHANGELOG.md` file.
 
 # ChefDK 2.5 Release Notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+# ChefDK 3.0.24 Release Notes
+
+## Cookbook generator creates a CHANGELOG.md
+
+`chef cookbook generate [cookbook_name]` now creates a `CHANGELOG.md` file.
+
 # ChefDK 3.0 Release Notes
 
 ## Platform Deprecation

--- a/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/cookbook.rb
@@ -38,6 +38,12 @@ template "#{cookbook_dir}/README.md" do
   action :create_if_missing
 end
 
+# CHANGELOG
+template "#{cookbook_dir}/CHANGELOG.md" do
+  helpers(ChefDK::Generator::TemplateHelper)
+  action :create_if_missing
+end
+
 # chefignore
 cookbook_file "#{cookbook_dir}/chefignore"
 

--- a/lib/chef-dk/skeletons/code_generator/templates/default/CHANGELOG.md.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/CHANGELOG.md.erb
@@ -1,0 +1,11 @@
+# <%= cookbook_name %> CHANGELOG
+
+This file is used to list changes made in each version of the <%= cookbook_name %> cookbook.
+
+# 0.1.0
+
+Initial release.
+
+- change 0
+- change 1
+

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -41,6 +41,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
       LICENSE
       metadata.rb
       README.md
+      CHANGELOG.md
       recipes
       recipes/default.rb
       spec
@@ -445,6 +446,14 @@ OUTPUT
 
     describe "README.md" do
       let(:file) { File.join(tempdir, "new_cookbook", "README.md") }
+
+      include_examples "a generated file", :cookbook_name do
+        let(:line) { "# new_cookbook" }
+      end
+    end
+
+    describe "CHANGELOG.md" do
+      let(:file) { File.join(tempdir, "new_cookbook", "CHANGELOG.md") }
 
       include_examples "a generated file", :cookbook_name do
         let(:line) { "# new_cookbook" }


### PR DESCRIPTION
### Description

Generates a `CHANGELOG.md` for each cookbook when using the default generator.

### Issues Resolved

Inspired by [this question on discourse](https://discourse.chef.io/t/cookbook-changelog-rb/12984/1).

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Nathen Harvey <nharvey@chef.io>
