### PR TITLE
Update Ruby to 2.6 and Rubygems to 3.0.3

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,5 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
-
+---
 # The name of the product keys for this product (from mixlib-install)
 product_key: chefdk
 
@@ -20,12 +20,6 @@ habitat_packages:
       also_build_for_linux_kernel2: true
 
 github:
-  # The file where the MAJOR.MINOR.PATCH version is kept. The version in this file
-  # is bumped automatically via the `built_in:bump_version` merge_action.
-  version_file: "VERSION"
-  # The file where our CHANGELOG is kept. This file is updated automatically with
-  # details from the Pull Request via the `built_in:update_changelog` merge_action.
-  changelog_file: "CHANGELOG.md"
   # This deletes the GitHub PR branch after successfully merged into the release branch
   delete_branch_on_merge: true
   # The tag format to use (e.g. v1.0.0)

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,9 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
+# the name we use for this project when interacting with expeditor chatbot
+project:
+  alias: chefdk-4
+
 # The name of the product keys for this product (from mixlib-install)
 product_key: chefdk
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,14 +25,14 @@ group(:omnibus_package, :development, :test) do
   # we pin these gems as they are installed in the ruby source and if we let them
   # float we'll end up with 2 copies shipped in DK. When we bump Ruby we need to
   # look at these pins and adjust them
-  gem "rake", "<= 12.3.0"
+  gem "rake", "<= 12.3.2"
   gem "rdoc", "<= 6.0.1"
   gem "minitest", "<= 5.10.3"
 
   gem "pry"
   gem "yard"
   gem "guard"
-  gem "cookstyle", "~> 4.0" # bump this on the next DK major release
+  gem "cookstyle", "~> 4.0"
   gem "foodcritic", ">= 12.1"
   gem "ffi-libarchive"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -54,10 +54,10 @@ group(:omnibus_package) do
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch
   # fixes.
-  gem "chef", git: "https://github.com/chef/chef.git", branch: "master"
+  gem "chef", ">= 14.11"
   gem "cheffish", ">= 14.0.1"
   gem "chefspec", ">= 7.3.0"
-  gem "fauxhai", "~> 7.0" # bump this on the next DK major release
+  gem "fauxhai", "~> 7.0"
   gem "inspec", ">= 3.0"
   gem "kitchen-azurerm", ">= 0.14"
   gem "kitchen-ec2", ">= 2.3"
@@ -77,7 +77,7 @@ group(:omnibus_package) do
   gem "knife-vsphere", ">= 2.1.1"
   gem "knife-vcenter", ">= 2.0"
   gem "mixlib-archive", ">= 0.4.16"
-  gem "ohai", git: "https://github.com/chef/ohai.git", branch: "master" # switch off git when 15 ships
+  gem "ohai", ">= 14"
   gem "net-ssh", ">= 4.2.0"
   gem "test-kitchen", ">= 1.23"
   gem "listen"
@@ -92,7 +92,7 @@ group(:omnibus_package) do
   gem "chef-sugar"
   gem "mixlib-versioning"
   gem "artifactory"
-  gem "opscode-pushy-client", git: "https://github.com/chef/opscode-pushy-client.git", branch: "master" # switch off git when next major ships
+  gem "opscode-pushy-client", ">= 2.1"
   gem "ffi-rzmq-core"
   gem "knife-push"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,111 +1,9 @@
