### PR TITLE
Update omnibus kitchen config to match chef-client

### DIFF
--- a/omnibus/.gitignore
+++ b/omnibus/.gitignore
@@ -1,8 +1,9 @@
 binstubs
 .bundle
 vendor/bundle
-pkg/
-.kitchen.local.yml
+pkg/*
+kitchen.local.yml
+bin/*
 files/chef-server-cookbooks/cache/
 files/msi/ChefClient-Config.wxi
 cookbooks

--- a/omnibus/.kitchen.vmware.yml
+++ b/omnibus/.kitchen.vmware.yml
@@ -1,6 +1,0 @@
-driver:
-  name: vagrant
-  provider: vmware_fusion
-  customize:
-    numvcpus: 4
-    memsize: 4096

--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -2,8 +2,11 @@ source "https://supermarket.chef.io"
 
 cookbook "omnibus"
 
+# Uncomment to use the latest version of the Omnibus cookbook from GitHub
+# cookbook 'omnibus', github: 'chef-cookbooks/omnibus'
+
 group :integration do
-  cookbook "apt",      "~> 2.3"
-  cookbook "freebsd",  "~> 0.1"
-  cookbook "yum-epel", "~> 0.3"
+  cookbook "apt"
+  cookbook "freebsd"
+  cookbook "yum-epel"
 end

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -1,21 +1,20 @@
-ChefDK Omnibus project
-============================
+# ChefDK Omnibus project
+
 This project creates full-stack platform-specific packages for ChefDK.
 
 Note that the repository name is chef-dk but the omnibus project definition is
 chefdk. This is a historical artifact that may eventually get fixed.
 
-Installation
-------------
-You must have a sane Ruby 1.9+ environment with Bundler installed. Ensure all
-the required gems are installed:
+## Installation
+
+You must have a sane Ruby environment with Bundler installed. Ensure all the required gems are installed:
 
 ```shell
 $ bundle install --without development
 ```
 
-Usage
------
+## Usage
+
 ### Build
 
 You create a platform-specific package using the `build project` command:
@@ -24,23 +23,17 @@ You create a platform-specific package using the `build project` command:
 $ bundle exec omnibus build chefdk
 ```
 
-The platform/architecture type of the package created will match the platform
-where the `build project` command is invoked. For example, running this command
-on a MacBook Pro will generate a Mac OS X package. After the build completes
-packages will be available in the `pkg/` folder.
+The platform/architecture type of the package created will match the platform where the `build project` command is invoked. For example, running this command on a MacBook Pro will generate a macOS package. After the build completes packages will be available in the `pkg/` folder.
 
 ### Clean
 
-You can clean up all temporary files generated during the build process with
-the `clean` command:
+You can clean up all temporary files generated during the build process with the `clean` command:
 
 ```shell
 $ bundle exec omnibus clean chefdk
 ```
 
-Adding the `--purge` purge option removes __ALL__ files generated during the
-build including the project install directory (`/opt/chef`) and
-the package cache directory (`/var/cache/omnibus/pkg`):
+Adding the `--purge` purge option removes **ALL** files generated during the build including the project install directory (`/opt/chefdk`) and the package cache directory (`/var/cache/omnibus/pkg`):
 
 ```shell
 $ bundle exec omnibus clean chefdk --purge
@@ -48,9 +41,7 @@ $ bundle exec omnibus clean chefdk --purge
 
 ### Publish
 
-Omnibus has a built-in mechanism for releasing to a variety of "backends", such
-as Amazon S3 and Artifactory. You must set the proper credentials in your `omnibus.rb`
-config file or specify them via the command line.
+Omnibus has a built-in mechanism for releasing to a variety of "backends", such as Amazon S3 and Artifactory. You must set the proper credentials in your `omnibus.rb` config file or specify them via the command line.
 
 ```shell
 $ bundle exec omnibus publish path/to/*.deb --backend s3
@@ -58,36 +49,24 @@ $ bundle exec omnibus publish path/to/*.deb --backend s3
 
 ### Help
 
-Full help for the Omnibus command line interface can be accessed with the
-`help` command:
+Full help for the Omnibus command line interface can be accessed with the `help` command:
 
 ```shell
 $ bundle exec omnibus help
 ```
 
-Kitchen-based Build Environment
--------------------------------
-Every Omnibus project ships will a project-specific
-[Berksfile](http://berkshelf.com/) that will allow you to build your omnibus projects on all of the projects listed
-in the `.kitchen.yml`. You can add/remove additional platforms as needed by
-changing the list found in the `.kitchen.yml` `platforms` YAML stanza.
+## Kitchen-based Build Environment
 
-This build environment is designed to get you up-and-running quickly. However,
-there is nothing that restricts you to building on other platforms. Simply use
-the [omnibus cookbook](https://github.com/chef-cookbooks/omnibus) to setup
-your desired platform and execute the build steps listed above.
+Every Omnibus project ships will a project-specific [Berksfile](https://docs.chef.io/berkshelf.html) that will allow you to build your omnibus projects on all of the projects listed in the `kitchen.yml`. You can add/remove additional platforms as needed by changing the list found in the `kitchen.yml` `platforms` YAML stanza.
 
-The default build environment requires Test Kitchen and VirtualBox for local
-development. Test Kitchen also exposes the ability to provision instances using
-various cloud providers like AWS, DigitalOcean, or OpenStack. For more
-information, please see the [Test Kitchen documentation](http://kitchen.ci).
+This build environment is designed to get you up-and-running quickly. However, there is nothing that restricts you to building on other platforms. Simply use the [omnibus cookbook](https://github.com/chef-cookbooks/omnibus) to setup your desired platform and execute the build steps listed above.
 
-Once you have tweaked your `.kitchen.yml` (or `.kitchen.local.yml`) to your
-liking, you can bring up an individual build environment using the `kitchen`
-command.
+The default build environment requires Test Kitchen and VirtualBox for local development. Test Kitchen also exposes the ability to provision instances using various cloud providers like AWS, DigitalOcean, or OpenStack. For more information, please see the [Test Kitchen documentation](http://kitchen.ci).
+
+Once you have tweaked your `kitchen.yml` (or `kitchen.local.yml`) to your liking, you can bring up an individual build environment using the `kitchen` command.
 
 ```shell
-$ bundle exec kitchen converge chefdk-ubuntu-1204
+$ bundle exec kitchen converge chefdk-ubuntu-1804
 ```
 
 Then login to the instance and build the project as described in the Usage
@@ -122,13 +101,12 @@ C:\vagrant\code\chef-dk\omnibus>bundle install --without development
 C:\vagrant\code\chef-dk\omnibus>bundle exec omnibus build chefdk -l internal
 ```
 
-For a complete list of all commands and platforms, run `kitchen list` or
-`kitchen help`.
+For a complete list of all commands and platforms, run `kitchen list` or `kitchen help`.
 
-License
--------
+## License
+
 ```text
-Copyright 2012-2014 Chef Software, Inc.
+Copyright 2012-2018, Chef Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
+++ b/omnibus/files/openssl-customization/windows/ssl_env_hack.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software, Inc.
+# Copyright:: Copyright 2014-2018, Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/omnibus/kitchen.yml
+++ b/omnibus/kitchen.yml
@@ -17,7 +17,6 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: true # Always install the latest version of Chef
   attributes:
     vagrant:
       this_key_exists_so_we_have_a_vagrant_key: true
@@ -28,43 +27,48 @@ provisioner:
       install_dir: /opt/chefdk
 
 platforms:
-  - name: centos-6.7
+  - name: centos-6
     run_list: yum-epel::default
-  - name: centos-7.3
+  - name: centos-7
     run_list: yum-epel::default
-  - name: debian-7.9
+  - name: debian-8
     run_list: apt::default
-  - name: debian-8.2
-    run_list: apt::default
-  - name: ubuntu-12.04
+  - name: debian-9
     run_list: apt::default
   - name: ubuntu-14.04
     run_list: apt::default
-  # The following (private) boxes are shared via Atlas and are only
+  - name: ubuntu-16.04
+    run_list: apt::default
+  - name: ubuntu-18.04
+    run_list: apt::default
+  # The following (private) boxes are shared via Vagrant Cloud and are only
   # available to users working for Chef. Sorry, it's about software licensing.
   #
   # Chef-internal users, you will need to:
-  # 1.  Create an Atlas account:  https://atlas.hashicorp.com/
-  # 2.  Ping #eng-services-support with your Atlas account name
-  #     to be added to the relevant team in Atlas,
-  # 3.  Do `vagrant login` with your Atlas creds so that you can download
-  #     the private boxes.
+  # 1.  Create an Vagrant Cloud account:  http://vagrantcloud.com/
+  # 2.  Ping #releng-support with your account name to be added to the relevant team.
+  # 3.  Do `vagrant login` with your creds so that you can download the private boxes.
   #
-  # The Mac OS X boxes are VMware only also. You can enable VMware Fusion
-  # by activating the `.kitchen.vmware.yml` file with the `KITCHEN_LOCAL_YAML`
+  # The macOS boxes are VMware only also. You can enable VMware Fusion
+  # by activating the `kitchen.vmware.yml` file with the `KITCHEN_LOCAL_YAML`
   # environment variable:
   #
-  #   KITCHEN_LOCAL_YAML=.kitchen.vmware.yml kitchen converge chefdk-macosx-109
+  #   KITCHEN_LOCAL_YAML=kitchen.vmware.yml kitchen converge chefdk-macosx-1011
   #
-  - name: macosx-10.9
+  # OSX
+  <% %w(
+    macosx-10.11
+    macos-10.12
+    macos-10.13
+  ).each do |mac_version| %>
+  - name: <%= mac_version %>
     driver:
-      box: chef/macosx-10.9 # private
-  - name: macosx-10.10
-    driver:
-      box: chef/macosx-10.10 # private
-  - name: macosx-10.11
-    driver:
-      box: chef/macosx-10.11 # private
+      provider: vmware_fusion
+      customize:
+        numvcpus: 4
+        memsize: 4096
+  <% end %>
+
   # By adding an `i386` to the name the Omnibus cookbook's `load-omnibus-toolchain.bat`
   # will load the 32-bit version of the MinGW toolchain.
   - name: windows-2012r2-standard-i386


### PR DESCRIPTION
This syncs a good portion of the omnibus kitchen config to match that now in chef-client. It modernizes the kitchen config and uses boxes that match what we actually ship.

Signed-off-by: Tim Smith <tsmith@chef.io>