### PR TITLE
More branding fixes + generator improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Chef Development Kit (ChefDK) brings Chef and the development tools developed by the Chef Community together and acts as the consistent interface to this awesomeness. This awesomeness is composed of:
 
-* [Chef][]
+* [Chef Infra Client][]
 * [Berkshelf][]
 * [Test Kitchen][]
 * [ChefSpec][]
@@ -79,7 +79,7 @@ some helpful bits of functionality already included in the `chef`
 command:
 
 #### `chef generate`
-The generate subcommand generates skeleton Chef code
+The generate subcommand generates skeleton Chef Infra code
 layouts so you can skip repetitive boilerplate and get down to
 automating your infrastructure quickly. Unlike other generators, it only
 generates the minimum required files when creating a cookbook so you can
@@ -185,7 +185,7 @@ environment, you can continue to do so. Just ensure that the ChefDK
 provided applications appear first in your `PATH` before any
 gem-installed versions and you're good to go.
 
-If you'd like to use ChefDK as your primary Ruby/Chef development
+If you'd like to use ChefDK as your primary Ruby/Chef Infra development
 environment, however, you can do so by initializing your shell with
 ChefDK's environment.
 
@@ -322,8 +322,8 @@ packaging, and building works.
 - - -
 
 [Berkshelf]: https://docs.chef.io/berkshelf.html "Berkshelf"
-[Chef]: https://www.chef.io/chef/ "Chef"
-[ChefDK]: https://downloads.chef.io/chefdk "Chef Development Kit"
+[Chef Infra Client]: https://www.chef.io/products/chef-infra/ "Chef Infra Client"
+[ChefDK]: https://downloads.chef.io/chefdk/ "Chef Development Kit"
 [Chef Documentation]: https://docs.chef.io "Chef Documentation"
 [ChefSpec]: http://chefspec.github.io/chefspec/ "ChefSpec"
 [Cookstyle]: https://docs.chef.io/cookstyle.html "Cookstyle"

--- a/lib/chef-dk/command/generate.rb
+++ b/lib/chef-dk/command/generate.rb
@@ -55,7 +55,7 @@ module ChefDK
       generator(:repo, :Repo, "Generate a Chef code repository")
       generator(:policyfile, :Policyfile, "Generate a Policyfile for use with the install/push commands")
       generator(:generator, :GeneratorGenerator, "Copy ChefDK's generator cookbook so you can customize it")
-      generator(:'build-cookbook', :BuildCookbook, "Generate a build cookbook for use with Delivery")
+      generator(:'build-cookbook', :BuildCookbook, "Generate a build cookbook for use with Chef Workflow (Delivery)")
 
       def self.banner_headline
         <<~E

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -229,7 +229,7 @@ module ChefDK
       def create_client_rb
         File.open(client_rb_staging_path, "wb+") do |f|
           f.print( <<~CONFIG )
-            ### Chef Client Configuration ###
+            ### Chef Infra Client Configuration ###
             # The settings in this file will configure chef to apply the exported policy in
             # this directory. To use it, run:
             #
@@ -279,9 +279,9 @@ module ChefDK
 
             ### .chef/config.rb
 
-            A configuration file for Chef Client. This file configures Chef Client to use
-            the correct `policy_name` and `policy_group` for this exported repository. Chef
-            Client will use this configuration automatically if you've set your working
+            A configuration file for Chef Infra Client. This file configures Chef Infra Client to
+            use the correct `policy_name` and `policy_group` for this exported repository. Chef
+            Infra Client will use this configuration automatically if you've set your working
             directory properly.
 
             ### cookbook_artifacts/

--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/README.md
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/README.md
@@ -74,7 +74,7 @@ cd .delivery/build_cookbook
 kitchen converge
 ```
 
-This will take some time at first, because the VMs need to be created, Chef installed, the Delivery CLI installed, etc. Later runs will be faster until they are destroyed. It will also fail on the first VM, as expected, because we wrote the test first. Now edit the parent cookbook project's default recipe to install `zsh`.
+This will take some time at first, because the VMs need to be created, Chef Infra Client installed, the Delivery CLI installed, etc. Later runs will be faster until they are destroyed. It will also fail on the first VM, as expected, because we wrote the test first. Now edit the parent cookbook project's default recipe to install `zsh`.
 
 ```
 cd ../../
@@ -114,7 +114,7 @@ Recipe: test::default
 
 Running handlers:
 Running handlers complete
