### PR TITLE
Remove some AIX code from our omnibus def

### DIFF
--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -72,14 +72,6 @@ build do
     config_hash["USE_ST_TIMESPEC"] = "YesPlease"
     config_hash["HAVE_BSD_SYSCTL"] = "YesPlease"
     config_hash["NO_R_TO_GCC_LINKER"] = "YesPlease"
-  elsif aix?
-    env["CC"] = "xlc_r"
-    env["INSTALL"] = "/opt/freeware/bin/install"
-    # xlc doesn't understand the '-Wl,-rpath' syntax at all so... we don't enable
-    # the NO_R_TO_GCC_LINKER flag. This means that it will try to use the
-    # old style -R for libraries and as a result, xlc will ignore it. In this case, we
-    # we want that to happen because we explicitly set the libpath with the correct
-    # command line argument in omnibus itself.
   else
     # Linux things!
     config_hash["HAVE_PATHS_H"] = "YesPlease"


### PR DESCRIPTION
This just came over when we copied the git def

Signed-off-by: Tim Smith <tsmith@chef.io>