-GIT
-  remote: https://github.com/chef/chef.git
-  revision: acb23859f867121b361b513c69a4a01b85ee3c19
-  branch: master
-  specs:
-    chef (15.0.200)
-      addressable
-      bundler (>= 1.10)
-      chef-config (= 15.0.200)
-      chef-zero (>= 14.0.11)
-      diff-lcs (~> 1.2, >= 1.2.4)
-      erubis (~> 2.7)
-      ffi (~> 1.9, >= 1.9.25)
-      ffi-yajl (~> 2.2)
-      highline (~> 1.6, >= 1.6.9)
-      iniparse (~> 1.4)
-      mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (~> 2.1)
-      mixlib-cli (>= 1.7, < 3.0)
-      mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 2.4, < 4.0)
-      net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (~> 4.2)
-      net-ssh-multi (~> 1.2, >= 1.2.1)
-      ohai (~> 15.0)
-      plist (~> 3.2)
-      proxifier (~> 1.0)
-      syslog-logger (~> 1.6)
-      uuidtools (~> 2.1.5)
-    chef (15.0.200-universal-mingw32)
-      addressable
-      bundler (>= 1.10)
-      chef-config (= 15.0.200)
-      chef-zero (>= 14.0.11)
-      diff-lcs (~> 1.2, >= 1.2.4)
-      erubis (~> 2.7)
-      ffi (~> 1.9, >= 1.9.25)
-      ffi-yajl (~> 2.2)
-      highline (~> 1.6, >= 1.6.9)
-      iniparse (~> 1.4)
-      iso8601 (~> 0.12.1)
-      mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (~> 2.1)
-      mixlib-cli (>= 1.7, < 3.0)
-      mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 2.4, < 4.0)
-      net-sftp (~> 2.1, >= 2.1.2)
-      net-ssh (~> 4.2)
-      net-ssh-multi (~> 1.2, >= 1.2.1)
-      ohai (~> 15.0)
-      plist (~> 3.2)
-      proxifier (~> 1.0)
-      syslog-logger (~> 1.6)
-      uuidtools (~> 2.1.5)
-      win32-api (~> 1.5.3)
-      win32-certstore (~> 0.3)
-      win32-dir (~> 0.5.0)
-      win32-event (~> 0.6.1)
-      win32-eventlog (= 0.6.3)
-      win32-mmap (~> 0.4.1)
-      win32-mutex (~> 0.4.2)
-      win32-process (~> 0.8.2)
-      win32-service (>= 2.1.2, < 3.0)
-      win32-taskscheduler (~> 2.0)
-      windows-api (~> 0.4.4)
-      wmi-lite (~> 1.0)
-    chef-config (15.0.200)
-      addressable
-      fuzzyurl
-      mixlib-config (>= 2.2.12, < 4.0)
-      mixlib-shellout (>= 2.0, < 4.0)
-      tomlrb (~> 1.2)
-
-GIT
-  remote: https://github.com/chef/ohai.git
-  revision: 05e507952d8dbff8e31528f1ebcab72664e99aa2
-  branch: master
-  specs:
-    ohai (15.0.30)
-      chef-config (>= 12.8, < 16)
-      ffi (~> 1.9)
-      ffi-yajl (~> 2.2)
-      ipaddress
-      mixlib-cli (>= 1.7.0)
-      mixlib-config (>= 2.0, < 4.0)
-      mixlib-log (>= 2.0.1, < 4.0)
-      mixlib-shellout (>= 2.0, < 4.0)
-      plist (~> 3.1)
-      systemu (~> 2.6.4)
-      wmi-lite (~> 1.0)
-
-GIT
-  remote: https://github.com/chef/opscode-pushy-client.git
-  revision: 990f49be0947fbf86b2f6b0bf528af22bd3b8d74
-  branch: master
-  specs:
-    opscode-pushy-client (2.5.11)
-      chef (>= 13.0, < 16.0)
-      ffi-rzmq
-      ohai (>= 13.0, < 16.0)
-      uuidtools
-
 PATH
   remote: .
   specs:
     chef-dk (4.0.8)
       addressable (>= 2.3.5, < 2.6)
-      chef (~> 15.0)
+      chef (~> 14.0)
       cookbook-omnifetch (~> 0.5)
       diff-lcs (~> 1.0)
       ffi-yajl (>= 1.0, < 3.0)
@@ -135,13 +33,13 @@ GEM
     artifactory (3.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.2)
-    aws-sdk (2.11.252)
-      aws-sdk-resources (= 2.11.252)
-    aws-sdk-core (2.11.252)
+    aws-sdk (2.11.256)
+      aws-sdk-resources (= 2.11.256)
+    aws-sdk-core (2.11.256)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.252)
-      aws-sdk-core (= 2.11.252)
+    aws-sdk-resources (2.11.256)
+      aws-sdk-core (= 2.11.256)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     axiom-types (0.1.1)
@@ -156,7 +54,7 @@ GEM
       ms_rest_azure (~> 0.11.0)
     azure_mgmt_resources (0.17.3)
       ms_rest_azure (~> 0.11.0)
-    backports (3.12.0)
+    backports (3.13.0)
     berkshelf (7.0.8)
       chef (>= 13.6.52)
       chef-config
@@ -174,6 +72,79 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (11.0.1)
+    chef (14.11.21)
+      addressable
+      bundler (>= 1.10)
+      chef-config (= 14.11.21)
+      chef-zero (>= 13.0)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi (~> 1.9, >= 1.9.25)
+      ffi-yajl (~> 2.2)
+      highline (~> 1.6, >= 1.6.9)
+      iniparse (~> 1.4)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (~> 2.1)
+      mixlib-cli (~> 1.7)
+      mixlib-log (~> 2.0, >= 2.0.3)
+      mixlib-shellout (~> 2.4)
+      net-sftp (~> 2.1, >= 2.1.2)
+      net-ssh (~> 4.2)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (~> 14.0)
+      plist (~> 3.2)
+      proxifier (~> 1.0)
+      rspec-core (~> 3.5)
+      rspec-expectations (~> 3.5)
+      rspec-mocks (~> 3.5)
+      rspec_junit_formatter (~> 0.2.0)
+      serverspec (~> 2.7)
+      specinfra (~> 2.10)
+      syslog-logger (~> 1.6)
+      uuidtools (~> 2.1.5)
+    chef (14.11.21-universal-mingw32)
+      addressable
+      bundler (>= 1.10)
+      chef-config (= 14.11.21)
+      chef-zero (>= 13.0)
+      diff-lcs (~> 1.2, >= 1.2.4)
+      erubis (~> 2.7)
+      ffi (~> 1.9, >= 1.9.25)
+      ffi-yajl (~> 2.2)
+      highline (~> 1.6, >= 1.6.9)
+      iniparse (~> 1.4)
+      iso8601 (~> 0.12.1)
+      mixlib-archive (>= 0.4, < 2.0)
+      mixlib-authentication (~> 2.1)
+      mixlib-cli (~> 1.7)
+      mixlib-log (~> 2.0, >= 2.0.3)
+      mixlib-shellout (~> 2.4)
+      net-sftp (~> 2.1, >= 2.1.2)
+      net-ssh (~> 4.2)
+      net-ssh-multi (~> 1.2, >= 1.2.1)
+      ohai (~> 14.0)
+      plist (~> 3.2)
+      proxifier (~> 1.0)
+      rspec-core (~> 3.5)
+      rspec-expectations (~> 3.5)
+      rspec-mocks (~> 3.5)
+      rspec_junit_formatter (~> 0.2.0)
+      serverspec (~> 2.7)
+      specinfra (~> 2.10)
+      syslog-logger (~> 1.6)
+      uuidtools (~> 2.1.5)
+      win32-api (~> 1.5.3)
+      win32-certstore (~> 0.2.4)
+      win32-dir (~> 0.5.0)
+      win32-event (~> 0.6.1)
+      win32-eventlog (= 0.6.3)
+      win32-mmap (~> 0.4.1)
+      win32-mutex (~> 0.4.2)
+      win32-process (~> 0.8.2)
+      win32-service (~> 1.0)
+      win32-taskscheduler (~> 2.0)
+      windows-api (~> 0.4.4)
+      wmi-lite (~> 1.0)
     chef-api (0.9.0)
       logify (~> 0.1)
       mime-types
@@ -190,6 +161,12 @@ GEM
       toml-rb
       train
       tty-spinner
+    chef-config (14.11.21)
+      addressable
+      fuzzyurl
+      mixlib-config (>= 2.2.12, < 3.0)
+      mixlib-shellout (~> 2.0)
+      tomlrb (~> 1.2)
     chef-sugar (5.0.1)
     chef-telemetry (0.1.8)
       chef-config
@@ -371,7 +348,7 @@ GEM
     ice_nine (0.11.2)
     inifile (3.0.0)
     iniparse (1.4.4)
-    inspec (3.7.11)
+    inspec (3.9.0)
       addressable (~> 2.4)
       faraday (>= 0.9.0)
       faraday_middleware (~> 0.12.2)
@@ -393,6 +370,7 @@ GEM
       thor (~> 0.20)
       tomlrb (~> 1.2)
       train (~> 1.5, >= 1.7.2)
+      train-habitat (~> 0.1)
       tty-prompt (~> 0.17)
       tty-table (~> 0.10)
     ipaddress (0.8.3)
@@ -498,14 +476,14 @@ GEM
     mixlib-archive (1.0.1-universal-mingw32)
       mixlib-log
     mixlib-authentication (2.1.1)
-    mixlib-cli (2.0.3)
+    mixlib-cli (1.7.0)
     mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.11)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (3.0.1)
+    mixlib-log (2.0.9)
     mixlib-shellout (2.4.4)
     mixlib-shellout (2.4.4-universal-mingw32)
       win32-process (~> 0.8.2)
@@ -536,6 +514,7 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
+    net-telnet (0.1.1)
     netaddr (1.5.1)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
