### PR TITLE
Pin ruby to 2.5.1 in habitat plan

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -14,7 +14,8 @@ pkg_build_deps=(
 pkg_deps=(
   core/glibc
   core/busybox-static
-  core/ruby
+  # if you change major or minor you also need to update the GEM_PATH below
+  core/ruby/2.5.1
   core/libxml2
   core/libxslt
   core/libiconv
@@ -134,9 +135,9 @@ wrap_ruby_bin() {
 #!$(pkg_path_for busybox-static)/bin/sh
 set -e
 if test -n "$DEBUG"; then set -x; fi
-export GEM_HOME="$pkg_prefix/ruby/2.4.0/"
-export GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.4.0:$(hab pkg path core/bundler):$pkg_prefix/ruby/2.4.0/:$GEM_HOME"
-export SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem 
+export GEM_HOME="$pkg_prefix/ruby/2.5.0/"
+export GEM_PATH="$(hab pkg path core/ruby)/lib/ruby/gems/2.5.0:$(hab pkg path core/bundler):$pkg_prefix/ruby/2.5.0/:$GEM_HOME"
+export SSL_CERT_FILE=$(hab pkg path core/cacerts)/ssl/cert.pem
 export APPBUNDLER_ALLOW_RVM=true
 unset RUBYOPT GEMRC
 exec $(pkg_path_for ruby)/bin/ruby ${real_cmd} \$@


### PR DESCRIPTION
### Description

Pins ruby to 2.5.1 in the habitat build and updates the GEM_PATH for the revision.

### Issues Resolved

Currently all of the app bundled binaries are broken by default because ruby 2.5.1 will meet the installation requirements but the plan expects 2.4.x.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

