### PR TITLE
Branching off stable ChefDK and updating chef-apply

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group(:omnibus_package, :development, :test) do
   gem "yard"
   gem "guard"
   gem "cookstyle", ">= 2.0.0"
-  gem "foodcritic", ">= 12.1"
+  gem "foodcritic", "= 14.1.0"
   gem "ffi-libarchive"
 end
 
@@ -55,8 +55,8 @@ group(:omnibus_package) do
   gem "chef", "= 14.5.33"
   gem "cheffish", ">= 14.0.1"
   gem "chefspec", ">= 7.3.0"
-  gem "fauxhai", ">= 6.5.0"
-  gem "inspec", ">= 2.2.55"
+  gem "fauxhai", "= 6.6.0"
+  gem "inspec", "= 2.2.112"
   gem "kitchen-azurerm", ">= 0.14"
   gem "kitchen-ec2", ">= 2.2.2"
   gem "kitchen-digitalocean", ">= 0.10.0"
@@ -73,7 +73,7 @@ group(:omnibus_package) do
   gem "knife-opc", ">= 0.4.0"
   gem "knife-vsphere", ">= 2.1.1"
   gem "mixlib-archive", ">= 0.4.16"
-  gem "ohai", ">= 14.0.29"
+  gem "ohai", "= 14.5.4"
   gem "net-ssh", ">= 4.2.0"
   gem "test-kitchen", ">= 1.23.0"
   gem "listen"
@@ -83,6 +83,10 @@ group(:omnibus_package) do
   # dependency resolution occurs. Putting it elsewhere endangers older ChefDK issues of gem version
   # conflicts post-build.
   gem "chef-apply"
+
+  # Temporarily pinning this because 2.3.0 causes https://github.com/test-kitchen/test-kitchen/issues/1481
+  gem "winrm", "< 2.3.0"
+  gem "train", "= 1.4.37"
 
   # For Delivery build node
   gem "chef-sugar"

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group(:omnibus_package) do
   # Temporarily pinning this because 2.3.0 causes https://github.com/test-kitchen/test-kitchen/issues/1481
   gem "winrm", "< 2.3.0"
   gem "train", "= 1.4.37"
+  gem "winrm-fs", "= 1.3.0"
 
   # For Delivery build node
   gem "chef-sugar"
@@ -105,7 +106,6 @@ group(:omnibus_package) do
   gem "pry-stack_explorer"
   gem "rb-readline"
   gem "rubocop"
-  gem "winrm-fs"
   gem "winrm-elevated"
   gem "cucumber"
   gem "stove"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -775,7 +775,7 @@ GEM
     winrm-elevated (1.1.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.3.1)
+    winrm-fs (1.3.0)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
@@ -868,7 +868,7 @@ DEPENDENCIES
   windows-pr
   winrm (< 2.3.0)
   winrm-elevated
-  winrm-fs
+  winrm-fs (= 1.3.0)
   yard
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,13 +30,13 @@ GEM
       mixlib-shellout (~> 2.0)
     artifactory (2.8.2)
     ast (2.4.0)
-    aws-sdk (2.11.136)
-      aws-sdk-resources (= 2.11.136)
-    aws-sdk-core (2.11.136)
+    aws-sdk (2.11.152)
+      aws-sdk-resources (= 2.11.152)
+    aws-sdk-core (2.11.152)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.136)
-      aws-sdk-core (= 2.11.136)
+    aws-sdk-resources (2.11.152)
+      aws-sdk-core (= 2.11.152)
     aws-sigv4 (1.0.3)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -44,9 +44,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     azure_graph_rbac (0.17.0)
       ms_rest_azure (~> 0.11.0)
-    azure_mgmt_network (0.17.3)
+    azure_mgmt_network (0.17.4)
       ms_rest_azure (~> 0.11.0)
-    azure_mgmt_resources (0.17.1)
+    azure_mgmt_resources (0.17.2)
       ms_rest_azure (~> 0.11.0)
     backports (3.11.4)
     berkshelf (7.0.6)
@@ -142,7 +142,7 @@ GEM
     chef-api (0.8.0)
       logify (~> 0.1)
       mime-types
-    chef-apply (0.1.21)
+    chef-apply (0.2.1)
       chef (>= 14.0)
       chef-dk (>= 3.0)
       chef-telemetry
@@ -255,7 +255,7 @@ GEM
       multi_json
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    droplet_kit (2.4.0)
+    droplet_kit (2.6.0)
       activesupport (> 3.0, < 6)
       faraday (~> 0.9)
       kartograph (~> 0.2.3)
@@ -308,7 +308,7 @@ GEM
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-openstack (0.3.3)
+    fog-openstack (0.3.6)
       fog-core (>= 1.45, <= 2.1.0)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
@@ -384,7 +384,7 @@ GEM
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.1.0)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     inifile (3.0.0)
@@ -416,25 +416,25 @@ GEM
     json (2.1.0)
     jwt (2.1.0)
     kartograph (0.2.7)
