### PR TITLE
Remove Ubuntu 14.04 from the build pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -23,8 +23,7 @@ builder-to-testers-map:
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
+  ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64
   windows-2012r2-i386:


### PR DESCRIPTION
Ubuntu 14.04 is EOL and we should stop building / testing packages for
it. Instead we'll build on Ubuntu 16.04 and test those packages on 16.04
and 18.04.

Signed-off-by: Tim Smith <tsmith@chef.io>