### PR TITLE
RFC097 include_policy with remote sources and validating policy_revision_id with path

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -179,6 +179,9 @@ subscriptions:
   - workload: ruby_gem_published:knife-vsphere-*
     actions:
       - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:knife-vsphere-*
+    actions:
+      - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:knife-windows-*
     actions:
       - bash:.expeditor/update_dep.sh
@@ -228,6 +231,9 @@ subscriptions:
     actions:
       - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:kitchen-vagrant-*
+    actions:
+      - bash:.expeditor/update_dep.sh
+  - workload: ruby_gem_published:kitchen-vcenter-*
     actions:
       - bash:.expeditor/update_dep.sh
   - workload: ruby_gem_published:test-kitchen-*

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -28,7 +28,7 @@ module ChefDK
       attr_accessor :source_options
       attr_accessor :chef_config
 
-      # Initialize a LocalLockFetcher
+      # Initialize a ChefServerLockFetcher
       #
       # @param name [String] The name of the policyfile
       # @param source_options [Hash] A hash with a :server key pointing at the chef server,
@@ -67,7 +67,7 @@ module ChefDK
         errors.empty?
       end
 
-      # Check the options provided when craeting this class for errors
+      # Check the options provided when creating this class for errors
       #
       # @return [Array<String>] A list of errors found
       def errors

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -74,7 +74,7 @@ module ChefDK
 
       # @return [String] of the policyfile lock data
       def lock_data
-        FFI_Yajl::Parser.new.parse(content).tap do |data|
+        fetch_lock_data.tap do |data|
           validate_revision_id(data["revision_id"])
           data["cookbook_locks"].each do |cookbook_name, cookbook_lock|
             cookbook_path = cookbook_lock["source_options"]["path"]
@@ -139,6 +139,9 @@ module ChefDK
         Pathname.new(source_options[:path]).expand_path(storage_config.relative_paths_root)
       end
 
+      def fetch_lock_data
+        FFI_Yajl::Parser.new.parse(content)
+      end
     end
   end
 end

--- a/lib/chef-dk/policyfile/local_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/local_lock_fetcher.rb
@@ -85,6 +85,19 @@ module ChefDK
         end
       end
 
+      def validate_revision_id(included_id)
+        expected_id = source_options[:policy_revision_id]
+        if expected_id
+          if included_id.eql?(expected_id) # are they the same?
+            return
+          elsif included_id[0, 10].eql?(expected_id) # did they use the 10 char substring
+            return
+          else
+            raise ChefDK::InvalidLockfile, "Expected policy_revision_id '#{expected_id}' does not match included_policy '#{included_id}'."
+          end
+        end
+      end
+
       private
 
       # Transforms cookbook paths to a path relative to the current
@@ -126,18 +139,6 @@ module ChefDK
         Pathname.new(source_options[:path]).expand_path(storage_config.relative_paths_root)
       end
 
-      def validate_revision_id(included_id)
-        expected_id = source_options[:policy_revision_id]
-        if expected_id
-          if included_id.eql?(expected_id) # are they the same?
-            return
-          elsif included_id[0, 10].eql?(expected_id) # did they use the 10 char substring
-            return
-          else
-            raise ChefDK::InvalidLockfile, "Expected policy_revision_id '#{expected_id}' does not match included_policy '#{included_id}'."
-          end
-        end
-      end
     end
   end
 end

--- a/lib/chef-dk/policyfile/policyfile_location_specification.rb
+++ b/lib/chef-dk/policyfile/policyfile_location_specification.rb
@@ -17,6 +17,7 @@
 
 require "chef-dk/policyfile_lock"
 require "chef-dk/policyfile/local_lock_fetcher"
+require "chef-dk/policyfile/remote_lock_fetcher"
 require "chef-dk/policyfile/chef_server_lock_fetcher"
 require "chef-dk/policyfile/git_lock_fetcher"
 require "chef-dk/exceptions"
@@ -37,7 +38,7 @@ module ChefDK
       attr_reader :chef_config
       attr_reader :ui
 
-      LOCATION_TYPES = [:path, :server, :git].freeze
+      LOCATION_TYPES = [:path, :remote, :server, :git].freeze
 
       # Initialize a location spec
       #
@@ -64,6 +65,8 @@ module ChefDK
         @fetcher ||= begin
                        if source_options[:path] && !source_options[:git]
                          Policyfile::LocalLockFetcher.new(name, source_options, storage_config)
+                       elsif source_options[:remote]
+                         Policyfile::RemoteLockFetcher.new(name, source_options, storage_config)
                        elsif source_options[:server]
                          Policyfile::ChefServerLockFetcher.new(name, source_options, chef_config)
                        elsif source_options[:git]

