### PR TITLE
remove train+appbundler software dep

### DIFF
--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -30,6 +30,20 @@ dependency "liblzma"
 dependency "zlib"
 dependency "libarchive"
 
+#
+# NOTE: NO GEM DEPENDENCIES
+#
+# we do not add dependencies here on omnibus-software definitions that install gems.
+#
+# all of the gems for chef-dk must be installed in the mega bundle install below.
+#
+# doing bundle install / rake install in dependent software definitions causes gemsets
+# to get solved without some of the chef-dk constraints, which results in multiple different
+# versions of gems in the omnibus bundle.
+#
+# for gems that depend on c-libs, we include the c-libraries directly here.
+#
+
 # For berkshelf
 dependency "libarchive"
 
@@ -40,10 +54,8 @@ dependency "libzmq"
 dependency "ruby"
 dependency "rubygems"
 
-# depend on train so that we get the correctly built protobuf version
-dependency "train"
-
-dependency "appbundler"
+# for train
+dependency "google-protobuf"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
include a big old banner as to why, since its only obvious to me
and not obvious to everyone else, and we have no testing around
multiple gems any more.

