### PR TITLE
[SHACK-304] Expeditor version update needs to only update the ChefDK version

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -11,7 +11,9 @@ sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" lib/chef-dk
 # There is a bug (https://github.com/bundler/bundler/issues/5644) that is preventing
 # us from updating the chef-dk gem via `bundle update` or `bundle lock --update`.
 # Until that is addressed, let's replace the version using sed.
-sed -i -r "s/chef-dk\s\(.+\)$/chef-dk \($(cat VERSION)\)/" Gemfile.lock
+# We only replace the first instance because chef-apply now also has ChefDK as a
+# dependency, and we don't want to replace that constraint.
+sed -i -r "0,/chef-dk\s\(.+\)$/s/chef-dk\s\(.+\)$/chef-dk \($(cat VERSION)\)/" Gemfile.lock
 
 # Once Expeditor finshes executing this script, it will commit the changes and push
 # the commit as a new tag corresponding to the value in the VERSION file.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       mime-types
     chef-apply (0.1.18)
       chef (>= 14.0)
-      chef-dk (3.1.7)
+      chef-dk (>= 3.0)
       chef-telemetry
       mixlib-cli
       mixlib-config


### PR DESCRIPTION
### Description

Right now it also updates the chef-apply gem dependency, which causes
failures in the build pipeline. We want to leave that constraint alone.

See
https://github.com/chef/chef-dk/commit/a56aa76c07610c2e202bb845d6f2b6c01d1488fb
for an example of the error occuring.

### Issues Resolved

SHACK-304

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>