-Chef Client finished, 3/32 resources updated in 54.665445968 seconds
+Chef Infra Client finished, 3/32 resources updated in 54.665445968 seconds
 Finished converging <default-centos-71> (1m26.83s).
 ```
 

--- a/lib/chef-dk/skeletons/code_generator/files/default/chefignore
+++ b/lib/chef-dk/skeletons/code_generator/files/default/chefignore
@@ -102,6 +102,7 @@ Policyfile.lock.json
 CHANGELOG*
 CONTRIBUTING*
 TESTING*
+CODE_OF_CONDUCT*
 
 # Vagrant #
 ###########

--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
@@ -26,7 +26,7 @@ cleanup = "chef exec kitchen destroy"
 
 # Remote project.toml file
 #
-# Instead of the local phases above you may specify a remote URI location for
+# Instead of the local phases above, you may specify a remote URI location for
 # the `project.toml` file. This is useful for teams that wish to centrally
 # manage the behavior of the `delivery local` command across many different
 # projects.

--- a/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
+++ b/lib/chef-dk/skeletons/code_generator/files/default/delivery-project.toml
@@ -1,15 +1,12 @@
-# Delivery Prototype for Local Phases Execution
+# Delivery for Local Phases Execution
 #
-# The purpose of this file is to prototype a new way to execute
-# phases locally on your workstation. The delivery-cli will read
-# this file and execute the command(s) that are configured for
-# each phase. You can customize them by just modifying the phase
-# key on this file.
+# This file allows you to execute test phases locally on a workstation or
+# in a CI pipeline. The delivery-cli will read this file and execute the
+# command(s) that are configured for each phase. You can customize them
+# by just modifying the phase key on this file.
 #
 # By default these phases are configured for Cookbook Workflow only
 #
-# As this is still a prototype we are not modifying the current
-# config.json file and it will continue working as usual.
 
 [local_phases]
 unit = "chef exec rspec spec/"
@@ -29,8 +26,9 @@ cleanup = "chef exec kitchen destroy"
 
 # Remote project.toml file
 #
-# Specify a remote URI location for the `project.toml` file.
-# This is useful for teams that wish to centrally manage the behavior
-# of the `delivery local` command across many different projects.
+# Instead of the local phases above you may specify a remote URI location for
+# the `project.toml` file. This is useful for teams that wish to centrally
+# manage the behavior of the `delivery local` command across many different
+# projects.
 #
 # remote_file = "https://url/project.toml"

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -180,18 +180,15 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
         let(:expected_content) do
           <<~PROJECT_DOT_TOML
-            # Delivery Prototype for Local Phases Execution
+            # Delivery for Local Phases Execution
             #
-            # The purpose of this file is to prototype a new way to execute
-            # phases locally on your workstation. The delivery-cli will read
-            # this file and execute the command(s) that are configured for
-            # each phase. You can customize them by just modifying the phase
-            # key on this file.
+            # This file allows you to execute test phases locally on a workstation or
+            # in a CI pipeline. The delivery-cli will read this file and execute the
+            # command(s) that are configured for each phase. You can customize them
+            # by just modifying the phase key on this file.
             #
             # By default these phases are configured for Cookbook Workflow only
             #
-            # As this is still a prototype we are not modifying the current
-            # config.json file and it will continue working as usual.
 
             [local_phases]
             unit = "chef exec rspec spec/"
@@ -211,9 +208,10 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
             # Remote project.toml file
             #
-            # Specify a remote URI location for the `project.toml` file.
-            # This is useful for teams that wish to centrally manage the behavior
-            # of the `delivery local` command across many different projects.
+            # Instead of the local phases above you may specify a remote URI location for
+            # the `project.toml` file. This is useful for teams that wish to centrally
+            # manage the behavior of the `delivery local` command across many different
+            # projects.
             #
             # remote_file = "https://url/project.toml"
           PROJECT_DOT_TOML

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -208,7 +208,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
             # Remote project.toml file
             #
-            # Instead of the local phases above you may specify a remote URI location for
+            # Instead of the local phases above, you may specify a remote URI location for
             # the `project.toml` file. This is useful for teams that wish to centrally
             # manage the behavior of the `delivery local` command across many different
             # projects.

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -269,7 +269,7 @@ describe ChefDK::PolicyfileServices::ExportRepo do
 
           it "creates a working local mode configuration file" do
             expected_config_text = <<~CONFIG
-              ### Chef Client Configuration ###
+              ### Chef Infra Client Configuration ###
               # The settings in this file will configure chef to apply the exported policy in
               # this directory. To use it, run:
               #


### PR DESCRIPTION
Add code of conduct files to the chefignore so these don't go up to the server
Replace Delivery with Workflow in a few places
Take the prototype bit out of the Delivery local mode file comments
Chef Client -> Chef Infra Client in more places

Signed-off-by: Tim Smith <tsmith@chef.io>