### PR TITLE
chef & knife tab completion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,12 @@
 
 ChefDK now ships with Chef 14.6.47\. See <https://docs.chef.io/release_notes.html> for more information on what's new.
 
+## Tab completion
+
+This is an improvement for all people to be able to support themselves with the tab completion of these commands and avoid being using the knife help that needs time to load their options.
+
+knife command is filled out dynamically the first time according to the chefdk version and caching in the home directory creating a .knife.tmp file for improving speed the next times that you use the tab for completion. 
+
 ## Smaller package size
 
 ChefDK RPM and Debian packages are now compressed. Additionally many gems were updated to remove extraneous files that do not need to be included. The download size of packages has decreased accordingly (all measurements in megabytes):

--- a/lib/chef-dk/completions/bash.sh.erb
+++ b/lib/chef-dk/completions/bash.sh.erb
@@ -1,5 +1,73 @@
+# Chef tab-completion  v1.1
+# Created by Jose Luis Mantilla 2018
+# email: joseluismantilla@gmail.com
+#
+# Features
+# chef command tab-completion 
+# knife command filled out dynamically the first time according to the chefdk version and caching on home directory 
+# for improving speed.
+
+
 _chef_comp() {
-    local COMMANDS="<%= commands.keys.join(' ')-%>"
-    COMPREPLY=($(compgen -W "$COMMANDS" -- ${COMP_WORDS[COMP_CWORD]} ))
+    local cur prev opts 
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ $prev == "chef" ]]; then
+        local COMMANDS="<%= commands.keys.join(' ')-%>"
+        COMPREPLY=($(compgen -W "$COMMANDS" -- ${COMP_WORDS[COMP_CWORD]} ))
+    else
+        case "${prev}" in
+        gem)
+            opts="install list build help server"
+            COMPREPLY=( $(compgen -W "$opts" ${cur}) )
+            ;;
+        generate )
+            local running="app attribute Available cookbook file generator helpers lwrp policyfile recipe repo resource template"
+            COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+            ;;
+        esac
+    fi
+
 }
+
+_knife_completion() 
+{
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    file_caching="/home/$USER/.knife.tmp"
+
+if [[ $prev = "knife" ]]; then
+        if [ -f "$file_caching" ]; then
+            base=$(grep -E ^knife $file_caching|awk '{ print $2 }'|uniq )
+            COMPREPLY=( $(compgen -W "${base}" -- ${cur}) )
+        else
+            base="$(for x in $(knife |grep -E ^knife| awk '{ print $2 }'|uniq); do echo ${x}; done)"
+            COMPREPLY=( $(compgen -W "${base}" -- ${cur}) )
+            knife > $file_caching
+        fi
+    return 0
+else
+    case "${prev}" in
+        gem)
+            opts="install list build help server"
+            COMPREPLY=( $(compgen -W "$opts" ${cur}) )
+            return 0
+        ;;
+        * )
+            local running=$(grep $prev $file_caching|grep -E ^knife| awk '{ print $3 }'|uniq)
+            COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
+                return 0
+            ;;
+    esac
+fi
+}
+
+complete -F _knife_completion knife
 complete -F _chef_comp chef

--- a/lib/chef-dk/completions/bash.sh.erb
+++ b/lib/chef-dk/completions/bash.sh.erb
@@ -4,8 +4,8 @@
 #
 # Features
 # chef command tab-completion 
-# knife command filled out dynamically the first time according to the chefdk version and caching on home directory 
-# for improving speed.
+# knife command filled out dynamically the first time according to the chefdk version and caching 
+# in the home directory for improving speed.
 
 
 _chef_comp() {

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -152,7 +152,7 @@ EOH
 
       let(:expected_completion_function) do
         <<~END_COMPLETION
-	    #Chef tab-completion v1.1
+		#Chef tab-completion v1.1
 		#Created by Jose Luis Mantilla 2018
 		#email: joseluismantilla@gmail.com
 		#
@@ -161,7 +161,7 @@ EOH
 		#knife command filled out dynamically the first time according to the chefdk version and caching on home directory for improving speed.
 
 		_chef_comp() {
-			local cur prev opts 
+			local cur prev opts
 			COMPREPLY=()
 			cur="${COMP_WORDS[COMP_CWORD]}"
 			prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -152,14 +152,6 @@ EOH
 
       let(:expected_completion_function) do
         <<~END_COMPLETION
-		#Chef tab-completion v1.1
-		#Created by Jose Luis Mantilla 2018
-		#email: joseluismantilla@gmail.com
-		#
-		#Features
-		#chef command tab-completion
-		#knife command filled out dynamically the first time according to the chefdk version and caching on home directory for improving speed.
-
 		_chef_comp() {
 			local cur prev opts
 			COMPREPLY=()
@@ -186,42 +178,6 @@ EOH
 			fi
 
 		}
-
-		_knife_completion()
-		{
-			local cur prev opts base
-			COMPREPLY=()
-			cur="${COMP_WORDS[COMP_CWORD]}"
-			prev="${COMP_WORDS[COMP_CWORD-1]}"
-			file_caching="/home/$USER/.knife.tmp"
-
-		if [[ $prev = "knife" ]]; then
-				if [ -f "$file_caching" ]; then
-					base=$(grep -E ^knife $file_caching|awk '{ print $2 }'|uniq )
-					COMPREPLY=( $(compgen -W "${base}" -- ${cur}) )
-				else
-					base="$(for x in $(knife |grep -E ^knife| awk '{ print $2 }'|uniq); do echo ${x}; done)"
-					COMPREPLY=( $(compgen -W "${base}" -- ${cur}) )
-					knife > $file_caching
-				fi
-			return 0
-		else
-			case "${prev}" in
-				gem)
-					opts="install list build help server"
-					COMPREPLY=( $(compgen -W "$opts" ${cur}) )
-					return 0
-				;;
-				* )
-					local running=$(grep $prev $file_caching|grep -E ^knife| awk '{ print $3 }'|uniq)
-					COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
-						return 0
-					;;
-			esac
-		fi
-		}
-
-		complete -F _knife_completion knife
 		complete -F _chef_comp chef
 END_COMPLETION
       end

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -152,15 +152,13 @@ EOH
 
       let(:expected_completion_function) do
         <<~END_COMPLETION
