### PR TITLE
Make chef generate repo quiet by default

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ The `chef generate` command has been updated to produce cookbooks and repositori
   - `chef generate cookbook --kitchen dokken` now generates a fully working kitchen-dokken config.
   - `chef generate cookbook` now generates Test Kitchen configs with the `product_name`/`product_version` method of specifying Chef Infra Client releases as `require_chef_omnibus` will be removed in the next major Test Kitchen release.
   - `chef generate cookbook_file` no longer places the specified file in a "default" folder as these aren't needed in Chef Infra Client 12 and later.
+  - `chef generate repo` no longer outputs the full Chef Infra Client run information while generating the repository. Similar to the `cookbook` command you can view this verbose output with the `--verbose` flag.
 
 ## Updated Components and Tools
 

--- a/lib/chef-dk/command/generator_commands/repo.rb
+++ b/lib/chef-dk/command/generator_commands/repo.rb
@@ -51,12 +51,20 @@ module ChefDK
           boolean:      true,
           default:      nil
 
+        option :verbose,
+          short:        "-V",
+          long:         "--verbose",
+          description:  "Show detailed output from the generator",
+          boolean:      true,
+          default:      false
+
         options.merge!(SharedGeneratorOptions.options)
 
         def initialize(params)
           @params_valid = true
           @repo_name = nil
           @use_policy = true
+          @verbose = false
           super
         end
 
@@ -64,7 +72,10 @@ module ChefDK
           read_and_validate_params
           if params_valid?
             setup_context
+            msg("Generating Chef Infra repo #{repo_name}")
             chef_runner.converge
+            msg("")
+            msg("Your new Chef Infra repo is ready! Type `cd #{repo_name}` to enter it.")
             0
           else
             err(opt_parser)
@@ -74,6 +85,7 @@ module ChefDK
 
         def setup_context
           super
+          Generator.add_attr_to_context(:verbose, verbose?)
           Generator.add_attr_to_context(:repo_root, repo_root)
           Generator.add_attr_to_context(:repo_name, repo_name)
           Generator.add_attr_to_context(:use_policy, use_policy?)
@@ -97,6 +109,10 @@ module ChefDK
 
         def use_policy?
           @use_policy
+        end
+
+        def verbose?
+          @verbose
         end
 
         def read_and_validate_params

--- a/lib/chef-dk/skeletons/code_generator/recipes/repo.rb
+++ b/lib/chef-dk/skeletons/code_generator/recipes/repo.rb
@@ -1,6 +1,10 @@
 context = ChefDK::Generator.context
 repo_dir = File.join(context.repo_root, context.repo_name)
 
+silence_chef_formatter unless context.verbose
+
+generator_desc('Ensuring correct Chef Infra repo file content')
+
 # repo root dir
 directory repo_dir
 


### PR DESCRIPTION
This matches the behavior of chef generate cookbook. We should probably just get verbose pushed up into generate itself and utilize it there, but this achieves the desired user experience of not seeing 2 pages of chef run when all you want is to know if the repo was generated.

Signed-off-by: Tim Smith <tsmith@chef.io>