### PR TITLE
set windows installer custom setup font to white

### DIFF
--- a/omnibus/resources/chefdk/msi/localization-en-us.wxl.erb
+++ b/omnibus/resources/chefdk/msi/localization-en-us.wxl.erb
@@ -9,6 +9,9 @@
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>
   <String Id="LicenseAgreementDlgDescription">{\WixUI_Font_Normal_White}Please read the following license agreement carefully</String>
 
+  <String Id="CustomizeDlgTitle">{\WixUI_Font_Title_White}Custom Setup</String>
+  <String Id="CustomizeDlgDescription">{\WixUI_Font_Normal_White}Select the way you want features to be installed.</String>
+
   <String Id="InstallDirDlgTitle">{\WixUI_Font_Title_White}Destination Folder</String>
   <String Id="InstallDirDlgDescription">{\WixUI_Font_Normal_White}Click Next to install to the default folder or click Change to choose another.</String>
 


### PR DESCRIPTION
The Custom Setup dialog was displaying its title and description text to the default black for font color. Set it to white here, so that the text is legible on the dark banner background.

Example of the hard-to-read dark text: 

![chefdk black font for custom setup dialog](https://user-images.githubusercontent.com/517302/40031291-fe201dac-57bc-11e8-89cd-aaa2a6653c8a.png)
