### PR TITLE
[SHACK-304] Add Chef Apply as a gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,11 @@ group(:omnibus_package) do
   gem "listen"
   gem "dco"
 
+  # Right now we must import chef-apply as a gem into the ChefDK because this is where all the gem
+  # dependency resolution occurs. Putting it elsewhere endangers older ChefDK issues of gem version
+  # conflicts post-build.
+  gem "chef-apply"
+
   # For Delivery build node
   gem "chef-sugar"
   gem "mixlib-versioning"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,19 @@ GEM
     chef-api (0.8.0)
       logify (~> 0.1)
       mime-types
+    chef-apply (0.1.18)
+      chef (>= 14.0)
+      chef-dk (>= 3.0)
+      chef-telemetry
+      mixlib-cli
+      mixlib-config
+      mixlib-install
+      mixlib-log
+      pastel
+      r18n-desktop
+      toml-rb
+      train
+      tty-spinner
     chef-config (14.3.37)
       addressable
       fuzzyurl
@@ -172,6 +185,11 @@ GEM
       retryable
       winrm-elevated
     chef-sugar (4.0.0)
+    chef-telemetry (0.1.0)
+      chef-config
+      concurrent-ruby (~> 1.0)
+      ffi-yajl (~> 2.2)
+      http (~> 2.2)
     chef-vault (3.3.0)
     chef-zero (14.0.6)
       ffi-yajl (~> 2.2)
@@ -188,6 +206,7 @@ GEM
       rspec (~> 3.0)
     chefstyle (0.10.0)
       rubocop (= 0.55.0)
+    citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.2)
     coercible (1.0.0)
@@ -240,6 +259,7 @@ GEM
       resource_kit (~> 0.1.5)
       virtus (~> 1.0.3)
     equalizer (0.0.11)
+    equatable (0.5.0)
     erubis (2.7.0)
     excon (0.62.0)
     faraday (0.15.2)
@@ -479,8 +499,15 @@ GEM
     hashie (3.5.7)
     highline (1.7.10)
     htmlentities (4.3.4)
+    http (2.2.2)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    http-form_data (1.0.3)
+    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
@@ -666,6 +693,9 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     parslet (1.8.2)
+    pastel (0.7.2)
+      equatable (~> 0.5.0)
+      tty-color (~> 0.4.0)
     plist (3.4.0)
     polyglot (0.3.5)
     powerpack (0.1.2)
@@ -683,6 +713,9 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.0.2)
+    r18n-core (3.0.5)
+    r18n-desktop (3.0.5)
+      r18n-core (= 3.0.5)
     rack (2.0.5)
     rainbow (3.0.0)
     rake (12.3.1)
@@ -786,6 +819,8 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     timeliness (0.3.8)
+    toml-rb (1.1.1)
+      citrus (~> 3.0, > 3.0)
     tomlrb (1.2.7)
     train (1.4.24)
       aws-sdk (~> 2)
@@ -804,6 +839,10 @@ GEM
     treetop (1.6.10)
       polyglot (~> 0.3)
     trollop (2.1.3)
+    tty-color (0.4.3)
+    tty-cursor (0.6.0)
+    tty-spinner (0.8.0)
+      tty-cursor (>= 0.5.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
@@ -878,6 +917,7 @@ DEPENDENCIES
   berkshelf (>= 7.0)
   bundler
   chef (= 14.3.37)
+  chef-apply
   chef-dk!
   chef-provisioning (>= 2.7.1)
   chef-provisioning-aws (>= 3.0.2)

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -184,6 +184,15 @@ KITCHEN_YML
         end
       end
 
+      add_component "chef-apply" do |c|
+        c.gem_base_dir = "chef-apply"
+        c.unit_test do
+          bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
+          sh("#{embedded_bin("bundle")} exec rspec")
+        end
+        c.smoke_test { sh("#{bin("chef-run")} -v") }
+      end
+
       # entirely possible this needs to be driven by a utility method in chef-provisioning.
       add_component "chef-provisioning" do |c|
         c.gem_base_dir = "chef-dk"

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -79,7 +79,7 @@ build do
   appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs provisioning}, env: env
   appbundle "inspec", lockdir: project_dir, gem: "inspec", without: %w{deploy tools maintenance integration}, env: env
 
-  %w{chef-dk chef-vault ohai opscode-pushy-client cookstyle dco berkshelf}.each do |gem|
+  %w{chef-dk chef-apply chef-vault ohai opscode-pushy-client cookstyle dco berkshelf}.each do |gem|
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -42,6 +42,7 @@ describe ChefDK::Command::Verify do
       "tk-policyfile-provisioner",
       "chef-client",
       "chef-dk",
+      "chef-apply",
       "chef-provisioning",
       "chefspec",
       "generated-cookbooks-pass-chefspec",


### PR DESCRIPTION
### Description

ChefDK holds all the logic for the massive dependency resolution task.
Because of this we have to include Chef Apply as a gem dependency, even
though we only want to expose it via Chef Workstation and not Chef
Apply. That is why we do not appbundle it here but do appbundle it in
Chef Workstation.

As we move the dependency solving logic out of the ChefDK (per
https://github.com/chef/chef-rfc/pull/308) and seperate out components
(like policyfile and the 'chef' binary) we will eventually not need this
dependency here. But until that day...

### Issues Resolved

SHACK-304

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
