### PR TITLE
Revert the Gemfile.lock back to 1.17.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -933,4 +933,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
I accidentally bumped this in my last PR

Signed-off-by: Tim Smith <tsmith@chef.io>