### PR TITLE
Update to Foodcritic 14.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
     fog-xml (0.1.3)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
-    foodcritic (14.0.0)
+    foodcritic (14.1.0)
       cucumber-core (>= 1.3)
       erubis
       ffi-yajl (~> 2.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.2.0)
     nori (2.6.0)
-    octokit (4.10.0)
+    octokit (4.11.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (14.4.2)
       chef-config (>= 12.8, < 15)


### PR DESCRIPTION
This gives us metadata for all the new resources in Chef 14.3 / 14.4

@tyler-ball This should go in before the DK release so we have the latest metadata.

Signed-off-by: Tim Smith <tsmith@chef.io>