-	    # Chef tab-completion  v1.1
-		# Created by Jose Luis Mantilla 2018
-		# email: joseluismantilla@gmail.com
+	    #Chef tab-completion v1.1
+		#Created by Jose Luis Mantilla 2018
+		#email: joseluismantilla@gmail.com
 		#
-		# Features
-		# chef command tab-completion 
-		# knife command filled out dynamically the first time according to the chefdk version and caching on home directory 
-		# for improving speed.
-
+		#Features
+		#chef command tab-completion
+		#knife command filled out dynamically the first time according to the chefdk version and caching on home directory for improving speed.
 
 		_chef_comp() {
 			local cur prev opts 
@@ -189,7 +187,7 @@ EOH
 
 		}
 
-		_knife_completion() 
+		_knife_completion()
 		{
 			local cur prev opts base
 			COMPREPLY=()

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -152,11 +152,79 @@ EOH
 
       let(:expected_completion_function) do
         <<~END_COMPLETION
-          _chef_comp() {
-              local COMMANDS="exec env gem generate"
-              COMPREPLY=($(compgen -W "$COMMANDS" -- ${COMP_WORDS[COMP_CWORD]} ))
-          }
-          complete -F _chef_comp chef
+	    # Chef tab-completion  v1.1
+		# Created by Jose Luis Mantilla 2018
+		# email: joseluismantilla@gmail.com
+		#
+		# Features
+		# chef command tab-completion 
+		# knife command filled out dynamically the first time according to the chefdk version and caching on home directory 
+		# for improving speed.
+
+
+		_chef_comp() {
+			local cur prev opts 
+			COMPREPLY=()
+			cur="${COMP_WORDS[COMP_CWORD]}"
+			prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+			if [[ $prev == "chef" ]]; then
+				local COMMANDS="<%= commands.keys.join(' ')-%>"
+				COMPREPLY=($(compgen -W "$COMMANDS" -- ${COMP_WORDS[COMP_CWORD]} ))
+			else
+				case "${prev}" in
+				gem)
+					opts="install list build help server"
+					COMPREPLY=( $(compgen -W "$opts" ${cur}) )
+					;;
+				generate )
+					local running="app attribute Available cookbook file generator helpers lwrp policyfile recipe repo resource template"
+					COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
+					return 0
+					;;
+				*)
+					;;
+				esac
+			fi
+
+		}
+
+		_knife_completion() 
+		{
+			local cur prev opts base
+			COMPREPLY=()
+			cur="${COMP_WORDS[COMP_CWORD]}"
+			prev="${COMP_WORDS[COMP_CWORD-1]}"
+			file_caching="/home/$USER/.knife.tmp"
+
+		if [[ $prev = "knife" ]]; then
+				if [ -f "$file_caching" ]; then
+					base=$(grep -E ^knife $file_caching|awk '{ print $2 }'|uniq )
+					COMPREPLY=( $(compgen -W "${base}" -- ${cur}) )
+				else
+					base="$(for x in $(knife |grep -E ^knife| awk '{ print $2 }'|uniq); do echo ${x}; done)"
+					COMPREPLY=( $(compgen -W "${base}" -- ${cur}) )
+					knife > $file_caching
+				fi
+			return 0
+		else
+			case "${prev}" in
+				gem)
+					opts="install list build help server"
+					COMPREPLY=( $(compgen -W "$opts" ${cur}) )
+					return 0
+				;;
+				* )
+					local running=$(grep $prev $file_caching|grep -E ^knife| awk '{ print $3 }'|uniq)
+					COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
+						return 0
+					;;
+			esac
+		fi
+		}
+
+		complete -F _knife_completion knife
+		complete -F _chef_comp chef
 END_COMPLETION
       end
 


### PR DESCRIPTION
### Description

chef and knife tab completion filled out dynamically the first time according to the chefdk version and caching on the home directory for improving speed

### Issues Resolved

This is an improvement or new feature for all people to be able to support themselves with the tab completion of these commands and avoid being using the knife help that needs time to load their options always.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
