### PR TITLE
Add graphviz to docker image to support berks viz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 RUN apt-get update && \
-    apt-get install -y  git rsync ssh vim-tiny wget && \
+    apt-get install -y git graphviz rsync ssh vim-tiny wget && \
     ln -s /usr/bin/vi /usr/bin/vim && \
     wget --content-disposition "http://packages.chef.io/files/${CHANNEL}/chefdk/${VERSION}/ubuntu/18.04/chefdk_${VERSION}-1_amd64.deb" -O /tmp/chefdk.deb && \
     dpkg -i /tmp/chefdk.deb && \


### PR DESCRIPTION
### Description

Added graphviz to docker to make `berkz viz` available


### Check List

- ~New functionality includes tests~
- [x] All tests pass
- ~RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)~
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
