### PR TITLE
'chef verify' strips all the environment so add CHEF_LICENSE back

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -342,7 +342,7 @@ module ChefDK
               INSPEC_TEST
             end
             # TODO when we appbundle inspec, no longer `chef exec`
-            sh("#{bin("chef")} exec #{embedded_bin("inspec")} exec . --chef-license=accept-no-persist", cwd: cwd)
+            sh("#{bin("chef")} exec #{embedded_bin("inspec")} exec .", cwd: cwd)
           end
         end
       end
@@ -423,7 +423,7 @@ module ChefDK
                 end
               EOF
             end
-            sh("#{bin("chef-apply")} foo.rb --chef-license 'accept-no-persist'", cwd: cwd)
+            sh("#{bin("chef-apply")} foo.rb", cwd: cwd)
           end
         end
       end

--- a/lib/chef-dk/component_test.rb
+++ b/lib/chef-dk/component_test.rb
@@ -181,6 +181,7 @@ module ChefDK
           # Add the embedded/bin to the PATH so that bundle executable can
           # be found while running the tests.
           path_variable_key => omnibus_path,
+          "CHEF_LICENSE" => "accept-no-persist",
         },
         timeout: 3600,
       }


### PR DESCRIPTION
### Description

Set it in the default environment variables so future tests don't need
any special change to work.

### Issues Resolved

Windows pipeline failures

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG