### PR TITLE
Pinning CI scripts to Bundler 1.17.3

### DIFF
--- a/.expeditor/update_dep.sh
+++ b/.expeditor/update_dep.sh
@@ -15,14 +15,16 @@ function new_gem_included() {
   git diff | grep -E '^\+' | grep "${GEM_NAME} (${VERSION})"
 }
 
+gem install bundler -v 1.17.3 --no-document
+
 branch="expeditor/${GEM_NAME}_${VERSION}"
 git checkout -b "$branch"
 
-bundle install
+bundle _1.17.3_ install
 
 tries=12
 for (( i=1; i<=$tries; i+=1 )); do
-  bundle exec rake dependencies:update_gemfile_lock
+  bundle _1.17.3_ exec rake dependencies:update_gemfile_lock
   new_gem_included && break || sleep 20
   if [ $i -eq $tries ]; then
     echo "Searching for '${GEM_NAME} (${VERSION})' ${i} times and did not find it"

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -32,9 +32,9 @@ namespace :dependencies do
       Dir.chdir(dir) do
         Bundler.with_clean_env do
           rm_f "#{dir}/Gemfile.lock"
-          sh "bundle lock --update --add-platform ruby"
-          sh "bundle lock --update --add-platform x64-mingw32"
-          sh "bundle lock --update --add-platform x86-mingw32"
+          sh "bundle _1.17.3_ lock --update --add-platform ruby"
+          sh "bundle _1.17.3_ lock --update --add-platform x64-mingw32"
+          sh "bundle _1.17.3_ lock --update --add-platform x86-mingw32"
         end
       end
     end
@@ -45,7 +45,7 @@ namespace :dependencies do
     task task_name do
       Dir.chdir(dir) do
         Bundler.with_clean_env do
-          sh "bundle update"
+          sh "bundle _1.17.3_ update"
         end
       end
     end


### PR DESCRIPTION
### Description

Bundler 2.0 messes up a bunch of stuff, so we cannot upgrade to it now.

This should be an easy find/replace for '_1.17.3_' when we want to
revert it.

### Issues Resolved

N/A

### Check List

- [x] ~New functionality includes tests~
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
