### PR TITLE
Improve chef --version command

### DIFF
--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -95,15 +95,19 @@ module ChefDK
     end
 
     def show_version
-      msg("Chef Development Kit Version: #{ChefDK::VERSION}")
-
-      ["chef-client", "delivery", "berks", "kitchen", "inspec"].each do |component|
-        result = Bundler.with_clean_env { shell_out("#{component} --version") }
+      msg("Chef Development Kit Version: #{ChefDK::VERSION}\n")
+      { "Chef Infra Client": "chef-client",
+        "Test Kitchen": "kitchen",
+        "Foodcritic": "foodcritic",
+        "Cookstyle": "cookstyle",
+        "InSpec": "inspec",
+      }.each do |name, cli|
+        result = Bundler.with_clean_env { shell_out("#{cli} --version") }
         if result.exitstatus != 0
-          msg("#{component} version: ERROR")
+          msg("#{name} version: ERROR")
         else
           version = result.stdout.lines.first.scan(/(?:master\s)?[\d+\.\(\)]+\S+/).join("\s")
-          msg("#{component} version: #{version}")
+          msg("#{name} version: #{version}")
         end
       end
     end

--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -95,7 +95,7 @@ module ChefDK
     end
 
     def show_version
-      msg("Chef Development Kit Version: #{ChefDK::VERSION}\n")
+      msg("Chef Development Kit Version: #{ChefDK::VERSION}")
       { "Chef Infra Client": "chef-client",
         "Test Kitchen": "kitchen",
         "Foodcritic": "foodcritic",

--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -97,10 +97,10 @@ module ChefDK
     def show_version
       msg("Chef Development Kit Version: #{ChefDK::VERSION}")
       { "Chef Infra Client": "chef-client",
+        "Chef InSpec": "inspec",
         "Test Kitchen": "kitchen",
         "Foodcritic": "foodcritic",
-        "Cookstyle": "cookstyle",
-        "InSpec": "inspec",
+        "Cookstyle": "cookstyle"
       }.each do |name, cli|
         result = Bundler.with_clean_env { shell_out("#{cli} --version") }
         if result.exitstatus != 0

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -131,6 +131,11 @@ describe ChefDK::CLI do
           "version_output" => "Chef Infra Client: 15.0.300",
           "expected_version" => "15.0.300",
         },
+        "Chef InSpec" => {
+          "command" => "inspec",
+          "version_output" => "4.6.2\n\nYour version of InSpec is out of date! The latest version is 4.6.4.",
+          "expected_version" => "4.6.2",
+        },
         "Test Kitchen" => {
           "command" => "kitchen",
           "version_output" => "Test Kitchen version 2.2.5",
@@ -145,11 +150,6 @@ describe ChefDK::CLI do
           "command" => "cookstyle",
           "version_output" => "Cookstyle 4.0.0\n  * RuboCop 0.62.0",
           "expected_version" => "4.0.0",
-        },
-        "InSpec" => {
-          "command" => "inspec",
-          "version_output" => "4.6.2\n\nYour version of InSpec is out of date! The latest version is 4.6.4.",
-          "expected_version" => "4.6.2",
         },
       }
     end

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -69,9 +69,9 @@ describe ChefDK::CLI do
 
   def run_cli_and_validate_tool_versions
     full_version_message = version_message
-    tools.each do |name, version|
-      expect(cli).to receive(:shell_out).with("#{name} --version").and_return(mock_shell_out(0, "#{version["version_output"]}", ""))
-      full_version_message += "#{name} version: #{version["expected_version"]}\n"
+    tools.each do |name, details|
+      expect(cli).to receive(:shell_out).with("#{details["command"]} --version").and_return(mock_shell_out(0, "#{details["version_output"]}", ""))
+      full_version_message += "#{name} version: #{details["expected_version"]}\n"
     end
     run_cli(0)
     expect(stdout).to eq(full_version_message)
@@ -123,42 +123,46 @@ describe ChefDK::CLI do
 
   context "given -v" do
     let(:argv) { %w{-v} }
