### PR TITLE
Rubygems pin back to 2.7.7

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,7 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.0.2"
+override :rubygems, version: "2.7.7"
 override :bundler, version: "1.17.3"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Upgrading rubygems to 3.0.2 failed tests on all Unix platforms so pinning it back to 2.7.7

### Issues Resolved

Tests pass on all platforms after pinning back

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
