### PR TITLE
Update Ruby in the hab plan to 2.5.5

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(
   core/glibc
   core/busybox-static
   # if you change major or minor you also need to update the GEM_PATH below
-  core/ruby/2.5.3
+  core/ruby/2.5.5
   core/libxml2
   core/libxslt
   core/libiconv


### PR DESCRIPTION
This fixes failures in the hab package

Signed-off-by: Tim Smith <tsmith@chef.io>