### PR TITLE
Add better support for habitat packaging

### DIFF
--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -96,8 +96,7 @@ module ChefDK
 
     def show_version
       msg("Chef Development Kit Version: #{ChefDK::VERSION}")
-
-      ["chef-client", "delivery", "berks", "kitchen", "inspec"].each do |component|
+      expected_components.each do |component|
         result = Bundler.with_clean_env { shell_out("#{component} --version") }
         if result.exitstatus != 0
           msg("#{component} version: ERROR")
@@ -106,6 +105,12 @@ module ChefDK
           msg("#{component} version: #{version}")
         end
       end
+    end
+
+    def expected_components
+      components = ["chef-client", "berks", "kitchen", "inspec"]
+      components << "delivery" unless habitat_install?
+      components
     end
 
     def show_help

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -131,10 +131,6 @@ describe ChefDK::CLI do
           "version_output" => "Chef: 12.0.3",
           "expected_version" => "12.0.3",
         },
-        "delivery" => {
-          "version_output" => "delivery #{delivery_version}",
-          "expected_version" => delivery_version,
-        },
         "berks" => {
           "version_output" => "3.2.3",
           "expected_version" => "3.2.3",
@@ -146,6 +142,10 @@ describe ChefDK::CLI do
         "inspec" => {
           "version_output" => "1.19.1\n\nYour version of InSpec is out of date! The latest version is 1.21.0.",
           "expected_version" => "1.19.1",
+        },
+        "delivery" => {
+          "version_output" => "delivery #{delivery_version}",
+          "expected_version" => delivery_version,
         },
       }
     end
@@ -228,6 +228,35 @@ describe ChefDK::CLI do
       params = %w{with some args --and-an-option}
       run_cli(23)
       expect(test_result[:params]).to eq(params)
+    end
+  end
+
+  context "#expected_components" do
+    let(:everything_except_delivery) do
+      [ "chef-client", "berks",
+                                        "kitchen", "inspec" ] end
+    let(:everything) { everything_except_delivery.dup.push("delivery") }
+
+    context "when running from a habitat package" do
+      before do
+        allow(subject).to receive(:habitat_install?).and_return true
+        allow(subject).to receive(:omnibus_install?).and_return false
+      end
+      it "should include everything except delivery" do
+        expect(subject.expected_components).to eq everything_except_delivery
+      end
+
+    end
+
+    context "when running from an omnibus package" do
+      before do
+        allow(subject).to receive(:habitat_install?).and_return false
+        allow(subject).to receive(:omnibus_install?).and_return true
+      end
+      it "should include everything" do
+        expect(subject.expected_components).to eq everything
+      end
+
     end
   end
 

--- a/spec/unit/command/shell_init_spec.rb
+++ b/spec/unit/command/shell_init_spec.rb
@@ -39,6 +39,18 @@ describe ChefDK::Command::ShellInit do
 
     before do
       allow(::Dir).to receive(:exist?).and_call_original
