### PR TITLE
Add missing license field to the Gemspec

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.email         = [ "dan@chef.io", "lamont@chef.io", "serdar@chef.io"]
   gem.description   = "A streamlined development and deployment workflow for Chef platform."
   gem.summary       = gem.description
+  gem.license       = "Apache-2.0"
   gem.homepage      = "https://www.chef.io/"
 
   gem.required_ruby_version = ">= 2.4"


### PR DESCRIPTION
This way it shows up as Apache-2.0 on rubygems

Signed-off-by: Tim Smith <tsmith@chef.io>