### PR TITLE
Cleanup the omnibus definition for DK

### DIFF
--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -62,15 +62,13 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   excluded_groups = %w{server docgen maintenance pry travis integration ci}
-  excluded_groups << "ruby_prof" if aix?
-  excluded_groups << "ruby_shadow" if aix?
 
   # install the whole bundle first
   bundle "install --without #{excluded_groups.join(' ')}", env: env
 
   gem "build chef-dk.gemspec", env: env
 
-  gem "install chef*.gem --no-ri --no-rdoc --verbose", env: env
+  gem "install chef*.gem --no-document --verbose", env: env
 
   env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
 

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -50,17 +50,6 @@ build do
   # clever.
   make "distclean", env: env
 
-  # AIX needs /opt/freeware/bin only for patch
-  if aix?
-    patch_env = env.dup
-    patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
-
-    # But only needs the below for 1.9.5
-    if version == "1.9.5"
-      patch source: "aix-strcmp-in-dirc.patch", plevel: 1, env: patch_env
-    end
-  end
-
   config_hash = {
     # Universal options
     NO_GETTEXT: "YesPlease",
@@ -82,11 +71,6 @@ build do
     config_hash["PTHREAD_LIBS"] = "-pthread"
     config_hash["USE_ST_TIMESPEC"] = "YesPlease"
     config_hash["HAVE_BSD_SYSCTL"] = "YesPlease"
-    config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
-  elsif solaris?
-    env["CC"] = "gcc"
-    env["SHELL_PATH"] = "#{install_dir}/embedded/bin/bash"
-    config_hash["NEEDS_SOCKET"] = "YesPlease"
     config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
   elsif aix?
     env["CC"] = "xlc_r"


### PR DESCRIPTION
Remove AIX/Solaris bits since workstation / DK will never run on AIX. I'm removing these from the upstream git definition as well since they're only necessary for old versions of git we shouldn't be supporting.
Use --no-document which is required for Ruby 2.6. This gets us ready to support Ruby 2.6.

Signed-off-by: Tim Smith <tsmith@chef.io>