### PR TITLE
Fix `# # encoding` in cookbook generator

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
@@ -1,4 +1,4 @@
-# # encoding: utf-8
+# encoding: utf-8
 
 # InSpec test for recipe <%= cookbook_name %>::<%= recipe_name %>
 

--- a/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/inspec_default_test.rb.erb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # InSpec test for recipe <%= cookbook_name %>::<%= recipe_name %>
 
 # The InSpec reference, with examples and extensive documentation, can be


### PR DESCRIPTION
FWIW, I think this line can be removed entirely...but not 100% sure.