### PR TITLE
Modernize the chef resource used to log during generate commands

### DIFF
--- a/lib/chef-dk/command/generator_commands/chef_exts/generator_desc_resource.rb
+++ b/lib/chef-dk/command/generator_commands/chef_exts/generator_desc_resource.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,6 @@
 #
 
 require "chef/resource"
-require "chef/provider"
 
 module ChefDK
   module ChefResource
@@ -28,58 +27,14 @@ module ChefDK
     # As the name implies, it is used to describe the steps that the generator
     # takes to create a cookbook.
     class GeneratorDesc < Chef::Resource
+      resource_name :generator_desc
 
-      resource_name(:generator_desc)
-
-      identity_attr(:message)
-
-      default_action(:write)
-
-      def initialize(name, run_context = nil)
-        super
-        @message = name
-      end
-
-      def message(arg = nil)
-        set_or_return(
-          :message,
-          arg,
-          kind_of: String
-        )
-      end
-
-    end
-  end
-
-  module ChefProvider
-
-    # Chef log provider, allows logging to chef's logs from recipes
-    class GeneratorDesc < Chef::Provider
-
-      provides :generator_desc
-
-      def whyrun_supported?
-        true
-      end
-
-      # No concept of a 'current' resource for logs, this is a no-op
-      #
-      # === Return
-      # true:: Always return true
-      def load_current_resource
-        true
-      end
+      property :message, String, name_property: true
 
       # Write the log to Chef's log
-      #
-      # === Return
-      # true:: Always return true
-      def action_write
+      action :write do
         run_context.events.subscribers.first.puts_line("- #{new_resource.message}")
-        new_resource.updated_by_last_action(true)
       end
-
     end
-
   end
 end

--- a/spec/unit/command/generator_commands/chef_exts/generator_desc_resource_spec.rb
+++ b/spec/unit/command/generator_commands/chef_exts/generator_desc_resource_spec.rb
@@ -72,26 +72,10 @@ describe ChefDK::ChefResource::GeneratorDesc do
       expect(resource.identity).to eq(message)
     end
 
-  end
-
-  describe "provider" do
-
-    let(:provider) do
-      ChefDK::ChefProvider::GeneratorDesc.new(resource, run_context)
-    end
-
-    it "supports why run" do
-      expect(provider.whyrun_supported?).to be(true)
-    end
-
-    it "does nothing for load current resource" do
-      expect(provider.load_current_resource).to be(true)
-    end
-
     it "writes the message to the formatter" do
-      provider.action_write
+      resource.action_write
       expect(stdout.string).to include(message)
     end
-  end
 
+  end
 end

--- a/spec/unit/command/generator_commands/chef_exts/generator_desc_resource_spec.rb
+++ b/spec/unit/command/generator_commands/chef_exts/generator_desc_resource_spec.rb
@@ -36,9 +36,7 @@ describe ChefDK::ChefResource::GeneratorDesc do
 
   let(:stderr) { StringIO.new }
 
-  let(:null_formatter) do
-    Chef::Formatters.new(:null, stdout, stderr)
-  end
+  let(:null_formatter) { Chef::Formatters.new(:null, stdout, stderr) }
 
   let(:events) do
     Chef::EventDispatch::Dispatcher.new.tap do |d|
@@ -48,15 +46,13 @@ describe ChefDK::ChefResource::GeneratorDesc do
 
   let(:cookbook_collection) { Chef::CookbookCollection.new }
 
-  let(:run_context) do
-    Chef::RunContext.new(node, cookbook_collection, events)
-  end
+  let(:run_context) { Chef::RunContext.new(node, cookbook_collection, events) }
 
   let(:message) { "this part of the cookbook does a thing" }
 
-  let(:resource) do
-    described_class.new(message, run_context)
-  end
+  let(:resource) { described_class.new(message, run_context) }
+
+  let(:provider) { resource.provider_for_action(:write) }
 
   describe "resource" do
 
@@ -73,7 +69,7 @@ describe ChefDK::ChefResource::GeneratorDesc do
     end
 
     it "writes the message to the formatter" do
-      resource.action_write
+      provider.action_write
       expect(stdout.string).to include(message)
     end
 


### PR DESCRIPTION
This was very Chef < 12.5 and needed some love.

Signed-off-by: Tim Smith <tsmith@chef.io>