### PR TITLE
Deprecating the 'chef provision' command

### DIFF
--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -101,6 +101,8 @@ module ChefDK
     class Provision < Base
 
       banner(<<~E)
+        DEPRECATED: This command is deprecated and will be removed in ChefDK 4.
+
         Usage: chef provision POLICY_GROUP --policy-name POLICY_NAME [options]
                chef provision POLICY_GROUP --sync [POLICYFILE_PATH] [options]
                chef provision --no-policy [options]
@@ -226,6 +228,7 @@ module ChefDK
       end
 
       def run(params = [])
+        ui.msg("DEPRECATED: This command is deprecated and will be removed in ChefDK 4.")
         return 1 unless apply_params!(params)
         chef_config # force chef config to load
         return 1 unless check_cookbook_and_recipe_path

--- a/spec/unit/command/provision_spec.rb
+++ b/spec/unit/command/provision_spec.rb
@@ -549,7 +549,7 @@ describe ChefDK::Command::Provision do
 
         it "exits 0" do
           return_value = command.run(params)
-          expect(ui.output).to eq("")
+          expect(ui.output).to eq("DEPRECATED: This command is deprecated and will be removed in ChefDK 4.\n")
           expect(return_value).to eq(0)
         end
 
@@ -561,7 +561,7 @@ describe ChefDK::Command::Provision do
 
         it "exits 0" do
           return_value = command.run(params)
-          expect(ui.output).to eq("")
+          expect(ui.output).to eq("DEPRECATED: This command is deprecated and will be removed in ChefDK 4.\n")
           expect(return_value).to eq(0)
         end
       end
@@ -577,7 +577,7 @@ describe ChefDK::Command::Provision do
 
         it "exits 0" do
           return_value = command.run(params)
-          expect(ui.output).to eq("")
+          expect(ui.output).to eq("DEPRECATED: This command is deprecated and will be removed in ChefDK 4.\n")
           expect(return_value).to eq(0)
         end
 


### PR DESCRIPTION
### Description

It will be removed in ChefDK 4. See
https://github.com/chef/chef-dk/pull/1614

### Issues Resolved

N/A

### Check List

- [ ] ~New functionality includes tests~
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
