### PR TITLE
Leverage new Buildkite-based Hab builds

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,0 +1,5 @@
+[chef-dk]
+build_targets = [
+  "x86_64-linux",
+  "x86_64-linux-kernel2"
+]

--- a/.expeditor/build.habitat.yml
+++ b/.expeditor/build.habitat.yml
@@ -1,0 +1,2 @@
+---
+origin: chef

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -15,9 +15,8 @@ rubygems:
 docker_images:
   - chefdk
 
-habitat_packages:
-  - chef-dk:
-      also_build_for_linux_kernel2: true
+pipelines:
+  - habitat/build
 
 github:
   # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
@@ -59,7 +58,7 @@ merge_actions:
       ignore_labels:
         - "Expeditor: Skip Changelog"
         - "Expeditor: Skip All"
-  - built_in:trigger_habitat_package_build:
+  - trigger_pipeline:habitat/build:
       ignore_labels:
         - "Expeditor: Skip Habitat"
         - "Expeditor: Skip All"


### PR DESCRIPTION
### Description

_This is a release engineering only change._

Update Expeditor configuration to use new Buildkite-based Habitat builds.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