-    let(:delivery_version) { "master (454c3f37819ed508a49c971f38e42267ce8a47de)" }
 
     let(:tools) do
       {
-        "chef-client" => {
-          "version_output" => "Chef: 12.0.3",
-          "expected_version" => "12.0.3",
+        "Chef Infra Client" => {
+          "command" => "chef-client",
+          "version_output" => "Chef Infra Client: 15.0.300",
+          "expected_version" => "15.0.300",
         },
-        "delivery" => {
-          "version_output" => "delivery #{delivery_version}",
-          "expected_version" => delivery_version,
+        "Test Kitchen" => {
+          "command" => "kitchen",
+          "version_output" => "Test Kitchen version 2.2.5",
+          "expected_version" => "2.2.5",
         },
-        "berks" => {
-          "version_output" => "3.2.3",
-          "expected_version" => "3.2.3",
+        "Foodcritic" => {
+          "command" => "foodcritic",
+          "version_output" => "foodcritic 16.0.0",
+          "expected_version" => "16.0.0",
         },
-        "kitchen" => {
-          "version_output" => "Test Kitchen version 1.3.1",
-          "expected_version" => "1.3.1",
+        "Cookstyle" => {
+          "command" => "cookstyle",
+          "version_output" => "Cookstyle 4.0.0\n  * RuboCop 0.62.0",
+          "expected_version" => "4.0.0",
         },
-        "inspec" => {
-          "version_output" => "1.19.1\n\nYour version of InSpec is out of date! The latest version is 1.21.0.",
-          "expected_version" => "1.19.1",
+        "InSpec" => {
+          "command" => "inspec",
+          "version_output" => "4.6.2\n\nYour version of InSpec is out of date! The latest version is 4.6.4.",
+          "expected_version" => "4.6.2",
         },
       }
     end
 
     it "does not print versions of tools with missing or errored tools" do
       full_version_message = version_message
-      tools.each do |name, version|
-        if name == "berks"
-          expect(cli).to receive(:shell_out).with("#{name} --version").and_return(mock_shell_out(1, "#{version["version_output"]}", ""))
+      tools.each do |name, details|
+        if name == "inspec"
+          expect(cli).to receive(:shell_out).with("#{details["command"]} --version").and_return(mock_shell_out(1, "#{details["version_output"]}", ""))
           full_version_message += "#{name} version: ERROR\n"
         else
-          expect(cli).to receive(:shell_out).with("#{name} --version").and_return(mock_shell_out(0, "#{version["version_output"]}", ""))
-          full_version_message += "#{name} version: #{version["expected_version"]}\n"
+          expect(cli).to receive(:shell_out).with("#{details["command"]} --version").and_return(mock_shell_out(0, "#{details["version_output"]}", ""))
+          full_version_message += "#{name} version: #{details["expected_version"]}\n"
         end
       end
       run_cli(0)
@@ -167,14 +171,6 @@ describe ChefDK::CLI do
 
     it "prints the version and versions of chef-dk tools" do
       run_cli_and_validate_tool_versions
-    end
-
-    context "alternate Delivery CLI version format" do
-      let(:delivery_version) { "0.0.15 (454c3f37819ed508a49c971f38e42267ce8a47de)" }
-
-      it "prints the expected version of Delivery CLI" do
-        run_cli_and_validate_tool_versions
-      end
     end
   end
 


### PR DESCRIPTION
1) Remove delivery and berkshelf from the output as we care less about these tools
2) Include cookstyle and foodcritic as we do care what versions we're running
3) Output the branding name not the CLI name

Old output:
```
Chef Development Kit Version: 4.0.75
chef-client version: 15.0.300
delivery version: 0.0.52 (9d07501a3b347cc687c902319d23dc32dd5fa621)
berks version: 7.0.8
kitchen version: 2.2.5
inspec version: 4.6.4
```

New output:
```
Chef Development Kit Version: 4.0.75

Chef Infra Client version: 15.0.300
Test Kitchen version: 2.2.5
Foodcritic version: 16.0.0
Cookstyle version: 4.0.0
InSpec version: 4.6.4
```

Signed-off-by: Tim Smith <tsmith@chef.io>