### PR TITLE
add vendor dir to default chefignore

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -55,6 +55,7 @@ examples/*
 Guardfile
 Procfile
 .kitchen*
+kitchen.yml*
 .rubocop.yml
 spec/*
 Rakefile


### PR DESCRIPTION
see chefspec/chefspec#870 where vendoring gems into a cookbook results
in a poor interaction with `:all_files` in the absence of a chefignore.

