### PR TITLE
Include more information about the policy in `chef push` output

### DIFF
--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -28,6 +28,7 @@ describe ChefDK::Policyfile::Uploader do
     {
       "name" => "example",
       "run_list" => [ "recipe[omnibus::default]" ],
+      "revision_id" => "f4b29d87c36de67cbfd9aa3147df77cebf9f719e8c884036b3cf34ba94773ca5",
       "cookbook_locks" => {
         "omnibus" => {
           "version" => "2.2.0",


### PR DESCRIPTION
### Description

The goal of this change is to surface more information so that it's
easier for users to detect a certain class of mistakes (e.g., run
`chef push` from the wrong working directory) and to produce a more
useful log of what `chef push` did when run in a Ci context.

Possible downside is that the extra information may be offputting to
novice users, but that's probably a wash as some novices would likely
appreciate the additional detail about the consequences of the command
they are running.

#### Old output:

```
Uploading policy to policy group new_pgroup
< other stuff >
```

#### New output:

```
Uploading policy jenkins (d064016951) to policy group new_pgroup
< other stuff >
```

### Issues Resolved

Inspired by a debugging session in Chef Software internal slack.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>