### PR TITLE
Update mixlib-config, mixlib-log, and nokogiri to reduce install size

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -91,6 +91,9 @@ subscriptions:
   - workload: ruby_gem_published:mixlib-cli-*
     actions:
       - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:mixlib-config-*
+    actions:
+      - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:mixlib-log-*
     actions:
       - bash:.expeditor/update_dep.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,13 +30,13 @@ GEM
       mixlib-shellout (~> 2.0)
     artifactory (3.0.0)
     ast (2.4.0)
-    aws-sdk (2.11.192)
-      aws-sdk-resources (= 2.11.192)
-    aws-sdk-core (2.11.192)
+    aws-sdk (2.11.193)
+      aws-sdk-resources (= 2.11.193)
+    aws-sdk-core (2.11.193)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.192)
-      aws-sdk-core (= 2.11.192)
+    aws-sdk-resources (2.11.193)
+      aws-sdk-core (= 2.11.193)
     aws-sigv4 (1.0.3)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -508,7 +508,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.5)
       mixlib-shellout

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,7 +514,7 @@ GEM
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.4)
+    mixlib-log (2.0.9)
     mixlib-shellout (2.4.4)
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
@@ -547,11 +547,11 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     netaddr (1.5.1)
-    nokogiri (1.9.0)
+    nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.9.0-x64-mingw32)
+    nokogiri (1.9.1-x64-mingw32)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.9.0-x86-mingw32)
+    nokogiri (1.9.1-x86-mingw32)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     notiffany (0.1.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: e551136c73499d7cacf550163b5f1832adb5a675
+  revision: 5b205da971d1564041c02ea329d3204378841643
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.124.0)
-    aws-sdk-core (3.44.0)
+    aws-partitions (1.125.0)
+    aws-sdk-core (3.44.1)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -148,7 +148,7 @@ GEM
       uuidtools (~> 2.1)
     citrus (3.0.2)
     cleanroom (1.0.0)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     diff-lcs (1.3)
     erubis (2.7.0)
     faraday (0.15.4)
@@ -191,7 +191,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.5)
       mixlib-shellout

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.4)
+    mixlib-log (2.0.9)
     mixlib-shellout (2.4.4)
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)


### PR DESCRIPTION
Reduce the install size by bumping mixlib-log and mixlib-config. Also bump to the latest nokogiri, which fixes a regression in 1.9.0