@@ -549,10 +528,27 @@ GEM
       shellany (~> 0.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    ohai (14.8.11)
+      chef-config (>= 12.8, < 15)
+      ffi (~> 1.9)
+      ffi-yajl (~> 2.2)
+      ipaddress
+      mixlib-cli (>= 1.7.0)
+      mixlib-config (>= 2.0, < 4.0)
+      mixlib-log (>= 2.0.1, < 4.0)
+      mixlib-shellout (>= 2.0, < 4.0)
+      plist (~> 3.1)
+      systemu (~> 2.6.4)
+      wmi-lite (~> 1.0)
+    opscode-pushy-client (2.5.6)
+      chef (>= 12.19, < 15.0)
+      ffi-rzmq
+      ohai (>= 8.23, < 15.0)
+      uuidtools
     os (1.0.0)
     paint (1.0.1)
     parallel (1.17.0)
-    parser (2.6.2.0)
+    parser (2.6.2.1)
       ast (~> 2.4.0)
     parslet (1.8.2)
     pastel (0.7.2)
@@ -578,7 +574,7 @@ GEM
     r18n-core (3.2.0)
     r18n-desktop (3.2.0)
       r18n-core (= 3.2.0)
-    rack (2.0.6)
+    rack (2.0.7)
     rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
@@ -616,6 +612,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.62.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -643,6 +642,12 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     semverse (3.0.0)
+    serverspec (2.41.3)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.72)
+    sfl (2.3)
     shellany (0.0.1)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -654,6 +659,11 @@ GEM
     solve (4.0.2)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
+    specinfra (2.77.0)
+      net-scp
+      net-ssh (>= 2.7)
+      net-telnet (= 0.1.1)
+      sfl
     sshkey (1.9.0)
     sslshake (1.3.0)
     stove (7.1.0)
@@ -702,6 +712,8 @@ GEM
       net-ssh (>= 2.9, < 6.0)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
+    train-habitat (0.1.1)
+      train (>= 1.7.5, < 3.0)
     treetop (1.6.10)
       polyglot (~> 0.3)
     trollop (2.9.9)
@@ -775,7 +787,7 @@ GEM
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
     win32-api (1.5.3-universal-mingw32)
-    win32-certstore (0.3.0)
+    win32-certstore (0.2.4)
       ffi
       mixlib-shellout
     win32-dir (0.5.1)
@@ -792,7 +804,7 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (2.1.2)
+    win32-service (1.0.1)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)
@@ -822,7 +834,7 @@ GEM
       winrm (~> 2.0)
     wisper (2.0.0)
     wmi-lite (1.0.2)
-    yard (0.9.18)
+    yard (0.9.19)
 
 PLATFORMS
   ruby
@@ -834,7 +846,7 @@ DEPENDENCIES
   artifactory
   berkshelf (>= 7.0.5)
   bundler
-  chef!
+  chef (>= 14.11)
   chef-apply
   chef-dk!
   chef-sugar
@@ -879,8 +891,8 @@ DEPENDENCIES
   mixlib-versioning
   net-ssh (>= 4.2.0)
   nokogiri
-  ohai!
-  opscode-pushy-client!
+  ohai (>= 14)
+  opscode-pushy-client (>= 2.1)
   pry
   pry-byebug
   pry-remote

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/chef/chef.git
-  revision: 6837d6bda9fbfdcab0c2d26f3313ec106137e203
+  revision: acb23859f867121b361b513c69a4a01b85ee3c19
   branch: master
   specs:
-    chef (15.0.196)
+    chef (15.0.200)
       addressable
       bundler (>= 1.10)
-      chef-config (= 15.0.196)
+      chef-config (= 15.0.200)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -27,10 +27,10 @@ GIT
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (15.0.196-universal-mingw32)
+    chef (15.0.200-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 15.0.196)
+      chef-config (= 15.0.200)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -60,11 +60,11 @@ GIT
       win32-mmap (~> 0.4.1)
       win32-mutex (~> 0.4.2)
       win32-process (~> 0.8.2)
-      win32-service (>= 1.0, < 3.0)
+      win32-service (>= 2.1.2, < 3.0)
       win32-taskscheduler (~> 2.0)
       windows-api (~> 0.4.4)
       wmi-lite (~> 1.0)
-    chef-config (15.0.196)
+    chef-config (15.0.200)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -118,7 +118,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.2.1)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -135,13 +135,13 @@ GEM
     artifactory (3.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.2)
-    aws-sdk (2.11.247)
-      aws-sdk-resources (= 2.11.247)
-    aws-sdk-core (2.11.247)
+    aws-sdk (2.11.252)
+      aws-sdk-resources (= 2.11.252)
+    aws-sdk-core (2.11.252)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.247)
-      aws-sdk-core (= 2.11.247)
+    aws-sdk-resources (2.11.252)
+      aws-sdk-core (= 2.11.252)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     axiom-types (0.1.1)
@@ -152,7 +152,7 @@ GEM
       ms_rest_azure (~> 0.11.0)
     azure_mgmt_key_vault (0.17.3)
       ms_rest_azure (~> 0.11.0)
