### PR TITLE
[SHACK-304] Habitat build fails with bundler error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       mime-types
     chef-apply (0.1.18)
       chef (>= 14.0)
-      chef-dk (3.1.6)
+      chef-dk (>= 3.0)
       chef-telemetry
       mixlib-cli
       mixlib-config


### PR DESCRIPTION
### Description

```
Fetching chef-apply 0.1.18
Downloading chef-apply-0.1.18 revealed dependencies not in the API or the
lockfile (chef-dk (>= 3.0)).
Either installing with `--full-index` or running `bundle update chef-apply`
should fix the problem.
```
Hoping this fixes ☝️ 

### Issues Resolved

SHACK-304

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>
