### PR TITLE
Fix hab plan to use correct gemspec name

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -16,7 +16,7 @@ docker_images:
   - chefdk
 
 habitat_packages:
-  - chefdk
+  - chef-dk
 
 github:
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -50,7 +50,7 @@ do_verify() {
 do_unpack() {
   # Unpack the gem we built to the source cache path. Building then unpacking
   # the gem reuses the file inclusion/exclusion rules defined in the gemspec.
-  gem unpack $PLAN_CONTEXT/../$pkg_name-$pkg_version.gem --target=$HAB_CACHE_SRC_PATH
+  gem unpack $PLAN_CONTEXT/../chef-dk-$pkg_version.gem --target=$HAB_CACHE_SRC_PATH
 }
 
 do_prepare() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,4 +1,4 @@
-pkg_name=chefdk
+pkg_name=chef-dk
 pkg_origin=chef
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 pkg_description="The Chef Developer Kit"
@@ -40,7 +40,7 @@ do_before() {
 do_download() {
   # Instead of downloading, build a gem based on the source in src/
   cd $PLAN_CONTEXT/..
-  gem build chef-dk.gemspec
+  gem build $pkg_name.gemspec
 }
 
 do_verify() {
@@ -50,7 +50,7 @@ do_verify() {
 do_unpack() {
   # Unpack the gem we built to the source cache path. Building then unpacking
   # the gem reuses the file inclusion/exclusion rules defined in the gemspec.
-  gem unpack $PLAN_CONTEXT/../chef-dk-$pkg_version.gem --target=$HAB_CACHE_SRC_PATH
+  gem unpack $PLAN_CONTEXT/../$pkg_name-$pkg_version.gem --target=$HAB_CACHE_SRC_PATH
 }
 
 do_prepare() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -40,7 +40,7 @@ do_before() {
 do_download() {
   # Instead of downloading, build a gem based on the source in src/
   cd $PLAN_CONTEXT/..
-  gem build $pkg_name.gemspec
+  gem build chef-dk.gemspec
 }
 
 do_verify() {


### PR DESCRIPTION
Signed-off-by: Jon Cowie <jonlives@gmail.com>

### Description

This fixes the habitat plan to look for the correct gemspec file (it's called chef-dk.gemspec)

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
