### PR TITLE
Update kitchen-dokken to 2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,7 +433,7 @@ GEM
     kitchen-digitalocean (0.10.3)
       droplet_kit (~> 2.8)
       test-kitchen (>= 1.17, < 3)
-    kitchen-dokken (2.6.9)
+    kitchen-dokken (2.7.0)
       docker-api (~> 1.33)
       lockfile (~> 2.1)
       test-kitchen (>= 1.15, < 3)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 4187714031ef65026ea91a38ce2b6b2087f8be7f
+  revision: 34e5138a5676dcaa3146a5a45aac4651ea2950ae
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,8 +32,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.167.0)
-    aws-sdk-core (3.53.1)
+    aws-partitions (1.168.0)
+    aws-sdk-core (3.54.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)


### PR DESCRIPTION
Pull in the latest dokken and omnibus-software as well

Signed-off-by: Tim Smith <tsmith@chef.io>