### PR TITLE
Sleep for 240 seconds before updating chef-client

### DIFF
--- a/.expeditor/update_chef.sh
+++ b/.expeditor/update_chef.sh
@@ -20,7 +20,7 @@ sed -i -r "s/^\s*gem \"chef\".*/  gem \"chef\", \"= ${VERSION}\"/" Gemfile
 
 # it appears that the gem that triggers this script fires off this script before
 # the gem is actually available via bundler on rubygems.org.
-sleep 120
+sleep 240
 
 gem install rake
 rake dependencies:update_gemfile_lock


### PR DESCRIPTION
The gems were not ready after 120 seconds. When running the job again it
ran fine. We just need more wait.

Signed-off-by: Tim Smith <tsmith@chef.io>