### PR TITLE
Add new option update-strategy for policy updates

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,6 +122,16 @@ include_policy 'base_policy',
                path: 'policies/base/Policyfile.lock.json'
 ```
 
+## Policyfiles: `chef update` gains `--update-strategy` option
+
+This option can take two values:
+
+- 'relaxed' (default value). This was the behavior before this release
+`chef update Policyfile.rb apache2` will upgrade apache2 and all its
+dependencies
+- 'strict'. This behavior is very strict: it updates only the cookbook(s)
+mentionned in the command line.
+
 ## Updated Tooling
 
 ### Test Kitchen

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -122,15 +122,10 @@ include_policy 'base_policy',
                path: 'policies/base/Policyfile.lock.json'
 ```
 
-## Policyfiles: `chef update` gains `--update-strategy` option
+## Policyfiles: `chef update` gains `--exclude-deps` flag
 
-This option can take two values:
-
-- 'relaxed' (default value). This was the behavior before this release
-`chef update Policyfile.rb apache2` will upgrade apache2 and all its
-dependencies
-- 'strict'. This behavior is very strict: it updates only the cookbook(s)
-mentionned in the command line.
+When using this, behavior is very strict: it updates only the cookbook(s)
+mentioned on command line.
 
 ## Updated Tooling
 

--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -67,6 +67,12 @@ BANNER
         default:      false,
         boolean:      true
 
+      option :update_strategy,
+        long:         "--update-strategy STRATEGY",
+        description:  "Use the given strategy for update. Possible values: relaxed (default), strict",
+        default:      "relaxed",
+        in:           %w{relaxed strict}
+
       attr_reader :policyfile_relative_path
 
       attr_accessor :ui
@@ -84,7 +90,7 @@ BANNER
       def run(params = [])
         return 1 unless apply_params!(params)
         attributes_updater.run
-        installer.run(@cookbooks_to_update) unless update_attributes_only?
+        installer.run(@cookbooks_to_update, config[:update_strategy]) unless update_attributes_only?
         0
       rescue PolicyfileServiceError => e
         handle_error(e)

--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -67,11 +67,11 @@ BANNER
         default:      false,
         boolean:      true
 
-      option :update_strategy,
-        long:         "--update-strategy STRATEGY",
-        description:  "Use the given strategy for update. Possible values: relaxed (default), strict",
-        default:      "relaxed",
-        in:           %w{relaxed strict}
+      option :exclude_deps,
+        long:         "--exclude-deps",
+        description:  "Only update cookbooks explicitely mentioned on the command line",
+        boolean:      true,
+        default:      false
 
       attr_reader :policyfile_relative_path
 
@@ -90,7 +90,7 @@ BANNER
       def run(params = [])
         return 1 unless apply_params!(params)
         attributes_updater.run
-        installer.run(@cookbooks_to_update, config[:update_strategy]) unless update_attributes_only?
+        installer.run(@cookbooks_to_update, config[:exclude_deps]) unless update_attributes_only?
         0
       rescue PolicyfileServiceError => e
         handle_error(e)

--- a/spec/unit/policyfile_services/update_spec.rb
+++ b/spec/unit/policyfile_services/update_spec.rb
@@ -130,11 +130,11 @@ EOH
       # elsewhere. We only check constraints changes
       expect(install_service).to receive(:generate_lock_and_install)
 
-      expect { install_service.run(["top-level"], update_strategy) }.not_to raise_error
+      expect { install_service.run(["top-level"], exclude_deps) }.not_to raise_error
     end
 
-    context "with relaxed update strategy" do
-      let(:update_strategy) { "relaxed" }
+    context "without exclude-deps flag" do
+      let(:exclude_deps) { false }
 
       it_behaves_like "regular update operation"
 
@@ -147,8 +147,8 @@ EOH
       end
     end
 
-    context "with strict update strategy" do
-      let(:update_strategy) { "strict" }
+    context "with exclude-deps flag" do
+      let(:exclude_deps) { true }
 
       it_behaves_like "regular update operation"
 


### PR DESCRIPTION
### Description


This option has two possible values for now:
- 'relaxed' (default value). This is the behavior before this patch.
  `chef update Policyfile.rb apache2` will upgrade apache2 and all its
  dependencies
- 'strict'. This behavior is very strict: it updates only the cookbook(s)
  mentionned in the command line.

The intent of this patch is to pave a possible way to have a third
strategy who would upgrade cookbooks mentionned on the command line to
their maximum existing version (possibly by upgrading other cookbooks if
necessary).

This patch already gives very fine control to users who want to update a
single cookbook (or a few cookbooks only).



### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
