### PR TITLE
Fix describe-cookbook to support cookbooks with metadata.json

### DIFF
--- a/lib/chef-dk/command/describe_cookbook.rb
+++ b/lib/chef-dk/command/describe_cookbook.rb
@@ -74,7 +74,7 @@ module ChefDK
         mdrb_path = File.join(cookbook_path, "metadata.rb")
         mdjson_path = File.join(cookbook_path, "metadata.json")
 
-        if !File.exist?(mdrb_path) && !File.exist?(mdjson_path)
+        unless File.exist?(mdrb_path) || File.exist?(mdjson_path)
           ui.err("Given cookbook path '#{cookbook_path}' does not appear to be a cookbook, it does not contain a metadata.rb or metadata.json")
           return false
         end

--- a/lib/chef-dk/command/describe_cookbook.rb
+++ b/lib/chef-dk/command/describe_cookbook.rb
@@ -71,9 +71,11 @@ module ChefDK
           return false
         end
 
-        md_path = File.join(cookbook_path, "metadata.rb")
-        unless File.exist?(md_path)
-          ui.err("Given cookbook path '#{cookbook_path}' does not appear to be a cookbook, it does not contain a metadata.rb")
+        mdrb_path = File.join(cookbook_path, "metadata.rb")
+        mdjson_path = File.join(cookbook_path, "metadata.json")
+
+        if !File.exist?(mdrb_path) && !File.exist?(mdjson_path)
+          ui.err("Given cookbook path '#{cookbook_path}' does not appear to be a cookbook, it does not contain a metadata.rb or metadata.json")
           return false
         end
         true


### PR DESCRIPTION
### Description

`describe-cookbook` should consider cookbooks with a metadata.json file as a valid cookbook.

### Issues Resolved

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG