### PR TITLE
Fix habitat packages that didn't build

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -89,7 +89,7 @@ do_build() {
   bundle install --without dep_selector --no-deployment --jobs 2 --retry 5 --path $pkg_prefix
 
   gem build chef-dk.gemspec
-  gem install chef-dk-*.gem
+  gem install --no-doc chef-dk-*.gem
 }
 
 do_install() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,6 +2,7 @@ pkg_name=chef-dk
 pkg_origin=chef
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 pkg_description="The Chef Developer Kit"
+pkg_version=$(cat ../VERSION)
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
@@ -18,7 +19,7 @@ pkg_deps=(
   core/ruby26
   core/libxml2
   core/libxslt
-  core/libiconv
+  core/pkg-config
   core/xz
   core/zlib
   core/bundler
@@ -29,10 +30,6 @@ pkg_deps=(
 )
 
 pkg_svc_user=root
-
-pkg_version() {
-  cat ../VERSION
-}
 
 do_before() {
   do_default_before
@@ -78,7 +75,7 @@ do_build() {
   export GEM_HOME=${pkg_prefix}
   export GEM_PATH=${_bundler_dir}:${GEM_HOME}
 
-  export NOKOGIRI_CONFIG="--use-system-libraries --with-zlib-dir=${_zlib_dir} --with-xslt-dir=${_libxslt_dir} --with-xml2-include=${_libxml2_dir}/include/libxml2 --with-xml2-lib=${_libxml2_dir}/lib"
+  export NOKOGIRI_CONFIG="--use-system-libraries --with-zlib-dir=${_zlib_dir} --with-xslt-dir=${_libxslt_dir} --with-xml2-include=${_libxml2_dir}/include/libxml2 --with-xml2-lib=${_libxml2_dir}/lib --without-iconv"
   bundle config --local build.nokogiri "${NOKOGIRI_CONFIG}"
 
   bundle config --local silence_root_warning 1

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -96,38 +96,37 @@ do_install() {
   cd $CACHE_PATH
   mkdir -p $pkg_prefix/ruby-bin
 
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin chef-dk
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin chef
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin ohai
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin foodcritic
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin test-kitchen
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin berkshelf
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin inspec-bin
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin cookstyle
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin chef-apply
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin chef-vault
-  bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin dco
+  # Appbundling gems speeds up runtime by creating binstubs for Ruby executables with
+  # versions of dependencies already resolved
+  gems_to_appbundle=(
+    berkshelf
+    chef
+    chef-apply
+    chef-bin
+    chef-dk
+    chef-vault
+    cookstyle
+    dco
+    foodcritic
+    inspec-bin
+    ohai
+    test-kitchen
+  )
+  for gem in "${gems_to_appbundle[@]}"; do
+    build_line "AppBundling ${gem}"
+    bundle exec appbundler $HAB_CACHE_SRC_PATH/$pkg_dirname $pkg_prefix/ruby-bin $gem
+  done
+
+  # Link the appbundled binstubs into the package's bin directory
+  mkdir -p $pkg_prefix/bin
+  for exe in $pkg_prefix/ruby-bin/*; do
+    wrap_ruby_bin $(basename ${exe})
+  done
 
   if [[ `readlink /usr/bin/env` = "$(pkg_path_for coreutils)/bin/env" ]]; then
     build_line "Removing the symlink we created for '/usr/bin/env'"
     rm /usr/bin/env
   fi
-
-  mkdir -p $pkg_prefix/bin
-
-  wrap_ruby_bin "chef"
-  wrap_ruby_bin "chef-client"
-  wrap_ruby_bin "chef-apply"
-  wrap_ruby_bin "chef-shell"
-  wrap_ruby_bin "chef-solo"
-  wrap_ruby_bin "ohai"
-  wrap_ruby_bin "knife"
-  wrap_ruby_bin "kitchen"
-  wrap_ruby_bin "berks"
-  wrap_ruby_bin "foodcritic"
-  wrap_ruby_bin "inspec"
-  wrap_ruby_bin "chef-resource-inspector"
-  wrap_ruby_bin "dco"
 }
 
 # Stubs


### PR DESCRIPTION
1) we don't use iconv in chef/chef so why use it here
2) we needed pkg-config, which is recommended on the nokogiri site

Signed-off-by: Tim Smith <tsmith@chef.io>