### PR TITLE
Update the omnibus build license to the Chef EULA

### DIFF
--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -18,8 +18,8 @@ name "chefdk"
 friendly_name "Chef Development Kit"
 maintainer "Chef Software, Inc. <maintainers@chef.io>"
 homepage "https://www.chef.io"
-license "Apache-2.0"
-license_file "../LICENSE"
+license "Chef EULA"
+license_file "https://www.chef.io/end-user-license-agreement/"
 
 build_iteration 1
 require_relative "../../../lib/chef-dk/version"


### PR DESCRIPTION
The resulting distribuions are licensed under the Chef EULA.

Signed-off-by: Bryan McLellan <btm@loftninjas.org>