### PR TITLE
Minor CI fixes and auto open PRs to bump deps when they're released

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -77,3 +77,128 @@ artifact_actions:
     - built_in:tag_docker_image
     - built_in:publish_rubygems
     - built_in:notify_chefio_slack_channels
+
+subscriptions:
+  - workload: ruby_gem_published:mixlib-archive-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:mixlib-authentication-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:mixlib-cli-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:mixlib-log-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:mixlib-shellout-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:chef-vault-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:chef-zero-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:ohai-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:inspec-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:train-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:win32-process-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:win32-service-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:win32-taskscheduler-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:ffi-yajl-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:libyajl2-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:cheffish-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: appbundler-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: chef-apply-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: chef-provisioning-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: chef-provisioning-aws-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: chef-provisioning-fog-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: chef-telemetry-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: chefstyle-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: cookstyle-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-acl-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-cloud-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-ec2-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-google-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-opc-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-push-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-tidy-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-vsphere-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: knife-windows-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: mixlib-install-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: mixlib-versioning-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: win32-event-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: win32-eventlog-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: win32-ipc-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: win32-mmap-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: win32-mutex-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: wmi-lite-*
+    actions:
+      - bash:.expeditor/update_dep.sh

--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -evx
+
+branch="expeditor/${GEM_NAME}_${VERSION}"
+git checkout -b "$branch"
+
+bundle update $GEM_NAME
+
+git add .
+git commit --message "Bump $GEM_NAME to $VERSION" --message "This pull request was triggered automatically via Expeditor when $GEM_NAME $VERSION was promoted to Rubygems."
+
+open_pull_request
+
+# Get back to master and cleanup the leftovers - any changed files left over at the end of this script will get committed to master.
+git checkout -
+git branch -D "$branch"

--- a/ci/version_show.sh
+++ b/ci/version_show.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ruby -Ilib -e "require \"chef-dk/version\"; puts ChefDK::VERSION"
+cat VERSION

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -66,18 +66,6 @@ namespace :dependencies do
     end
   end
 
-  def berks_update_task(task_name, dir)
-    desc "Update #{dir}/Berksfile.lock."
-    task task_name do
-      FileUtils.rm_f("#{dir}/Berksfile.lock")
-      Dir.chdir(dir) do
-        Bundler.with_clean_env do
-          sh "bundle exec berks install"
-        end
-      end
-    end
-  end
-
   bundle_update_locked_multiplatform_task :update_gemfile_lock, "."
   bundle_update_locked_multiplatform_task :update_omnibus_gemfile_lock, "omnibus"
   bundle_update_task :update_acceptance_gemfile_lock, "acceptance"

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016-2017, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2018, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+require "bundler"
+
 desc "Tasks to update and check dependencies"
 namespace :dependencies do
 
@@ -23,19 +25,19 @@ namespace :dependencies do
   desc "Update all dependencies. dependencies:update to update as little as possible."
   task :update do |t, rake_args|
     # FIXME: probably broken, and needs less indirection
-    system("#{File.join(Dir.pwd, "ci", "dependency_update.sh")}")
+    system((File.join(Dir.pwd, "ci", "dependency_update.sh")).to_s)
   end
 
   desc "Force update (when adding new gems to Gemfiles)"
   task :force_update do |t, rake_args|
     # FIXME: probably broken, and needs less indirection
     FileUtils.rm_f(File.join(Dir.pwd, ".bundle", "config"))
-    system("#{File.join(Dir.pwd, "ci", "dependency_update.sh")}")
+    system((File.join(Dir.pwd, "ci", "dependency_update.sh")).to_s)
   end
 
   # Update all dependencies to the latest constraint-matching version
   desc "Update all dependencies. dependencies:update to update as little as possible (CI-only)."
-  task :update_ci => %w{
+  task update_ci: %w{
                     dependencies:update_gemfile_lock
                     dependencies:update_omnibus_gemfile_lock
                     dependencies:update_acceptance_gemfile_lock
@@ -72,6 +74,6 @@ namespace :dependencies do
 end
 
 desc "Update all dependencies and check for outdated gems."
-task :dependencies_ci => [ "dependencies:update_ci" ]
-task :dependencies => [ "dependencies:update" ]
-task :update => [ "dependencies:update" ]
+task dependencies_ci: [ "dependencies:update_ci" ]
+task dependencies: [ "dependencies:update" ]
+task update: [ "dependencies:update" ]


### PR DESCRIPTION
Use expeditor subscriptions to open PRs when a new dep is released. Most of these aren't wired up in Expeditor yet, but I'm getting them all slowly.