### PR TITLE
Bump mixlib-archive to 0.4.16

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group(:omnibus_package) do
   gem "knife-windows", ">= 1.9.1"
   gem "knife-opc", ">= 0.4.0"
   gem "knife-vsphere", ">= 2.1.1"
-  gem "mixlib-archive", "= 0.4.6" # FIXME: equality pinned for now because windows is busted on 0.4.7
+  gem "mixlib-archive", ">= 0.4.16"
   gem "ohai", ">= 14.0.29"
   gem "net-ssh", ">= 4.2.0"
   gem "test-kitchen", ">= 1.23.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,7 +492,7 @@ GEM
     mini_portile2 (2.3.0)
     minitar (0.6.1)
     minitest (5.11.3)
-    mixlib-archive (0.4.6)
+    mixlib-archive (0.4.16)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
@@ -828,7 +828,7 @@ DEPENDENCIES
   knife-vsphere (>= 2.1.1)
   knife-windows (>= 1.9.1)
   listen
-  mixlib-archive (= 0.4.6)
+  mixlib-archive (>= 0.4.16)
   mixlib-install
   mixlib-versioning
   net-ssh (>= 4.2.0)


### PR DESCRIPTION
### Description

Update mixlib-archive to resolve chdir issues with TK and Berkshelf.

### Issues Resolved

#1663 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
