### PR TITLE
[chefdk-3] Use new omnibus-toolchain scripts in omnibus-test.* scripts

### DIFF
--- a/omnibus/omnibus-test.ps1
+++ b/omnibus/omnibus-test.ps1
@@ -10,31 +10,11 @@ If ([string]::IsNullOrEmpty($product)) { $product = "chefdk" }
 $version = "$Env:VERSION"
 If ([string]::IsNullOrEmpty($version)) { $version = "latest" }
 
-. C:\buildkite-agent\bin\load-omnibus-toolchain.ps1
-
-If ($env:OMNIBUS_WINDOWS_ARCH -eq "x86") {
-  $architecture = "i386"
-}
-ElseIf ($env:OMNIBUS_WINDOWS_ARCH -eq "x64") {
-  $architecture = "x86_64"
-}
-
-Write-Output "--- Downloading $channel $product $version"
-$download_url = C:\opscode\omnibus-toolchain\embedded\bin\mixlib-install.bat download --url --channel "$channel" "$product" --version "$version" --architecture "$architecture"
-$package_file = "$Env:Temp\$(Split-Path -Path $download_url -Leaf)"
-Invoke-WebRequest -OutFile "$package_file" -Uri "$download_url"
-
-Write-Output "--- Checking that $package_file has been signed."
-If ((Get-AuthenticodeSignature "$package_file").Status -eq 'Valid') {
-  Write-Output "Verified $package_file has been signed."
-}
-Else {
-  Write-Output "Exiting with an error because $package_file has not been signed. Check your omnibus project config."
-  exit 1
-}
-
 Write-Output "--- Installing $channel $product $version"
-Start-Process "$package_file" /quiet -Wait
+$package_file = $(C:\opscode\omnibus-toolchain\bin\install-omnibus-product.ps1 -Product "$product" -Channel "$channel" -Version "$version" | Select-Object -Last 1)
+
+Write-Output "--- Verifying omnibus package is signed"
+C:\opscode\omnibus-toolchain\bin\check-omnibus-package-signed.ps1 "$package_file"
 
 Write-Output "--- Running verification for $channel $product $version"
 

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -6,15 +6,17 @@ product="${PRODUCT:-chefdk}"
 version="${VERSION:-latest}"
 
 echo "--- Installing $channel $product $version"
-package_file="$(install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
+package_file="$(/opt/omnibus-toolchain/bin/install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
 
 echo "--- Verifying omnibus package is signed"
-check-omnibus-package-signed "$package_file"
+/opt/omnibus-toolchain/bin/check-omnibus-package-signed "$package_file"
+
+sudo rm -f "$package_file"
 
 echo "--- Verifying ownership of package files"
 
 export INSTALL_DIR=/opt/chefdk
-NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
+NONROOT_FILES="$(find "$INSTALL_DIR" ! -user 0 -print)"
 if [[ "$NONROOT_FILES" == "" ]]; then
   echo "Packages files are owned by root.  Continuing verification."
 else


### PR DESCRIPTION
### Description

This just updates the `omnibus-test.*` scripts to use tools that have been moved into the omnibus-toolchain. It also makes some changes to output to be more consistent across our omnibus projects.