### PR TITLE
Prevent rake from being packaged twice in DK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,10 @@ gemspec
 gem "bundler"
 
 group(:omnibus_package, :development, :test) do
-  gem "rake"
+  # we pin rake as a copy of rake is installed from the ruby source
+  # if you bump the ruby version you should confirm we don't end up with
+  # two rake gems installed again
+  gem "rake", "<= 12.3.0"
   gem "pry"
   gem "rdoc"
   gem "yard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,13 +30,13 @@ GEM
       mixlib-shellout (~> 2.0)
     artifactory (2.8.2)
     ast (2.4.0)
-    aws-sdk (2.11.183)
-      aws-sdk-resources (= 2.11.183)
-    aws-sdk-core (2.11.183)
+    aws-sdk (2.11.184)
+      aws-sdk-resources (= 2.11.184)
+    aws-sdk-core (2.11.184)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.183)
-      aws-sdk-core (= 2.11.183)
+    aws-sdk-resources (2.11.184)
+      aws-sdk-core (= 2.11.184)
     aws-sigv4 (1.0.3)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -604,7 +604,7 @@ GEM
       r18n-core (= 3.2.0)
     rack (2.0.6)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -858,7 +858,7 @@ DEPENDENCIES
   pry-byebug
   pry-remote
   pry-stack_explorer
-  rake
+  rake (<= 12.3.0)
   rb-readline
   rdoc
   rdp-ruby-wmi

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: ca035f744ece299cbdf81f52edb997b4ba1693b2
+  revision: 708e9c7413c83a6e19a40e212ad884c78a905a5d
   branch: master
   specs:
-    omnibus (6.0.7)
+    omnibus (6.0.8)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.117.0)
-    aws-sdk-core (3.40.0)
+    aws-partitions (1.121.0)
+    aws-sdk-core (3.42.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.27.0)
+    aws-sdk-s3 (1.29.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -287,7 +287,7 @@ GEM
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.23.2)
+    test-kitchen (1.23.3)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)


### PR DESCRIPTION
Rake is being included out of the box with our ruby install and then we
install the latest. This results in double rake. If we pin we can avoid
that. We'll need to adjust this pin when we bump to 2.6 but it works
great in 2.5.3.

Signed-off-by: Tim Smith <tsmith@chef.io>