### PR TITLE
Update command help / contents to make sense in Workstation

### DIFF
--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -46,8 +46,8 @@ module ChefDK
       banner(<<~HELP)
         Usage: chef shell-init
 
-        `chef shell-init` modifies your shell environment to make ChefDK your default
-        ruby.
+        `chef shell-init` modifies your shell environment to make ChefDK or Workstation your
+        default Ruby.
 
           To enable for just the current shell session:
 

--- a/lib/chef-dk/policyfile_services/push_archive.rb
+++ b/lib/chef-dk/policyfile_services/push_archive.rb
@@ -90,8 +90,8 @@ module ChefDK
             This archive is in an unsupported format.
 
             This archive was created with an older version of ChefDK. This version of
-            ChefDK does not support archives in the older format. Re-create the archive
-            with a newer version of ChefDK or downgrade ChefDK.
+            ChefDK does not support archives in the older format. Please Re-create the
+            archive with a newer version of ChefDK or Workstation.
           MESSAGE
         end
 

--- a/lib/chef-dk/skeletons/code_generator/files/default/repo/dot-chef-repo.txt
+++ b/lib/chef-dk/skeletons/code_generator/files/default/repo/dot-chef-repo.txt
@@ -1,6 +1,6 @@
 .chef-repo.txt
 ==============
 
-This file gives Chef DK's generators a hint that you are using a Chef Repo and
-this is the root directory of your Chef Repo. Chef DK's generators use this to
-generate code that is designed to work with the Chef Repo workflow.
+This file gives the Chef CLI's generators a hint that you are using a Chef Infra
+Repo and this is the root directory of your Chef Infra Repo. Chef CLI's generators
+use this to generate code that is designed to work with the Chef Repo workflow.

--- a/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/Policyfile.rb.erb
@@ -1,4 +1,4 @@
-# Policyfile.rb - Describe how you want Chef to build your system.
+# Policyfile.rb - Describe how you want Chef Infra Client to build your system.
 #
 # For more information on the Policyfile feature, visit
 # https://docs.chef.io/policyfile.html

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -525,7 +525,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
 
         let(:expected_content) do
           <<~POLICYFILE_RB
-            # Policyfile.rb - Describe how you want Chef to build your system.
+            # Policyfile.rb - Describe how you want Chef Infra Client to build your system.
             #
             # For more information on the Policyfile feature, visit
             # https://docs.chef.io/policyfile.html

--- a/spec/unit/command/generator_commands/policyfile_spec.rb
+++ b/spec/unit/command/generator_commands/policyfile_spec.rb
@@ -115,7 +115,7 @@ describe ChefDK::Command::GeneratorCommands::Policyfile do
 
     let(:expected_policyfile_content) do
       <<~POLICYFILE_RB
-        # Policyfile.rb - Describe how you want Chef to build your system.
+        # Policyfile.rb - Describe how you want Chef Infra Client to build your system.
         #
         # For more information on the Policyfile feature, visit
         # https://docs.chef.io/policyfile.html

--- a/spec/unit/command/generator_commands/repo_spec.rb
+++ b/spec/unit/command/generator_commands/repo_spec.rb
@@ -215,7 +215,7 @@ describe ChefDK::Command::GeneratorCommands::Repo do
         let(:file) { ".chef-repo.txt" }
 
         it "explains why it's there" do
-          expect(file_contents).to include("This file gives Chef DK's generators a hint")
+          expect(file_contents).to include("This file gives the Chef CLI's generators a hint")
         end
       end
 

--- a/spec/unit/policyfile_services/push_archive_spec.rb
+++ b/spec/unit/policyfile_services/push_archive_spec.rb
@@ -287,8 +287,8 @@ describe ChefDK::PolicyfileServices::PushArchive do
               This archive is in an unsupported format.
 
               This archive was created with an older version of ChefDK. This version of
-              ChefDK does not support archives in the older format. Re-create the archive
-              with a newer version of ChefDK or downgrade ChefDK.
+              ChefDK does not support archives in the older format. Please Re-create the
+              archive with a newer version of ChefDK or Workstation.
             MESSAGE
             expect(exception_cause.message).to eq(msg)
           end


### PR DESCRIPTION
These commands run in Workstation, which is a bit confusing when everything says DK all over. We should probably use our own dist file concept to get around this, but this makes things more generic, which works for now.

Signed-off-by: Tim Smith <tsmith@chef.io>