--- a/lib/chef-dk/policyfile/remote_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/remote_lock_fetcher.rb
@@ -1,0 +1,75 @@
+#
+# Copyright:: Copyright (c) 2019 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef-dk/policyfile_lock"
+require "chef-dk/exceptions"
+require "chef/http"
+require "tempfile"
+
+module ChefDK
+  module Policyfile
+
+    # A policyfile lock fetcher that can read a lock from a remote location
+    # essentially the same as the LocalLockFetcher, it copies the file a locally
+    class RemoteLockFetcher < LocalLockFetcher
+
+      # Check the options provided when creating this class for errors
+      #
+      # @return [Array<String>] A list of errors found
+      def errors
+        error_messages = []
+
+        [:remote].each do |key|
+          error_messages << "include_policy for #{name} is missing key #{key}" unless source_options[key]
+        end
+
+        error_messages
+      end
+
+      # @return [String] of the policyfile lock data
+      def lock_data
+        @lock_data ||= fetch_lock_data.tap do |data|
+          validate_revision_id(data["revision_id"])
+          data["cookbook_locks"].each do |cookbook_name, cookbook_lock|
+            cookbook_path = cookbook_lock["source_options"]["path"]
+            if !cookbook_path.nil?
+              cookbook_lock["source_options"]["path"] = transform_path(cookbook_path)
+            end
+          end
+        end
+      end
+
+      private
+
+      def fetch_lock_data
+        FFI_Yajl::Parser.parse(http_client.get(""))
+      rescue Net::ProtocolError => e
+        if e.respond_to?(:response) && e.response.code.to_s == "404"
+          raise ChefDK::PolicyfileLockDownloadError.new("No remote policyfile lock '#{name}' found at #{http_client.url}")
+        else
+          raise ChefDK::PolicyfileLockDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}")
+        end
+      rescue => e
+        raise e
+      end
+
+      def http_client
+        @http_client ||= Chef::HTTP.new(source_options[:remote])
+      end
+    end
+  end
+end

--- a/lib/chef-dk/policyfile/remote_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/remote_lock_fetcher.rb
@@ -40,19 +40,6 @@ module ChefDK
         error_messages
       end
 
-      # @return [String] of the policyfile lock data
-      def lock_data
-        @lock_data ||= fetch_lock_data.tap do |data|
-          validate_revision_id(data["revision_id"])
-          data["cookbook_locks"].each do |cookbook_name, cookbook_lock|
-            cookbook_path = cookbook_lock["source_options"]["path"]
-            if !cookbook_path.nil?
-              cookbook_lock["source_options"]["path"] = transform_path(cookbook_path)
-            end
-          end
-        end
-      end
-
       private
 
       def fetch_lock_data

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -78,6 +78,48 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     end
   end
 
+  describe "when include_policy specifies a remote policy" do
+    describe "and the included policy is correctly configured" do
+      let(:included_policies) { [["foo", { remote: "http://example.local/foo.lock.json" }]] }
+
+      it "has an included policy" do
+        expect(policyfile.included_policies.length).to eq(1)
+      end
+
+      it "uses a remote fetcher" do
+        expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::RemoteLockFetcher)
+      end
+
+      it "has a fetcher with no errors" do
+        expect(policyfile.included_policies[0].fetcher.errors).to eq([])
+      end
+
+      it "has a fetcher that is valid" do
+        expect(policyfile.included_policies[0].fetcher.valid?).to eq(true)
+      end
+    end
+
+    describe "and the included policy and policy_revision_id are correctly configured" do
+      let(:included_policies) { [["foo", { remote: "http://example.local/foo.lock.json", policy_revision_id: "bar" }]] }
+
+      it "has an included policy" do
+        expect(policyfile.included_policies.length).to eq(1)
+      end
+
+      it "uses a remote fetcher" do
+        expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::RemoteLockFetcher)
+      end
+
+      it "has a fetcher with no errors" do
+        expect(policyfile.included_policies[0].fetcher.errors).to eq([])
+      end
+
+      it "has a fetcher that is valid" do
+        expect(policyfile.included_policies[0].fetcher.valid?).to eq(true)
+      end
+    end
+  end
+
   describe "when include_policy specifies a policy on a chef server" do
     let(:included_policies) { [["foo", { server: "http://example.com", policy_name: "foo" }]] }
     describe "and policy_revision_id and policy_group are missing" do

--- a/spec/unit/policyfile_includes_dsl_spec.rb
+++ b/spec/unit/policyfile_includes_dsl_spec.rb
@@ -40,7 +40,7 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
     describe "and the included policy is correctly configured" do
       let(:included_policies) { [["foo", { path: "./foo.lock.json" }]] }
 
-      it "has a included policy" do
+      it "has an included policy" do
         expect(policyfile.included_policies.length).to eq(1)
       end
 
@@ -57,6 +57,25 @@ describe ChefDK::PolicyfileCompiler, "including upstream policy locks" do
       end
     end
 
+    describe "and the included policy and policy_revision_id are correctly configured" do
+      let(:included_policies) { [["foo", { path: "./foo.lock.json", policy_revision_id: "bar" }]] }
+
+      it "has an included policy" do
+        expect(policyfile.included_policies.length).to eq(1)
+      end
+
+      it "uses a local fetcher" do
+        expect(policyfile.included_policies[0].fetcher).to be_a(ChefDK::Policyfile::LocalLockFetcher)
+      end
+
+      it "has a fetcher with no errors" do
+        expect(policyfile.included_policies[0].fetcher.errors).to eq([])
+      end
+
+      it "has a fetcher that is valid" do
+        expect(policyfile.included_policies[0].fetcher.valid?).to eq(true)
+      end
+    end
   end
 
   describe "when include_policy specifies a policy on a chef server" do


### PR DESCRIPTION
### Description

Addresses https://github.com/chef/chef-rfc/pull/333 by adding support for include_policy with remote sources and adds support and validation for policy_revision_id with path and remote include_policy.

### Issues Resolved

https://github.com/chef/chef-rfc/pull/333

### Check List

Updated unit tests and applied chefstyle.
