### PR TITLE
Don't ship omnibus_overrides or readme in the gemfile

### DIFF
--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -31,8 +31,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.files = %w{Rakefile LICENSE README.md warning.txt} +
-    %w{omnibus_overrides.rb} +
+  gem.files = %w{Rakefile LICENSE warning.txt} +
     Dir.glob("Gemfile*") + # Includes Gemfile and locks
     Dir.glob("*.gemspec") +
     Dir.glob("{lib,spec,acceptance,tasks}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }


### PR DESCRIPTION
The omnibus_overrides is used to build the omnibus package and shouldn't
be needed in a release artifact. We also don't need a readme buried deep
in a ruby gems dir on the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>