### PR TITLE
Add rsync to docker image to support kitchen-dokken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y wget ssh git vim-tiny && \
+    apt-get install -y  git rsync ssh vim-tiny wget && \
     ln -s /usr/bin/vi /usr/bin/vim && \
     wget --content-disposition "http://packages.chef.io/files/${CHANNEL}/chefdk/${VERSION}/ubuntu/18.04/chefdk_${VERSION}-1_amd64.deb" -O /tmp/chefdk.deb && \
     dpkg -i /tmp/chefdk.deb && \


### PR DESCRIPTION
### Description

Allows the `kitchen-dokken` to be used in CI pipelines without modification.  Typically you have to install rsync to make it work.


E.g. for Gitlab CI
```
image: chef/chefdk:current

variables:
  DOCKER_HOST: tcp://docker:2375

services:
  - docker:dind

before_script:
  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
  - chef --version
  - cookstyle --version
  - foodcritic --version
  - apt-get update && apt-get install rsync -y
```

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