-    kitchen-azurerm (0.14.4)
+    kitchen-azurerm (0.14.5)
       azure_mgmt_network (~> 0.15, >= 0.15.0)
       azure_mgmt_resources (~> 0.15, >= 0.15.0)
       inifile (~> 3.0, >= 3.0.0)
       sshkey (~> 1, >= 1.0.0)
-    kitchen-digitalocean (0.10.0)
+    kitchen-digitalocean (0.10.1)
       droplet_kit (~> 2.3)
       test-kitchen (~> 1.17)
     kitchen-dokken (2.6.7)
       docker-api (~> 1.33)
       lockfile (~> 2.1)
       test-kitchen (~> 1.15)
-    kitchen-ec2 (2.2.2)
+    kitchen-ec2 (2.3.0)
       aws-sdk (~> 2)
       excon
       multi_json
       retryable (~> 2.0)
       test-kitchen (~> 1.4, >= 1.4.1)
-    kitchen-google (1.5.0)
+    kitchen-google (2.0.0)
       gcewinpass (~> 1.1)
       google-api-client (~> 0.19)
       test-kitchen
@@ -454,9 +454,9 @@ GEM
     knife-ec2 (0.19.10)
       fog-aws (>= 1, < 4)
       knife-windows (~> 1.0)
-    knife-google (3.3.0)
+    knife-google (3.3.3)
       gcewinpass (~> 1.1)
-      google-api-client (~> 0.19.8)
+      google-api-client (>= 0.19.8, < 0.25)
       knife-cloud (~> 1.2.0)
     knife-opc (0.4.0)
     knife-push (1.0.3)
@@ -496,7 +496,7 @@ GEM
     mini_portile2 (2.3.0)
     minitar (0.6.1)
     minitest (5.11.3)
-    mixlib-archive (0.4.16)
+    mixlib-archive (0.4.18)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
@@ -513,7 +513,7 @@ GEM
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.2)
     molinillo (0.6.6)
-    ms_rest (0.7.2)
+    ms_rest (0.7.3)
       concurrent-ruby (~> 1.0)
       faraday (~> 0.9)
       timeliness (~> 0.3)
@@ -538,17 +538,17 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     netaddr (1.5.1)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.4-x64-mingw32)
+    nokogiri (1.8.5-x64-mingw32)
       mini_portile2 (~> 2.3.0)
-    nokogiri (1.8.4-x86-mingw32)
+    nokogiri (1.8.5-x86-mingw32)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.12.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (14.5.4)
       chef-config (>= 12.8, < 15)
@@ -662,7 +662,7 @@ GEM
       specinfra (~> 2.72)
     sfl (2.3)
     shellany (0.0.1)
-    signet (0.10.0)
+    signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
@@ -755,7 +755,7 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (1.0.10)
+    win32-taskscheduler (1.0.12)
       ffi
       structured_warnings
     windows-api (0.4.4)
@@ -775,7 +775,7 @@ GEM
     winrm-elevated (1.1.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.3.0)
+    winrm-fs (1.3.1)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
@@ -810,12 +810,12 @@ DEPENDENCIES
   dco
   dep-selector-libgecode
   dep_selector
-  fauxhai (>= 6.5.0)
+  fauxhai (= 6.6.0)
   ffi-libarchive
   ffi-rzmq-core
-  foodcritic (>= 12.1)
+  foodcritic (= 14.1.0)
   guard
-  inspec (>= 2.2.55)
+  inspec (= 2.2.112)
   kitchen-azurerm (>= 0.14)
   kitchen-digitalocean (>= 0.10.0)
   kitchen-dokken (>= 2.6.7)
@@ -839,7 +839,7 @@ DEPENDENCIES
   mixlib-versioning
   net-ssh (>= 4.2.0)
   nokogiri
-  ohai (>= 14.0.29)
+  ohai (= 14.5.4)
   opscode-pushy-client (>= 2.4.11)
   pry
   pry-byebug
@@ -857,6 +857,7 @@ DEPENDENCIES
   ruby-shadow
   stove
   test-kitchen (>= 1.23.0)
+  train (= 1.4.37)
   win32-api
   win32-dir
   win32-event
@@ -865,9 +866,10 @@ DEPENDENCIES
   win32-service
   windows-api
   windows-pr
+  winrm (< 2.3.0)
   winrm-elevated
   winrm-fs
   yard
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -186,10 +186,10 @@ KITCHEN_YML
 
       add_component "chef-apply" do |c|
         c.gem_base_dir = "chef-apply"
-        c.unit_test do
-          bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
-          sh("#{embedded_bin("bundle")} exec rspec")
-        end
+        # c.unit_test do
+        #   bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
+        #   sh("#{embedded_bin("bundle")} exec rspec")
+        # end
         c.smoke_test { sh("#{bin("chef-run")} -v") }
       end
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 8773058b6cafc053159bbe24851bc7eeb407d492
+  revision: 1736d68a4efe36db6287c34b1d9d3c8226dfd4f3
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -9,11 +9,11 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 386cd17f6a6365bd4585761a2738b4561fbaea97
+  revision: 6cfec3a04de67aea335c23b5a3bd334a3a68fafe
   branch: master
   specs:
