### PR TITLE
Expeditor should retry gem installs until successful

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -11,17 +11,26 @@
 
 set -evx
 
+function new_gem_included() {
+  git diff | grep -E '^\+' | grep "${GEM_NAME} (${VERSION})"
+}
+
 branch="expeditor/${GEM_NAME}_${VERSION}"
 git checkout -b "$branch"
 
-bundle install
-
-# it appears that the gem that triggers this script fires off this script before
-# the gem is actually available via bundler on rubygems.org.
-sleep 120
-
 gem install rake
-rake dependencies:update_gemfile_lock
+
+tries=6
+for i in {1..$tries}; do
+  rake dependencies:update_gemfile_lock
+  new_gem_included && break || sleep 20
+  if [ $i -eq $tries ]; then
+    echo "Searching for '${GEM_NAME} (${VERSION})' ${i} times and did not find it"
+    exit 1
+  else
+    echo "Searched ${i} times for '${GEM_NAME} (${VERSION})'"
+  fi
+done
 
 git add .
 


### PR DESCRIPTION
### Description

Rather than blindly sleeping 120 seconds lets attempt to update the dependencies until we get a success. This will also ensure we get a retryable message from expeditor if it cannot correctly update the dependencies.

### Issues Resolved

N/A

### Check List

- [ ] ~New functionality includes tests~
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>