### PR TITLE
Update Dockerfile for Ruby 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Chef Software, Inc. <docker@chef.io>
 ARG CHANNEL=stable
 ARG VERSION=4.0.60
 ENV DEBIAN_FRONTEND=noninteractive \
-    PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:/root/.chefdk/gem/ruby/2.5.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    PATH=/opt/chefdk/bin:/opt/chefdk/embedded/bin:/root/.chefdk/gem/ruby/2.6.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Run the entire container with the default locale to be en_US.UTF-8
 RUN apt-get update && \


### PR DESCRIPTION
### Description

ChefDK is now on Ruby 2.6, this should be reflected in the PATH.  Gems installed using `chef gem install` will otherwise not be on the PATH.
