### PR TITLE
Bump license_scout to 1.0.20 for licensing tests

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.19)
+    license_scout (1.0.20)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)


### PR DESCRIPTION
This will allow the new inspec deps to pass

Signed-off-by: Tim Smith <tsmith@chef.io>