### PR TITLE
Update cookbook templates to use Ubuntu 18.04

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/README.md
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/README.md
@@ -47,9 +47,9 @@ The change we'll use for an example is to install the `zsh` package. Write a fai
 require 'spec_helper'
 
 describe 'godzilla::default' do
-  context 'When all attributes are default, on Ubuntu 16.04' do
+  context 'When all attributes are default, on Ubuntu 18.04' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04')
       runner.converge(described_recipe)
     end
 

--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/kitchen.yml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/kitchen.yml
@@ -11,7 +11,7 @@ provisioner:
   product_name: chefdk
 
 platforms:
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-7
 
 suites:

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -13,7 +13,7 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-7
 
 suites:

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_dokken.yml.erb
@@ -14,9 +14,9 @@ verifier:
 platforms:
   # @see https://github.com/someara/dokken-images
   # @see https://hub.docker.com/r/dokken/
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
     driver:
-      image: dokken/ubuntu-16.04
+      image: dokken/ubuntu-18.04
   - name: centos-7
     driver:
       image: dokken/centos-7

--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen_policyfile.yml.erb
@@ -22,7 +22,7 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-7
 
 suites:

--- a/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/recipe_spec.rb.erb
@@ -7,11 +7,11 @@
 require 'spec_helper'
 
 describe '<%= cookbook_name %>::<%= recipe_name %>' do
-  context 'When all attributes are default, on Ubuntu 16.04' do
+  context 'When all attributes are default, on Ubuntu 18.04' do
     let(:chef_run) do
       # for a complete list of available platforms and versions see:
       # https://github.com/customink/fauxhai/blob/master/PLATFORMS.md
-      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '18.04')
       runner.converge(described_recipe)
     end
 

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -586,7 +586,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
               name: inspec
 
             platforms:
-              - name: ubuntu-16.04
+              - name: ubuntu-18.04
               - name: centos-7
 
             suites:
@@ -663,7 +663,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
               name: inspec
 
             platforms:
-              - name: ubuntu-16.04
+              - name: ubuntu-18.04
               - name: centos-7
 
             suites:


### PR DESCRIPTION
We should auto generate cookbooks testing Ubuntu 18.04 not 16.04.

Signed-off-by: Tim Smith <tsmith@chef.io>