### PR TITLE
Add a sleep to the dep updater in Expeditor

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
 
+############################################################################
+# What is this script?
+#
+# Chef-DK uses a workflow tool called Expeditor to manage version bumps, changelogs
+# and releases. When a dependency of chef is released, expeditor is triggered
+# against this repository to run this script. It bumps our gem lock files and opens
+# a PR. That way humans can do hard work and bots can open gem bump PRs.
+############################################################################
+
 set -evx
 
 branch="expeditor/${GEM_NAME}_${VERSION}"
 git checkout -b "$branch"
 
 bundle install
+
+# it appears that the gem that triggers this script fires off this script before
+# the gem is actually available via bundler on rubygems.org.
+sleep 120
+
 bundle exec rake dependencies:update
 
 git add .
-git commit --message "Bump $GEM_NAME to $VERSION" --message "This pull request was triggered automatically via Expeditor when $GEM_NAME $VERSION was promoted to Rubygems." --message "Obvious fix - no DCO required"
+
+# give a friendly message for the commit and make sure it's noted for any future audit of our codebase that no
+# DCO sign-off is needed for this sort of PR since it contains no intellectual property
+git commit --message "Bump $GEM_NAME to $VERSION" --message "This pull request was triggered automatically via Expeditor when $GEM_NAME $VERSION was promoted to Rubygems." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."
 
 open_pull_request
 

--- a/.expeditor/update_dockerfile.sh
+++ b/.expeditor/update_dockerfile.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+############################################################################
+# What is this script?
+#
+# Chef-DK uses a workflow tool called Expeditor to manage version bumps, changelogs
+# and releases. When the current release of Chef-DK is promoted to stable this script
+# is run by Expeditor to update the version in the Dockerfile to match the stable
+# release.
+############################################################################
+
 set -evx
 
 sed -i -r "s/^ARG VERSION=.+/ARG VERSION=${VERSION}/" Dockerfile


### PR DESCRIPTION
Attempt to wait long enough for rubygems to have the gem we need.

Signed-off-by: Tim Smith <tsmith@chef.io>
