### PR TITLE
Promote Hab package alongside Omnibus package

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -72,11 +72,13 @@ subscriptions:
   - workload: artifact_published:current:chefdk:{{version_constraint}}
     actions:
       - built_in:tag_docker_image
+      - built_in:promote_habitat_packages
   - workload: artifact_published:stable:chefdk:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - built_in:tag_docker_image
+      - built_in:promote_habitat_packages
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
   - workload: artifact_published:stable:chef:14*


### PR DESCRIPTION
This change ensures we are promoting our Hab packages to `current` and
`stable` at the same time we execute said promotions for the Omnibus
packages.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