-    azure_mgmt_network (0.18.5)
+    azure_mgmt_network (0.18.6)
       ms_rest_azure (~> 0.11.0)
     azure_mgmt_resources (0.17.3)
       ms_rest_azure (~> 0.11.0)
@@ -257,7 +257,7 @@ GEM
       multi_json
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    droplet_kit (2.8.0)
+    droplet_kit (2.9.0)
       activesupport (> 3.0, < 6)
       faraday (~> 0.15)
       kartograph (~> 0.2.3)
@@ -489,7 +489,7 @@ GEM
     method_source (0.9.2)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     mini_portile2 (2.4.0)
     minitar (0.8)
     minitest (5.10.3)
@@ -547,11 +547,11 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.13.0)
+    octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     os (1.0.0)
     paint (1.0.1)
-    parallel (1.15.0)
+    parallel (1.17.0)
     parser (2.6.2.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
@@ -580,7 +580,7 @@ GEM
       r18n-core (= 3.2.0)
     rack (2.0.6)
     rainbow (3.0.0)
-    rake (12.3.0)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -885,7 +885,7 @@ DEPENDENCIES
   pry-byebug
   pry-remote
   pry-stack_explorer
-  rake (<= 12.3.0)
+  rake (<= 12.3.2)
   rb-readline
   rdoc (<= 6.0.1)
   rdp-ruby-wmi

--- a/chef-dk.gemspec
+++ b/chef-dk.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   gem.add_dependency "ffi-yajl", ">= 1.0", "< 3.0"
   gem.add_dependency "minitar", "~> 0.6"
-  gem.add_dependency "chef", "~> 15.0"
+  gem.add_dependency "chef", "~> 14.0"
   gem.add_dependency "solve", "< 5.0", "> 2.0"
   gem.add_dependency "addressable", ">= 2.3.5", "< 2.6"
   gem.add_dependency "cookbook-omnifetch", "~> 0.5"

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 3d5181c28da3fdf602f86096c00d3a7c666b538c
+  revision: 3f3bd5dd6d17212f2b90a2e45c63bf97224b48e6
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: c824e911af6dab44e9866a5e05d2e0217518a76f
+  revision: 7ad32798cd5893191e4b9bfc5b53e4cc8f32646b
   branch: master
   specs:
-    omnibus (6.0.21)
+    omnibus (6.0.23)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
-    aws-partitions (1.146.0)
-    aws-sdk-core (3.48.2)
+    aws-partitions (1.148.0)
+    aws-sdk-core (3.48.3)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -41,7 +41,7 @@ GEM
     aws-sdk-kms (1.16.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.35.0)
+    aws-sdk-s3 (1.36.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -177,7 +177,7 @@ GEM
     kitchen-vagrant (1.5.1)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)
-    license_scout (1.0.22)
+    license_scout (1.0.24)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -219,7 +219,7 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     nori (2.6.0)
-    octokit (4.13.0)
+    octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     ohai (14.8.11)
       chef-config (>= 12.8, < 15)
@@ -280,7 +280,7 @@ GEM
     solve (4.0.2)
       molinillo (~> 0.6)
       semverse (>= 1.1, < 4.0)
-    specinfra (2.76.9)
+    specinfra (2.77.0)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 3f3bd5dd6d17212f2b90a2e45c63bf97224b48e6
+  revision: 8e902b14ff285a57846a41231edc939a9be399d6
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
-    aws-partitions (1.148.0)
+    aws-partitions (1.149.0)
     aws-sdk-core (3.48.3)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
@@ -243,7 +243,7 @@ GEM
     progressbar (1.10.0)
     proxifier (1.0.3)
     public_suffix (3.0.3)
-    rack (2.0.6)
+    rack (2.0.7)
     retryable (3.0.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,7 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.0.2"
+override :rubygems, version: "3.0.3"
 override :bundler, version: "1.17.3"
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
@@ -16,7 +16,7 @@ override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "5.9"
 override "pkg-config-lite", version: "0.28-1"
-override "ruby", version: "2.5.5"
+override "ruby", version: "2.6.2"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"


### PR DESCRIPTION
We have working Ruby 2.6 builds in omnibus-software now. This bumps DK up.

Signed-off-by: Tim Smith <tsmith@chef.io>