+
+      # REVIEW TODO - sanity check
+      #
+      # the below :omnibus_install? is added due to a change in behavior  where
+      # we only add the omnibus paths to PATH if we can identify this
+      # as an omnibus-based install.  Previously we were doing it
+      # unconditionally, and the omnibus_*_dir mocks would prevent
+      # us from hitting the 'not installed via omnibus' path.
+      #
+      # Setting this flag allowoos us to ... continue not hitting that path.
+      # Seems a thing we want coverage for, but I can add that in a separate PR
+      allow(command_instance).to receive(:omnibus_install?).and_return true
     end
 
     context "with no explicit omnibus directory" do

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -1,0 +1,131 @@
+require "chef-dk/helpers"
+class HelperTest
+  include ChefDK::Helpers
+end
+
+describe HelperTest do
+
+  describe "#habitat_install?" do
+    after do
+      ENV.delete("VIA_HABITAT")
+    end
+    context "when the environment variable VIA_HABITAT=='true'" do
+      before do
+        ENV["VIA_HABITAT"] = "true"
+      end
+      it "returns true" do
+        expect(subject.habitat_install?).to eq true
+      end
+    end
+
+    context "when the environment variable VIA_HABITAT is not 'true'" do
+      before do
+        ENV.delete("VIA_HABITAT")
+      end
+
+      it "returns false" do
+        expect(subject.habitat_install?).to eq false
+      end
+    end
+  end
+
+  describe "#git_bin_dir" do
+    context "when running from a habitat package" do
+      let(:expected_git_bin_dir) { "/hab-path-to-git-bin-dir" }
+      before do
+        allow(subject).to receive(:habitat_install?).and_return true
+        ENV["HAB_WS_GIT_BIN_DIR"] = expected_git_bin_dir
+      end
+
+      after do
+        ENV.delete("HAB_WS_GIT_BIN_DIR")
+      end
+
+      it "provides a git path from the HAB_WS_GIT_BIN dir environment variable" do
+        expect(subject.git_bin_dir).to eq expected_git_bin_dir
+      end
+    end
+
+    context "when running from an omnibus package" do
+      before do
+        allow(subject).to receive(:habitat_install?).and_return false
+      end
+      it "should provide a path that references the gitbin directory" do
+        expect(subject.git_bin_dir).to match(/.*#{File::SEPARATOR}gitbin.*/)
+      end
+    end
+  end
+
+  describe "#omnibus_env" do
+    let(:omnibus_bin_dir) { "/omnibus-bin-dir" }
+    let(:git_bin_dir) { "/dir/for/gitbin" }
+    let(:habitat_bin_dir) { "/habitat-bin-dir" }
+    let(:git_windows_bin_dir) { "C:\\gitbin" }
+    let(:omnibus_embedded_bin_dir) { "/omnibus-embedded-bin-dir" }
+    let(:habitat_embedded_bin_dir) { "/hab-embedded-bin-dir1:/hab-embedded-bin-dir2" }
+    let(:env_path) { "/usr/bin:/bin" }
+    let(:gem_user_dir) { File.expand_path("/home/user1/.gems") }
+    let(:gem_default_dir) { "/gem/default/dir" }
+    let(:gem_path) { ["/gem/path"] }
+    before do
+      allow(subject).to receive(:omnibus_bin_dir).and_return omnibus_bin_dir
+      allow(subject).to receive(:habitat_bin_dir).and_return habitat_bin_dir
+      allow(subject).to receive(:git_bin_dir).and_return git_bin_dir
+      allow(subject).to receive(:git_windows_bin_dir).and_return git_windows_bin_dir
+      allow(subject).to receive(:omnibus_embedded_bin_dir).and_return omnibus_embedded_bin_dir
+      allow(subject).to receive(:habitat_embedded_bin_dir).and_return habitat_embedded_bin_dir
+      allow(ENV).to receive(:[]).with("PATH").and_return env_path
+
+      allow(Gem).to receive(:user_dir).and_return gem_user_dir
+      allow(Gem).to receive(:default_dir).and_return gem_default_dir
+      allow(Gem).to receive(:path).and_return gem_path
+      allow(Dir).to receive(:exist?).with(git_bin_dir).and_return true
+      allow(Dir).to receive(:exist?).with(git_windows_bin_dir).and_return true
+    end
+
+    context "when running from a habitat package" do
+      before do
+        allow(subject).to receive(:habitat_install?).and_return true
+        allow(subject).to receive(:omnibus_install?).and_return false
+      end
+      it "provides an environment with habitat paths and no omnibus paths" do
+        expected_path = [habitat_bin_dir,
+                         File.join(gem_user_dir, "bin"),
+                         habitat_embedded_bin_dir,
+                         env_path].join(File::PATH_SEPARATOR)
+        expected_env = {
+          "GEM_HOME" => gem_user_dir,
+          "GEM_PATH" => gem_path.join(File::PATH_SEPARATOR),
+          "GEM_ROOT" => gem_default_dir,
+          "PATH" => expected_path,
+        }
+        expect(subject.omnibus_env).to eq expected_env
+      end
+    end
+
+    context "when running from an omnibus package" do
+      before do
+        allow(subject).to receive(:habitat_install?).and_return false
+        allow(subject).to receive(:omnibus_install?).and_return true
+      end
+      it "provides an environment with omnibus paths and no habitat paths" do
+        expected_path = [omnibus_bin_dir,
+                         File.join(gem_user_dir, "bin"),
+                         omnibus_embedded_bin_dir,
+                         env_path,
+                         git_bin_dir,
+                         git_windows_bin_dir].join(File::PATH_SEPARATOR)
+
+        expected_env = {
+          "GEM_HOME" => gem_user_dir,
+          "GEM_PATH" => gem_path.join(File::PATH_SEPARATOR),
+          "GEM_ROOT" => gem_default_dir,
+          "PATH" => expected_path,
+        }
+
+        expect(subject.omnibus_env).to eq expected_env
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
### Description

This fixes a few issues that are encountered when using
the `chef` command out of a Workstation habitat package:

- '-v' will skip delivery to avoid a raised exception
- 'shell_init' will provide a correct environment for habitat-based installs

These changes will work in the context of the Chef Workstation
habitat package. 'helpers.rb' has been modified to
expect habitat-related environment variables - these are populated
in plan.sh of Workstation:

- `VIA_HABITAT` = string "true"
- `HAB_WS_BIN_DIR` - bin directory of the Workstation hab install
- `HAB_WS_GIT_BIN_DIR` - bin directory of the git hab install
- `HAB_WS_EMBEDDED_GIT_BIN_DIR` - path string containing ancillary bin
                                dirs, such as for ruby and bundler

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] New functionality includes tests
- [x] All tests pass (the same tests pass locally that pass without these changes...) 
- [x] (n/a) RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
