### PR TITLE
Update Fauxhai to 6.11 and lock it there

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,7 @@ group(:omnibus_package, :development, :test) do
   gem "pry"
   gem "yard"
   gem "guard"
-  # Cookstyle 4.0 includes non-backwards compatable changes so we need to pin to 3.x.
-  gem "cookstyle", "~> 3.0"
+  gem "cookstyle", "~> 3.0" # bump this on the next DK major release
   gem "foodcritic", ">= 12.1"
   gem "ffi-libarchive"
 end
@@ -61,7 +60,7 @@ group(:omnibus_package) do
   gem "chef", "= 14.10.9"
   gem "cheffish", ">= 14.0.1"
   gem "chefspec", ">= 7.3.0"
-  gem "fauxhai", ">= 6.7"
+  gem "fauxhai", "~> 6.11" # bump this on the next DK major release
   gem "inspec", ">= 2.3"
   gem "kitchen-azurerm", ">= 0.14"
   gem "kitchen-ec2", ">= 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       http-cookie (~> 1.0.0)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    fauxhai (6.10.0)
+    fauxhai (6.11.0)
       net-ssh
     ffi (1.10.0)
     ffi (1.10.0-x64-mingw32)
@@ -763,9 +763,9 @@ GEM
     ubuntu_ami (0.4.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
-    unf_ext (0.0.7.5-x64-mingw32)
-    unf_ext (0.0.7.5-x86-mingw32)
+    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.2-x64-mingw32)
+    unf_ext (0.0.7.2-x86-mingw32)
     unicode-display_width (1.4.1)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
@@ -851,7 +851,7 @@ DEPENDENCIES
   dco
   dep-selector-libgecode
   dep_selector
-  fauxhai (>= 6.7)
+  fauxhai (~> 6.11)
   ffi-libarchive
   ffi-rzmq-core
   foodcritic (>= 12.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: ce1e03de4c9970da53b4c63176b17af518426968
+  revision: e5c168f42dc18f585b3109245e1604649d0a366a
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.134.0)
+    aws-partitions (1.136.0)
     aws-sdk-core (3.46.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
@@ -60,10 +60,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.9.13)
+    chef (14.10.9)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.9.13)
+      chef-config (= 14.10.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -90,10 +90,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.9.13-universal-mingw32)
+    chef (14.10.9-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.9.13)
+      chef-config (= 14.10.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -133,7 +133,7 @@ GEM
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (14.9.13)
+    chef-config (14.10.9)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
@@ -173,7 +173,7 @@ GEM
     ipaddress (0.8.3)
     iso8601 (0.12.1)
     jmespath (1.4.0)
-    kitchen-vagrant (1.3.6)
+    kitchen-vagrant (1.4.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     license_scout (1.0.22)
@@ -303,7 +303,7 @@ GEM
     tomlrb (1.2.8)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.2.2)
+    win32-certstore (0.2.3)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)
@@ -363,4 +363,4 @@ DEPENDENCIES
   winrm-elevated
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
7.0 is out, but this is for the next major DK release

Signed-off-by: Tim Smith <tsmith@chef.io>