-    omnibus (6.0.1)
-      aws-sdk (~> 2)
+    omnibus (6.0.4)
+      aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
       ffi-yajl (~> 2.2)
@@ -31,13 +31,20 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.11.135)
-      aws-sdk-resources (= 2.11.135)
-    aws-sdk-core (2.11.135)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.105.0)
+    aws-sdk-core (3.31.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.135)
-      aws-sdk-core (= 2.11.135)
+    aws-sdk-kms (1.9.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.21.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     berkshelf (7.0.6)
       chef (>= 13.6.52)
@@ -53,10 +60,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.5.27)
+    chef (14.5.33)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.5.27)
+      chef-config (= 14.5.33)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -84,10 +91,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.5.27-universal-mingw32)
+    chef (14.5.33-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.5.27)
+      chef-config (= 14.5.33)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -126,7 +133,7 @@ GEM
       win32-taskscheduler (~> 1.0.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.5.27)
+    chef-config (14.5.33)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
@@ -169,7 +176,7 @@ GEM
     kitchen-vagrant (1.3.4)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.15)
+    license_scout (1.0.16)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -178,7 +185,7 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     minitar (0.6.1)
-    mixlib-archive (0.4.16)
+    mixlib-archive (0.4.18)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
@@ -207,11 +214,11 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    net-telnet (0.2.0)
+    net-telnet (0.1.1)
     nori (2.6.0)
-    octokit (4.12.0)
+    octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.5.4)
+    ohai (14.6.2)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -270,10 +277,10 @@ GEM
     solve (4.0.0)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 3.0)
-    specinfra (2.76.1)
+    specinfra (2.76.2)
       net-scp
       net-ssh (>= 2.7)
-      net-telnet
+      net-telnet (= 0.1.1)
       sfl
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
@@ -311,12 +318,12 @@ GEM
     win32-service (1.0.1)
       ffi
       ffi-win32-extensions
-    win32-taskscheduler (1.0.10)
+    win32-taskscheduler (1.0.12)
       ffi
       structured_warnings
     windows-api (0.4.4)
       win32-api (>= 1.4.5)
-    winrm (2.2.3)
+    winrm (2.3.0)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -328,7 +335,7 @@ GEM
     winrm-elevated (1.1.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.3.0)
+    winrm-fs (1.3.1)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
@@ -351,4 +358,4 @@ DEPENDENCIES
   winrm-elevated
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -79,8 +79,17 @@ if windows?
   dependency "ruby-windows-system-libraries"
 end
 
+dependency "ruby-cleanup"
+
 package :rpm do
   signing_passphrase ENV["OMNIBUS_RPM_SIGNING_PASSPHRASE"]
+  compression_level 1
+  compression_type :xz
+end
+
+package :deb do
+  compression_level 1
+  compression_type :xz
 end
 
 package :pkg do

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -83,19 +83,10 @@ build do
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 
-  # Clear the now-unnecessary git caches, cached gems, and git-checked-out gems
-  block "Delete bundler git cache and git installs" do
+  # Clear git-checked-out gems (most of this cleanup has been moved into the chef-cleanup omnibus-software definition,
+  # but chef-client still needs git-checked-out gems)
+  block "Delete bundler git installs" do
     gemdir = shellout!("#{install_dir}/embedded/bin/gem environment gemdir", env: env).stdout.chomp
-    remove_directory "#{gemdir}/cache"
     remove_directory "#{gemdir}/bundler"
   end
-
-  # Clean up docs
-  delete "#{install_dir}/embedded/docs"
-  delete "#{install_dir}/embedded/share/man"
-  delete "#{install_dir}/embedded/share/doc"
-  delete "#{install_dir}/embedded/share/gtk-doc"
-  delete "#{install_dir}/embedded/ssl/man"
-  delete "#{install_dir}/embedded/man"
-  delete "#{install_dir}/embedded/info"
 end


### PR DESCRIPTION
### Description

We branched v3.3.23 (last stable ChefDK) release and pulled in some
select changes. First, we updated chef-apply because we want users
using the latest version of that. Second, we pinned a bunch of gems
(fauxhai, inspec, etc.) that we don't want customers consuming until
the next ChefDK release. But we did allow patch fix updates and updates
to cloud gems.

We're creating a ChefDK branch for Workstation to use as we are unable
to release a stable ChefDK due to needing an updated chef-client build
which we are unable to build due to an esoteric platform requiring a new
license (this is on the way but won't be today). This branch is not
intended to be long lived and normal pinning to the stable ChefDK
release will resume once the dust settles.

### Issues Resolved

☝️ 

### Check List

- [x] ~New functionality includes tests~
- [ ] All tests pass
- [x] ~RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)~
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>