### PR TITLE
Prevent double bundler by pinning to 1.17.2

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -5,7 +5,7 @@
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
 override :rubygems, version: "3.0.3"
-override :bundler, version: "1.17.3"
+override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"
 override "liblzma", version: "5.2.4"


### PR DESCRIPTION
Otherwise we have 1.17.2 and 1.17.3 and that introduces extreme performance issues.

Signed-off-by: Tim Smith <tsmith@chef.io>