### PR TITLE
Update mixlib-config / mixlib-install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,13 +30,13 @@ GEM
       mixlib-shellout (~> 2.0)
     artifactory (2.8.2)
     ast (2.4.0)
-    aws-sdk (2.11.80)
-      aws-sdk-resources (= 2.11.80)
-    aws-sdk-core (2.11.80)
+    aws-sdk (2.11.85)
+      aws-sdk-resources (= 2.11.85)
+    aws-sdk-core (2.11.85)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.80)
-      aws-sdk-core (= 2.11.80)
+    aws-sdk-resources (2.11.85)
+      aws-sdk-core (= 2.11.85)
     aws-sigv4 (1.0.3)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -280,7 +280,7 @@ GEM
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-openstack (0.1.26)
+    fog-openstack (0.1.27)
       fog-core (~> 1.45.0)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
@@ -412,7 +412,7 @@ GEM
       chef (>= 0.10.10)
       knife-windows (>= 0.5.14)
       mixlib-shellout
-    knife-ec2 (0.18.0)
+    knife-ec2 (0.18.2)
       fog-aws (~> 1.0)
       knife-windows (~> 1.0)
       mime-types
@@ -463,9 +463,9 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.11)
+    mixlib-config (2.2.12)
       tomlrb
-    mixlib-install (3.10.0)
+    mixlib-install (3.11.2)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -501,11 +501,11 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     netaddr (1.5.1)
-    nokogiri (1.8.3)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.3-x64-mingw32)
+    nokogiri (1.8.4-x64-mingw32)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.3-x86-mingw32)
+    nokogiri (1.8.4-x86-mingw32)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     notiffany (0.1.1)
@@ -513,7 +513,7 @@ GEM
       shellany (~> 0.0)
     octokit (4.9.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.2.0)
+    ohai (14.3.0)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -533,7 +533,7 @@ GEM
     os (0.9.6)
     paint (1.0.1)
     parallel (1.12.1)
-    parser (2.5.1.0)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
     parslet (1.8.2)
     plist (3.4.0)
@@ -626,7 +626,7 @@ GEM
     solve (4.0.0)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.73.4)
+    specinfra (2.74.0)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -31,13 +31,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.80)
-      aws-sdk-resources (= 2.11.80)
-    aws-sdk-core (2.11.80)
+    aws-sdk (2.11.85)
+      aws-sdk-resources (= 2.11.85)
+    aws-sdk-core (2.11.85)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.80)
-      aws-sdk-core (= 2.11.80)
+    aws-sdk-resources (2.11.85)
+      aws-sdk-core (= 2.11.85)
     aws-sigv4 (1.0.3)
     berkshelf (6.3.2)
       buff-config (~> 2.0)
@@ -191,9 +191,9 @@ GEM
       mixlib-log
     mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.11)
+    mixlib-config (2.2.12)
       tomlrb
-    mixlib-install (3.10.0)
+    mixlib-install (3.11.2)
       mixlib-shellout
       mixlib-versioning
       thor
@@ -298,7 +298,7 @@ GEM
     solve (4.0.0)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.73.4)
+    specinfra (2.74.0)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet


### PR DESCRIPTION
mixlib-config adds the is_default? method
mixlib-install properly detects Amazon Linux 2

Signed-off-by: Tim Smith <tsmith@chef.io>