### PR TITLE
Bring in Chef 14.12.9 and other newer deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,3 @@ branches:
   only:
     - master
     - chefdk-3
-    - chefdk-2

--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group(:omnibus_package) do
   gem "fauxhai", "~> 6.11" # bump this on the next DK major release
   gem "inspec", ">= 2.3"
   gem "kitchen-azurerm", ">= 0.14"
-  gem "kitchen-ec2", ">= 2.3"
+  gem "kitchen-ec2", ">= 2.3", "< 3.0"
   gem "kitchen-digitalocean", ">= 0.10.0"
   gem "kitchen-dokken", ">= 2.6.7"
   gem "kitchen-google", ">= 2.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group(:omnibus_package) do
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch
   # fixes.
-  gem "chef", "= 14.12.3"
+  gem "chef", "= 14.12.9"
   gem "cheffish", ">= 14.0.1"
   gem "chefspec", ">= 7.3.0"
   gem "fauxhai", "~> 6.11" # bump this on the next DK major release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,19 +25,19 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     app_conf (0.4.2)
-    appbundler (0.12.0)
+    appbundler (0.12.5)
       mixlib-cli (>= 1.4, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
     artifactory (3.0.0)
     ast (2.4.0)
-    aws-eventstream (1.0.2)
-    aws-sdk (2.11.256)
-      aws-sdk-resources (= 2.11.256)
-    aws-sdk-core (2.11.256)
+    aws-eventstream (1.0.3)
+    aws-sdk (2.11.263)
+      aws-sdk-resources (= 2.11.263)
+    aws-sdk-core (2.11.263)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.256)
-      aws-sdk-core (= 2.11.256)
+    aws-sdk-resources (2.11.263)
+      aws-sdk-core (= 2.11.263)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     axiom-types (0.1.1)
@@ -70,10 +70,10 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (11.0.1)
-    chef (14.12.3)
+    chef (14.12.9)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.12.3)
+      chef-config (= 14.12.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -100,10 +100,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.12.3-universal-mingw32)
+    chef (14.12.9-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.12.3)
+      chef-config (= 14.12.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -158,7 +158,7 @@ GEM
       toml-rb
       train
       tty-spinner
-    chef-config (14.12.3)
+    chef-config (14.12.9)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -510,7 +510,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (2.0.3)
-    mixlib-config (2.2.18)
+    mixlib-config (3.0.1)
       tomlrb
     mixlib-install (3.11.12)
       mixlib-shellout
@@ -549,11 +549,11 @@ GEM
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
     netaddr (1.5.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.2-x64-mingw32)
+    nokogiri (1.10.3-x64-mingw32)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.2-x86-mingw32)
+    nokogiri (1.10.3-x86-mingw32)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     notiffany (0.1.1)
@@ -578,7 +578,7 @@ GEM
       ffi-rzmq
       ohai (>= 8.23, < 15.0)
       uuidtools
-    os (1.0.0)
+    os (1.0.1)
     paint (1.0.1)
     parallel (1.17.0)
     parser (2.6.2.1)
@@ -635,7 +635,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-its (1.3.0)
@@ -767,9 +767,7 @@ GEM
     ubuntu_ami (0.4.2)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
-    unf_ext (0.0.7.2-x64-mingw32)
-    unf_ext (0.0.7.2-x86-mingw32)
+    unf_ext (0.0.7.6)
     unicode-display_width (1.5.0)
     unicode_utils (1.4.0)
     uuidtools (2.1.5)
@@ -796,7 +794,7 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (2.1.2)
+    win32-service (2.1.4)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)
@@ -807,7 +805,7 @@ GEM
     windows-pr (1.2.6)
       win32-api (>= 1.4.5)
       windows-api (>= 0.4.0)
-    winrm (2.3.1)
+    winrm (2.3.2)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -839,7 +837,7 @@ DEPENDENCIES
   artifactory
   berkshelf (>= 7.0.5)
   bundler
-  chef (= 14.12.3)
+  chef (= 14.12.9)
   chef-apply
   chef-dk!
   chef-provisioning (>= 2.7.1)
@@ -864,7 +862,7 @@ DEPENDENCIES
   kitchen-azurerm (>= 0.14)
   kitchen-digitalocean (>= 0.10.0)
   kitchen-dokken (>= 2.6.7)
