### PR TITLE
update repo to new Chef OSS practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 [![Docker Stars](https://img.shields.io/docker/stars/chef/chefdk.svg?maxAge=2592000)](https://hub.docker.com/r/chef/chefdk)
 [![Docker Pulls](https://img.shields.io/docker/pulls/chef/chefdk.svg?maxAge=2592000)](https://hub.docker.com/r/chef/chefdk)
 
+**Umbrella Project**: [Workstation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-workstation.md)
+
+* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Active
+* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+
 Chef Development Kit (ChefDK) brings Chef and the development tools developed by the Chef Community together and acts as the consistent interface to this awesomeness. This awesomeness is composed of:
 
 * [Chef][]

--- a/tasks/dependencies.rb
+++ b/tasks/dependencies.rb
@@ -33,7 +33,7 @@ namespace :dependencies do
       # in the lock file we be updated in an incompatible way. Bundler 2.1 *may* fix this issue for us.
       bundler_version = `grep bundler omnibus_overrides.rb | cut -d'"' -f2`
       gem "bundler", "~> #{bundler_version}"
-      
+
       Dir.chdir(dir) do
         Bundler.with_clean_env do
           rm_f "#{dir}/Gemfile.lock"


### PR DESCRIPTION
### Description

In accordance with https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md

* update README with project state and response times

Bonus trailing whitespace removal to appease chefstyle.