### PR TITLE
ChefDK 4.x Release notes prep for promotion to stable

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -72,16 +72,16 @@ subscriptions:
   - workload: artifact_published:current:chefdk:{{version_constraint}}
     actions:
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
+      # - built_in:promote_habitat_packages Disable until we fix our hab package
   - workload: artifact_published:stable:chefdk:{{version_constraint}}
     actions:
       - built_in:rollover_changelog
       - bash:.expeditor/update_dockerfile.sh
       - built_in:tag_docker_image
-      - built_in:promote_habitat_packages
+      # - built_in:promote_habitat_packages Disable until we fix our hab package
       - built_in:publish_rubygems
       - built_in:notify_chefio_slack_channels
-  - workload: artifact_published:stable:chef:14*
+  - workload: artifact_published:stable:chef:15*
     actions:
       - bash:.expeditor/update_chef.sh
   - workload: ruby_gem_published:mixlib-archive-*

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,4 @@
-# ChefDK 4.0 WIP Release Notes
-
-**4.0 is not out yet. These are work in progress release notes**
+# ChefDK 4.0 Release Notes
 
 ## Improved Chef Generate command
 
@@ -47,6 +45,22 @@ Kitchen-ec2 has been updated to 3.0, which uses the newer `aws-sdk-v3` and inclu
 ### Chef Provisioning
 
 Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019. The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard GitHub organization and will not be further maintained. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+### `knife bootstrap` against cloud providers
