### PR TITLE
Remove the Rake gemtasks since we use expeditor

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2018 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-require "bundler/gem_tasks"
 require_relative "tasks/dependencies"
 require_relative "tasks/announce"
 


### PR DESCRIPTION
This keeps someone from running rake release on accident.

Signed-off-by: Tim Smith <tsmith@chef.io>