-  kitchen-ec2 (>= 2.3)
+  kitchen-ec2 (>= 2.3, < 3.0)
   kitchen-google (>= 2.0.0)
   kitchen-hyperv (>= 0.5.1)
   kitchen-inspec (>= 1.0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ branches:
   only:
     - master
     - chefdk-3
-    - chefdk-3
 
 install:
   - systeminfo

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 0dc67ede1784d56a975cb4a7aea47ad2349bf24a
+  revision: e4553dad2f70aae8fee6b19689e8d8596b60bb0e
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 7b0318666d179cbb19a1e28ba53fd26552003bcc
+  revision: b6e267d0554feca5fd0a09d306cccfac7f7e43b9
   branch: master
   specs:
-    omnibus (6.0.24)
+    omnibus (6.0.26)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -31,22 +31,25 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-eventstream (1.0.2)
-    aws-partitions (1.149.0)
-    aws-sdk-core (3.48.3)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.154.0)
+    aws-sdk-core (3.48.6)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.16.0)
+    aws-sdk-kms (1.17.0)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.36.0)
+    aws-sdk-s3 (1.36.1)
       aws-sdk-core (~> 3, >= 3.48.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    bcrypt_pbkdf (1.0.1)
+    bcrypt_pbkdf (1.0.1-x64-mingw32)
+    bcrypt_pbkdf (1.0.1-x86-mingw32)
     berkshelf (7.0.8)
       chef (>= 13.6.52)
       chef-config
@@ -61,10 +64,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.12.3)
+    chef (14.12.9)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.12.3)
+      chef-config (= 14.12.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -91,10 +94,10 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef (14.12.3-universal-mingw32)
+    chef (14.12.9-universal-mingw32)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.12.3)
+      chef-config (= 14.12.9)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -133,7 +136,7 @@ GEM
       win32-service (>= 1.0, < 3.0)
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
-    chef-config (14.12.3)
+    chef-config (14.12.9)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -150,6 +153,8 @@ GEM
     cleanroom (1.0.0)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    ed25519 (1.2.4)
+    equatable (0.5.0)
     erubis (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -176,6 +181,11 @@ GEM
     kitchen-vagrant (1.5.1)
       test-kitchen (>= 1.4, < 3)
     libyajl2 (1.2.0)
+    license-acceptance (0.2.16)
+      pastel (~> 0.7)
+      tomlrb (~> 1.2)
+      tty-box (~> 0.3)
+      tty-prompt (~> 0.18)
     license_scout (1.0.24)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
@@ -191,7 +201,7 @@ GEM
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (2.0.3)
-    mixlib-config (2.2.18)
+    mixlib-config (3.0.1)
       tomlrb
     mixlib-install (3.11.12)
       mixlib-shellout
@@ -206,6 +216,7 @@ GEM
     molinillo (0.6.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    necromancer (0.4.0)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-sftp (2.1.2)
@@ -232,6 +243,9 @@ GEM
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
+    pastel (0.7.2)
+      equatable (~> 0.5.0)
+      tty-color (~> 0.4.0)
     pedump (0.5.2)
       awesome_print
       iostruct (>= 0.0.4)
@@ -250,7 +264,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-its (1.3.0)
@@ -284,10 +298,18 @@ GEM
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
       sfl
+    strings (0.1.5)
+      strings-ansi (~> 0.1)
+      unicode-display_width (~> 1.5)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.1.0)
     structured_warnings (0.3.0)
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (2.0.1)
+    test-kitchen (2.2.0)
+      bcrypt_pbkdf (~> 1.0)
+      ed25519 (~> 1.2)
+      license-acceptance (>= 0.2.16, < 2.0)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (>= 1.1, < 3.0)
@@ -298,9 +320,29 @@ GEM
       winrm-elevated (~> 1.0)
       winrm-fs (~> 1.1)
     thor (0.20.3)
+    timers (4.3.0)
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.8)
+    tty-box (0.3.0)
+      pastel (~> 0.7.2)
+      strings (~> 0.1.4)
+      tty-cursor (~> 0.6.0)
+    tty-color (0.4.3)
+    tty-cursor (0.6.1)
+    tty-prompt (0.18.1)
+      necromancer (~> 0.4.0)
+      pastel (~> 0.7.0)
+      timers (~> 4.0)
+      tty-cursor (~> 0.6.0)
+      tty-reader (~> 0.5.0)
+    tty-reader (0.5.0)
+      tty-cursor (~> 0.6.0)
+      tty-screen (~> 0.6.4)
+      wisper (~> 2.0.0)
+    tty-screen (0.6.5)
+    unicode-display_width (1.5.0)
+    unicode_utils (1.4.0)
     uuidtools (2.1.5)
     win32-api (1.5.3-universal-mingw32)
     win32-certstore (0.3.0)
@@ -320,13 +362,13 @@ GEM
       win32-ipc (>= 0.6.0)
     win32-process (0.8.3)
       ffi (>= 1.0.0)
-    win32-service (2.1.2)
+    win32-service (2.1.4)
       ffi
       ffi-win32-extensions
     win32-taskscheduler (2.0.4)
       ffi
       structured_warnings
-    winrm (2.3.1)
+    winrm (2.3.2)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -343,6 +385,7 @@ GEM
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
+    wisper (2.0.0)
     wmi-lite (1.0.2)
     zhexdump (0.0.2)
 


### PR DESCRIPTION
Remove some branch mess in travis/appveyor, prevented the new kitchen-ec2 plugin from coming in, and bumped the world.