+
+`knife bootstrap` was
+[rewritten](https://github.com/chef/chef/blob/cfbb01cb5648297835941679bc9638d3a823ad5e/RELEASE_NOTES.md#knife-bootstrap)
+in Chef Infra Client 15. The `knife-*` cloud providers need to be updated to use this new API. As of ChefDK 4.0 `knife
+bootstrap` functionality against the cloud providers will be broken. We will fix this ASAP in a ChefDK 4.1 release. The
+only gem *not* affected is the `knife-windows` gem. It has already been re-written to leverage the new bootstrap
+library.
+
+Affected gems:
+* `knife-ec2`
+* `knife-google`
+* `knife-vsphere`
+
+If you leverage this functionality please wait to update ChefDK until 4.1 is released with fixes for these gems.
 
 # ChefDK 3.10 Release Notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,7 +50,7 @@ Chef Provisioning is no longer included with Chef DK, and will be officially end
 
 `knife bootstrap` was
 [rewritten](https://github.com/chef/chef/blob/cfbb01cb5648297835941679bc9638d3a823ad5e/RELEASE_NOTES.md#knife-bootstrap)
-in Chef Infra Client 15. The `knife-*` cloud providers need to be updated to use this new API. As of ChefDK 4.0 `knife
+in Chef Infra Client 15. The `knife-*` cloud providers need to be updated to use this new API. As of ChefDK 4.0, `knife
 bootstrap` functionality against the cloud providers will be broken. We will fix this ASAP in a ChefDK 4.1 release. The
 only gem *not* affected is the `knife-windows` gem. It has already been re-written to leverage the new bootstrap
 library.
@@ -60,7 +60,7 @@ Affected gems:
 * `knife-google`
 * `knife-vsphere`
 
-If you leverage this functionality please wait to update ChefDK until 4.1 is released with fixes for these gems.
+If you leverage this functionality, please wait to update ChefDK until 4.1 is released with fixes for these gems.
 
 # ChefDK 3.10 Release Notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,27 @@
 # ChefDK 4.0 Release Notes
 
+## Breaking Changes
+
+### Chef Provisioning
+
+Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019. The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard GitHub organization and will not be further maintained. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
+
+### `knife bootstrap` against cloud providers
+
+`knife bootstrap` was [rewritten](https://github.com/chef/chef/blob/cfbb01cb5648297835941679bc9638d3a823ad5e/RELEASE_NOTES.md#knife-bootstrap) in Chef Infra Client 15.
+The `knife-*` cloud providers need to be updated to use this new API.
+As of ChefDK 4.0, `knife bootstrap` functionality against the cloud providers will be broken.
+We will fix this ASAP in a ChefDK 4.1 release.
+The only gem *not* affected is the `knife-windows` gem.
+It has already been re-written to leverage the new bootstrap library.
+
+Affected gems:
+* `knife-ec2`
+* `knife-google`
+* `knife-vsphere`
+
+If you leverage this functionality, please wait to update ChefDK until 4.1 is released with fixes for these gems.
+
 ## Improved Chef Generate command
 
 The `chef generate` command has been updated to produce cookbooks and repositories that match Chef's best practices.
@@ -39,28 +61,6 @@ Test Kitchen has been updated from 1.24 to 2.2.5. This update adds support for a
 ### Kitchen-ec2 3.0
 
 Kitchen-ec2 has been updated to 3.0, which uses the newer `aws-sdk-v3` and includes a large number of improvements to the driver including improved hostname detection, backoff retries, additional security group configuration options, and more. See the [kitchen-ec2 Changelog](https://github.com/test-kitchen/kitchen-ec2/blob/master/CHANGELOG.md#v300-2019-05-01) for additional details.
-
-## Breaking Changes
-
-### Chef Provisioning
-
-Chef Provisioning is no longer included with Chef DK, and will be officially end of life on August 31, 2019. The source code of Chef Provisioning and the drivers have been moved into the chef-boneyard GitHub organization and will not be further maintained. Current users of Chef Provisioning should contact your Chef Customer Success Manager or Account Representative to review your options.
-
-### `knife bootstrap` against cloud providers
-
-`knife bootstrap` was [rewritten](https://github.com/chef/chef/blob/cfbb01cb5648297835941679bc9638d3a823ad5e/RELEASE_NOTES.md#knife-bootstrap) in Chef Infra Client 15.
-The `knife-*` cloud providers need to be updated to use this new API.
-As of ChefDK 4.0, `knife bootstrap` functionality against the cloud providers will be broken.
-We will fix this ASAP in a ChefDK 4.1 release.
-The only gem *not* affected is the `knife-windows` gem.
-It has already been re-written to leverage the new bootstrap library.
-
-Affected gems:
-* `knife-ec2`
-* `knife-google`
-* `knife-vsphere`
-
-If you leverage this functionality, please wait to update ChefDK until 4.1 is released with fixes for these gems.
 
 # ChefDK 3.10 Release Notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,12 +48,12 @@ Chef Provisioning is no longer included with Chef DK, and will be officially end
 
 ### `knife bootstrap` against cloud providers
 
-`knife bootstrap` was
-[rewritten](https://github.com/chef/chef/blob/cfbb01cb5648297835941679bc9638d3a823ad5e/RELEASE_NOTES.md#knife-bootstrap)
-in Chef Infra Client 15. The `knife-*` cloud providers need to be updated to use this new API. As of ChefDK 4.0, `knife
-bootstrap` functionality against the cloud providers will be broken. We will fix this ASAP in a ChefDK 4.1 release. The
-only gem *not* affected is the `knife-windows` gem. It has already been re-written to leverage the new bootstrap
-library.
+`knife bootstrap` was [rewritten](https://github.com/chef/chef/blob/cfbb01cb5648297835941679bc9638d3a823ad5e/RELEASE_NOTES.md#knife-bootstrap) in Chef Infra Client 15.
+The `knife-*` cloud providers need to be updated to use this new API.
+As of ChefDK 4.0, `knife bootstrap` functionality against the cloud providers will be broken.
+We will fix this ASAP in a ChefDK 4.1 release.
+The only gem *not* affected is the `knife-windows` gem.
+It has already been re-written to leverage the new bootstrap library.
 
 Affected gems:
 * `knife-ec2`


### PR DESCRIPTION
### Description

* Adds a note about `knife bootstrap` cloud providers not working until we update the associated gems, will happen in 4.1
* Fix out expeditor config so we can successfully `/expeditor promote`

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG