### PR TITLE
Switch from chef-cleanup to ruby-cleanup definition

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -79,7 +79,7 @@ if windows?
   dependency "ruby-windows-system-libraries"
 end
 
-dependency "chef-cleanup"
+dependency "ruby-cleanup"
 
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]


### PR DESCRIPTION
This should unbreak the build.

Signed-off-by: Tim Smith <tsmith@chef.io>