### PR TITLE
Create omnibus buildkite pipelines

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -21,6 +21,11 @@ docker_images:
 
 pipelines:
   - habitat/build
+  - omnibus/release
+  - omnibus/adhoc:
+      definition: .expeditor/release.omnibus.yml
+      env:
+        - ADHOC: true
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -1,0 +1,36 @@
+---
+project-name: chefdk
+config: omnibus/omnibus.rb
+test-path: omnibus/omnibus-test.sh
+test-path-windows: omnibus/omnibus-test.ps1
+fips-platforms:
+  - el-*-x86_64
+  - windows-*
+builder-to-testers-map:
+  debian-8-x86_64:
+    - debian-8-x86_64
+    - debian-9-x86_64
+  el-6-x86_64:
+    - el-6-x86_64
+  el-7-x86_64:
+    - el-7-x86_64
+  mac_os_x-10.12-x86_64:
+    - mac_os_x-10.12-x86_64
+    - mac_os_x-10.13-x86_64
+    - mac_os_x-10.14-x86_64
+  sles-11-x86_64:
+    - sles-11-x86_64
+  sles-12-x86_64:
+    - sles-12-x86_64
+    - sles-15-x86_64
+  ubuntu-14.04-x86_64:
+    - ubuntu-14.04-x86_64
+    - ubuntu-16.04-x86_64
+    - ubuntu-18.04-x86_64
+  windows-2012r2-i386:
+    - windows-2012r2-i386
+  windows-2012r2-x86_64:
+    - windows-2008r2-x86_64
+    - windows-2012-x86_64
+    - windows-2012r2-x86_64
+    - windows-2016-x86_64

--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -1,0 +1,56 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+$channel = "$Env:CHANNEL"
+If ([string]::IsNullOrEmpty($channel)) { $channel = "unstable" }
+
+$product = "$Env:PRODUCT"
+If ([string]::IsNullOrEmpty($product)) { $product = "chefdk" }
+
+$version = "$Env:VERSION"
+If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
+
+. C:\buildkite-agent\bin\load-omnibus-toolchain.ps1
+
+If ($env:OMNIBUS_WINDOWS_ARCH -eq "x86") {
+  $architecture = "i386"
+}
+ElseIf ($env:OMNIBUS_WINDOWS_ARCH -eq "x64") {
+  $architecture = "x86_64"
+}
+
+Write-Output "--- Downloading $channel $product $version"
+$download_url = C:\opscode\omnibus-toolchain\embedded\bin\mixlib-install.bat download --url --channel "$channel" "$product" --version "$version" --architecture "$architecture"
+$package_file = "$Env:Temp\$(Split-Path -Path $download_url -Leaf)"
+Invoke-WebRequest -OutFile "$package_file" -Uri "$download_url"
+
+Write-Output "--- Checking that $package_file has been signed."
+If ((Get-AuthenticodeSignature "$package_file").Status -eq 'Valid') {
+  Write-Output "Verified $package_file has been signed."
+}
+Else {
+  Write-Output "Exiting with an error because $package_file has not been signed. Check your omnibus project config."
+  exit 1
+}
+
+Write-Output "--- Installing $channel $product $version"
+Start-Process "$package_file" /quiet -Wait
+
+Write-Output "--- Running verification for $channel $product $version"
+
+# reload Env:PATH to ensure it gets any changes that the install made (e.g. C:\opscode\inspec\bin\ )
+$Env:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+# Set TEMP and TMP environment variables to a short path because buildkite-agent user's default path is so long it causes tests to fail
+$Env:TEMP = "C:\cheftest"
+$Env:TMP = "C:\cheftest"
+Remove-Item -Recurse -Force $Env:TEMP -ErrorAction SilentlyContinue
+New-Item -ItemType directory -Path $Env:TEMP
+
+# Ensure user variables are set in git config
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+
+# Run this last so the correct exit code is propagated
+chef verify --chef-license 'accept-no-persist'
+If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ueo pipefail
+
+channel="${CHANNEL:-unstable}"
+product="${PRODUCT:-chefdk}"
+version="${VERSION:-latest}"
+
+echo "--- Installing $channel $product $version"
+package_file="$(install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
+
+echo "--- Verifying omnibus package is signed"
+check-omnibus-package-signed "$package_file"
+
+echo "--- Verifying ownership of package files"
+
+export INSTALL_DIR=/opt/chefdk
+NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
+if [[ "$NONROOT_FILES" == "" ]]; then
+  echo "Packages files are owned by root.  Continuing verification."
+else
+  echo "Exiting with an error because the following files are not owned by root:"
+  echo "$NONROOT_FILES"
+  exit 1
+fi
+
+echo "--- Running verification for $channel $product $version"
+
+# This has to be the last thing we run so that we return the correct exit code
+# to the Ci system. delivery-cli tests will cause a panic on some platforms
+# unless we set the terminal colors just right
+sudo TERM=xterm-256color CHEF_FIPS="" CHEF_LICENSE="accept-no-persist" chef verify --unit


### PR DESCRIPTION
### Description

_This is a release engineering only change._

This creates buildkite pipelines that will be used for omnibus builds/tests of the `master` branch. It does not actually replace the current build/test infrastructure. That will be done in a separate PR once we finish testing these new pipelines.