### PR TITLE
Remove the old provisioning readme

### DIFF
--- a/PROVISION_README.md
+++ b/PROVISION_README.md
@@ -1,3 +1,0 @@
-# `chef provision` Command README
-
-`chef provision` is now documented on [docs.chef.io](https://docs.chef.io/ctl_chef.html#chef-provision).


### PR DESCRIPTION
Nothing links to this according to Google.

Signed-off-by: Tim Smith <tsmith@chef.io>