### PR TITLE
Increase expeditor dependency update timeout

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -20,7 +20,7 @@ git checkout -b "$branch"
 
 gem install rake
 
-tries=6
+tries=12
 for (( i=1; i<=$tries; i+=1 )); do
   rake dependencies:update_gemfile_lock
   new_gem_included && break || sleep 20


### PR DESCRIPTION
### Description

120 seconds does not seem to be enough time for Rubygems to actually
publish the gem so it can be downloaded.

### Issues Resolved

N/A

### Check List

- [x] ~New functionality includes tests~
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: tyler-ball <tball@chef.io>
