### PR TITLE
Disable appx builds on Windows

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -106,7 +106,7 @@ package :msi do
 end
 
 package :appx do
-  signing_identity "E05FF095D07F233B78EB322132BFF0F035E11B5B", machine_store: true
+  skip_packager true
 end
 
 compress :dmg


### PR DESCRIPTION

We do not distribute appx builds, and the packaging/upload of them
adds between 20-30 minutes to the Windows build duration.


Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>


### Check List

- n/a New functionality includes tests
- n/a All tests pass
- n/a RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
