### PR TITLE
Do not request license when users shell-init

### DIFF
--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -174,6 +174,11 @@ module ChefDK
       def powershell_export(var, val)
         emit_shell_cmd(%Q{$env:#{var}="#{val}"})
       end
+
+      def check_license_acceptance
+        # It gives a very weird error if users try to eval the shell-init command and it requests the
+        # license from them. Instead, let users shell-init without accepting the license.
+      end
     end
   end
 end


### PR DESCRIPTION
### Description
The shell tries to execute the error message 'you cannot run without
accepting the license...' and it is very non-intuitive for users.

### Issues Resolved
N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG