### PR TITLE
Missing required gems for rake to run tasks

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -18,11 +18,11 @@ function new_gem_included() {
 branch="expeditor/${GEM_NAME}_${VERSION}"
 git checkout -b "$branch"
 
-gem install rake
+bundle install
 
 tries=12
 for (( i=1; i<=$tries; i+=1 )); do
-  rake dependencies:update_gemfile_lock
+  bundle exec rake dependencies:update_gemfile_lock
   new_gem_included && break || sleep 20
   if [ $i -eq $tries ]; then
     echo "Searching for '${GEM_NAME} (${VERSION})' ${i} times and did not find it"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*               * @chef/chef-workstation @chef/client-maintainers
-.expeditor/**   @chef/jex-team
+*                   @chef/chef-workstation
+.expeditor/**       @chef/jex-team
+README.md           @chef/docs-team
+RELEASE_NOTES.md    @chef/docs-team


### PR DESCRIPTION
### Description

Something changed with our expeditor build image. Now if we only
'gem install rake' we are missing both dependend gems and local code
paths. Running rake in the scope of 'bundle' should fix this.

### Issues Resolved

N/A

### Check List

- [x] ~New functionality includes tests~
- [ ] All tests pass
- [x] ~RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)~
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
