### PR TITLE
Swap rbnacl-libsodium gem with omnibus libsodium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,8 +125,7 @@ end
 # For consistency with Chef-Client we exclude this on Solaris
 # (yeah, we don't build ChefDK on Solaris, but lets be consistent and have this group)
 group(:ed25519) do
-  gem "rbnacl-libsodium"
-  gem "rbnacl", "~> 5.0" # pin to 5.x until we can replace rbnacl-libsodium
+  gem "rbnacl"
   gem "bcrypt_pbkdf"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,10 +615,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rb-readline (0.5.5)
-    rbnacl (5.0.0)
+    rbnacl (6.0.1)
       ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     rbvmomi (1.13.0)
       builder (~> 3.0)
       json (>= 1.8)
@@ -897,8 +895,7 @@ DEPENDENCIES
   pry-stack_explorer
   rake (<= 12.3.0)
   rb-readline
-  rbnacl (~> 5.0)
-  rbnacl-libsodium
+  rbnacl
   rdoc (<= 6.0.1)
   rdp-ruby-wmi
   rspec-core (~> 3.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: bf006801aa98595383904ea65c098846d8c12ea4
+  revision: 10151d127fef039839ce0e6072b68fe695b1d3c5
   branch: master
   specs:
-    omnibus (6.0.18)
+    omnibus (6.0.19)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 3213f1d282f6b62dfa656353c6c8557fdca8378b
+  revision: 36811008f3a8baedad00cf54732a3d0350476324
   branch: master
   specs:
     omnibus-software (4.0.0)

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -75,6 +75,7 @@ dependency "stunnel" if fips_mode?
 # compilations that use ./configure et all (the msys env) to break
 if windows?
   override :"ruby-windows-devkit", version: "4.5.2-20111229-1559" if windows_arch_i386?
+  dependency "rbnacl-libsodium-fix"
   dependency "ruby-windows-devkit"
   dependency "ruby-windows-devkit-bash"
   dependency "ruby-windows-system-libraries"

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -106,7 +106,7 @@ package :msi do
 end
 
 package :appx do
-  signing_identity "E05FF095D07F233B78EB322132BFF0F035E11B5B", machine_store: true
+  skip_packager true
 end
 
 compress :dmg

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -50,6 +50,9 @@ dependency "libarchive"
 # For opscode-pushy-client
 dependency "libzmq"
 
+# ed25519
+dependency "libsodium"
+
 # ruby and bundler and friends
 dependency "ruby"
 dependency "rubygems"

--- a/omnibus/config/software/rbnacl-libsodium-fix.rb
+++ b/omnibus/config/software/rbnacl-libsodium-fix.rb
@@ -1,0 +1,12 @@
+name "rbnaclk-libsodium-fix"
+
+default_version "0.0.1"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+build do
+  if windows?
+    copy "#{install_dir}/embedded/bin/libsodium-23.dll", "#{install_dir}/embedded/bin/sodium.dll"
+  end
+end


### PR DESCRIPTION
### Description

rbnacl-libsodium is no longer maintained[1]. The libsodium
it pulls in for by rbnacl-libsodium does not seem to have support for ed25519,
and is causing DK gem loading errors.

This PR replaces the libsodium gem with the libsodium build out of omnibus.

[1] https://github.com/crypto-rb/rbnacl-libsodium

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>




### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
