### PR TITLE
Enable x86_64-linux-kernel2 habitat builds for chef-dk

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -16,7 +16,8 @@ docker_images:
   - chefdk
 
 habitat_packages:
-  - chef-dk
+  - chef-dk:
+      also_build_for_linux_kernel2: true
 
 github:
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file


### PR DESCRIPTION
This PR enables Habitat package builds of chef-dk for the x86_64-linux-kernel2 PackageTarget. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>
