### PR TITLE
Update chef-vault to 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group(:omnibus_package) do
   gem "chef-provisioning", ">= 2.7.1", group: :provisioning
   gem "chef-provisioning-aws", ">= 3.0.2", group: :provisioning
   gem "chef-provisioning-fog", ">= 0.26.1", group: :provisioning
-  gem "chef-vault", ">= 3.3.0"
+  gem "chef-vault", ">= 3.4.1"
   # Expeditor manages the version of chef released to Rubygems. We only release 'stable' chef
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       concurrent-ruby (~> 1.0)
       ffi-yajl (~> 2.2)
       http (~> 2.2)
-    chef-vault (3.4.0)
+    chef-vault (3.4.1)
     chef-zero (14.0.6)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -801,7 +801,7 @@ DEPENDENCIES
   chef-provisioning-aws (>= 3.0.2)
   chef-provisioning-fog (>= 0.26.1)
   chef-sugar
-  chef-vault (>= 3.3.0)
+  chef-vault (>= 3.4.1)
   cheffish (>= 14.0.1)
   chefspec (>= 7.3.0)
   chefstyle


### PR DESCRIPTION
Require at least 3.4.1 since 3.4.0 is broken for appbundling

Signed-off-by: Tim Smith <tsmith@chef.io>