### PR TITLE
Use subscriptions and fix expeditor warning

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -64,21 +64,20 @@ merge_actions:
         - "Expeditor: Skip All"
       only_if: built_in:bump_version
 
-# These actions are taken, in the order specified, when an Omnibus artifact is promoted
-# within Chef's internal artifact storage system.
-artifact_actions:
-  promoted_to_unstable:
-    - built_in:build_docker_image
-  promoted_to_current:
-    - built_in:tag_docker_image
-  promoted_to_stable:
-    - built_in:rollover_changelog
-    - bash:.expeditor/update_dockerfile.sh
-    - built_in:tag_docker_image
-    - built_in:publish_rubygems
-    - built_in:notify_chefio_slack_channels
-
 subscriptions:
+  - workload: artifact_published:unstable:chefdk:3*
+    actions:
+      - built_in:build_docker_image
+  - workload: artifact_published:current:chefdk:3*
+    actions:
+      - built_in:tag_docker_image
+  - workload: artifact_published:stable:chefdk:3*
+    actions:
+      - built_in:rollover_changelog
+      - bash:.expeditor/update_dockerfile.sh
+      - built_in:tag_docker_image
+      - built_in:publish_rubygems
+      - built_in:notify_chefio_slack_channels
   - workload: artifact_published:stable:chef:14*
     actions:
       - bash:.expeditor/update_chef.sh


### PR DESCRIPTION
Signed-off-by: Seth Thomas <sthomas@chef.io>

### Description

Update expeditor config to use subscriptions as artifact_actions is deprecated