### PR TITLE
Add Dist file to control the product / CLI names

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -116,7 +116,7 @@ Test Kitchen has been updated to 1.25 with backports of many non-breaking Test K
 
 # ChefDK 3.10 Release Notes
 
-## New Policy File Functionality
+## New Policyfile Functionality
 
 `include_policy` now supports `:remote` policy files. This new functionality allows you to include policy files over http. Remote policy files require remote cookbooks and `install` will fail otherwise if the included policy file includes cookbooks with paths. Thanks [@mattray](https://github.com/mattray)!
 

--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -35,23 +35,23 @@ ChefDK.commands do |c|
 
   c.builtin "update", :Update, desc: "Updates a Policyfile.lock.json with latest run_list and cookbooks"
 
-  c.builtin "push", :Push, desc: "Push a local policy lock to a policy group on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "push", :Push, desc: "Push a local policy lock to a policy group on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "push-archive", :PushArchive, desc: "Push a policy archive to a policy group on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "push-archive", :PushArchive, desc: "Push a policy archive to a policy group on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "show-policy", :ShowPolicy, desc: "Show policyfile objects on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "show-policy", :ShowPolicy, desc: "Show policyfile objects on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
   c.builtin "diff", :Diff, desc: "Generate an itemized diff of two Policyfile lock documents"
 
   c.builtin "export", :Export, desc: "Export a policy lock as a #{ChefDK::Dist::ZERO_PRODUCT} code repo"
 
-  c.builtin "clean-policy-revisions", :CleanPolicyRevisions, desc: "Delete unused policy revisions on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "clean-policy-revisions", :CleanPolicyRevisions, desc: "Delete unused policy revisions on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "clean-policy-cookbooks", :CleanPolicyCookbooks, desc: "Delete unused policyfile cookbooks on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "clean-policy-cookbooks", :CleanPolicyCookbooks, desc: "Delete unused policyfile cookbooks on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "delete-policy", :DeletePolicy, desc: "Delete all revisions of a policy on your #{ChefDK::Dist::SERVER_PRODUCT}"
+  c.builtin "delete-policy", :DeletePolicy, desc: "Delete all revisions of a policy on the #{ChefDK::Dist::SERVER_PRODUCT}"
 
   c.builtin "undelete", :Undelete, desc: "Undo a delete command"
 

--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,46 +15,48 @@
 # limitations under the License.
 #
 
+require "chef-dk/dist"
+
 ChefDK.commands do |c|
   c.builtin "exec", :Exec, require_path: "chef-dk/command/exec",
                            desc: "Runs the command in context of the embedded ruby"
 
   c.builtin "env", :Env, require_path: "chef-dk/command/env",
-                         desc: "Prints environment variables used by ChefDK"
+                         desc: "Prints environment variables used by #{ChefDK::Dist::PRODUCT}"
 
   c.builtin "gem", :GemForwarder, require_path: "chef-dk/command/gem",
-                                  desc: "Runs the `gem` command in context of the embedded ruby"
+                                  desc: "Runs the `gem` command in context of the the embedded Ruby"
 
-  c.builtin "generate", :Generate, desc: "Generate a new app, cookbook, or component"
+  c.builtin "generate", :Generate, desc: "Generate a new repository, cookbook, or other component"
 
-  c.builtin "shell-init", :ShellInit, desc: "Initialize your shell to use ChefDK as your primary ruby"
+  c.builtin "shell-init", :ShellInit, desc: "Initialize your shell to use #{ChefDK::Dist::PRODUCT} as your primary Ruby"
 
   c.builtin "install", :Install, desc: "Install cookbooks from a Policyfile and generate a locked cookbook set"
 
   c.builtin "update", :Update, desc: "Updates a Policyfile.lock.json with latest run_list and cookbooks"
 
-  c.builtin "push", :Push, desc: "Push a local policy lock to a policy group on the server"
+  c.builtin "push", :Push, desc: "Push a local policy lock to a policy group on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "push-archive", :PushArchive, desc: "Push a policy archive to a policy group on the server"
+  c.builtin "push-archive", :PushArchive, desc: "Push a policy archive to a policy group on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "show-policy", :ShowPolicy, desc: "Show policyfile objects on your Chef Infra Server"
+  c.builtin "show-policy", :ShowPolicy, desc: "Show policyfile objects on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
   c.builtin "diff", :Diff, desc: "Generate an itemized diff of two Policyfile lock documents"
 
-  c.builtin "export", :Export, desc: "Export a policy lock as a Chef Zero code repo"
+  c.builtin "export", :Export, desc: "Export a policy lock as a #{ChefDK::Dist::ZERO_PRODUCT} code repo"
 
-  c.builtin "clean-policy-revisions", :CleanPolicyRevisions, desc: "Delete unused policy revisions on the server"
+  c.builtin "clean-policy-revisions", :CleanPolicyRevisions, desc: "Delete unused policy revisions on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "clean-policy-cookbooks", :CleanPolicyCookbooks, desc: "Delete unused policyfile cookbooks on the server"
+  c.builtin "clean-policy-cookbooks", :CleanPolicyCookbooks, desc: "Delete unused policyfile cookbooks on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on the server"
+  c.builtin "delete-policy-group", :DeletePolicyGroup, desc: "Delete a policy group on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
-  c.builtin "delete-policy", :DeletePolicy, desc: "Delete all revisions of a policy on the server"
+  c.builtin "delete-policy", :DeletePolicy, desc: "Delete all revisions of a policy on your #{ChefDK::Dist::SERVER_PRODUCT}"
 
   c.builtin "undelete", :Undelete, desc: "Undo a delete command"
 
   c.builtin "describe-cookbook", :DescribeCookbook, require_path: "chef-dk/command/describe_cookbook",
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
 
-  c.builtin "verify", :Verify, desc: "Test the embedded ChefDK applications", hidden: true
+  c.builtin "verify", :Verify, desc: "Test the embedded #{ChefDK::Dist::PRODUCT} applications", hidden: true
 end

--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -25,7 +25,7 @@ ChefDK.commands do |c|
                          desc: "Prints environment variables used by #{ChefDK::Dist::PRODUCT}"
 
   c.builtin "gem", :GemForwarder, require_path: "chef-dk/command/gem",
-                                  desc: "Runs the `gem` command in context of the the embedded Ruby"
+                                  desc: "Runs the `gem` command in context of the embedded Ruby"
 
   c.builtin "generate", :Generate, desc: "Generate a new repository, cookbook, or other component"
 

--- a/lib/chef-dk/chef_runner.rb
+++ b/lib/chef-dk/chef_runner.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +45,7 @@ module ChefDK
       message = "Could not find cookbook(s) to satisfy run list #{run_list.inspect} in #{cookbook_path}"
       raise CookbookNotFound.new(message, e)
     rescue => e
-      raise ChefConvergeError.new("Chef failed to converge: #{e} from file #{e.backtrace.first}", e)
+      raise ChefConvergeError.new("#{ChefDK::Dist::INFRA_PRODUCT} failed to converge: #{e} from file #{e.backtrace.first}", e)
     end
 
     def run_context

--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ require "chef-dk/commands_map"
 require "chef-dk/builtin_commands"
 require "chef-dk/helpers"
 require "chef-dk/ui"
+require "chef-dk/dist"
 require "chef/util/path_helper"
 require "chef/mixin/shell_out"
 require "bundler"
@@ -41,7 +42,7 @@ module ChefDK
     option :version,
       short: "-v",
       long: "--version",
-      description: "Show chef version",
+      description: "Show #{ChefDK::Dist::PRODUCT} version",
       boolean: true
 
     option :help,
@@ -95,9 +96,9 @@ module ChefDK
     end
 
     def show_version
-      msg("Chef Development Kit Version: #{ChefDK::VERSION}")
-      { "Chef Infra Client": "chef-client",
-        "Chef InSpec": "inspec",
+      msg("#{ChefDK::Dist::PRODUCT}: #{ChefDK::VERSION}")
+      { "#{ChefDK::Dist::INFRA_CLIENT_PRODUCT}": "#{ChefDK::Dist::INFRA_CLIENT_CLI}",
+        "#{ChefDK::Dist::INSPEC_PRODUCT}": "#{ChefDK::Dist::INSPEC_CLI}",
         "Test Kitchen": "kitchen",
         "Foodcritic": "foodcritic",
         "Cookstyle": "cookstyle",
@@ -193,11 +194,11 @@ module ChefDK
         if bin_index
           if embed_index < bin_index
             err("WARN: #{omnibus_embedded_bin_dir} is before #{omnibus_bin_dir} in your #{path_key}, please reverse that order.")
-            err("WARN: consider using the correct `chef shell-init <shell>` command to setup your environment correctly.")
+            err("WARN: consider using the correct `#{ChefDK::Dist::EXEC} shell-init <shell>` command to setup your environment correctly.")
           end
         else
           err("WARN: only #{omnibus_embedded_bin_dir} is present in your path, you must add #{omnibus_bin_dir} before that directory.")
-          err("WARN: consider using the correct `chef shell-init <shell>` command to setup your environment correctly.")
+          err("WARN: consider using the correct `#{ChefDK::Dist::EXEC} shell-init <shell>` command to setup your environment correctly.")
         end
       end
     end

--- a/lib/chef-dk/cli.rb
+++ b/lib/chef-dk/cli.rb
@@ -96,7 +96,7 @@ module ChefDK
     end
 
     def show_version
-      msg("#{ChefDK::Dist::PRODUCT}: #{ChefDK::VERSION}")
+      msg("#{ChefDK::Dist::PRODUCT} version: #{ChefDK::VERSION}")
       { "#{ChefDK::Dist::INFRA_CLIENT_PRODUCT}": "#{ChefDK::Dist::INFRA_CLIENT_CLI}",
         "#{ChefDK::Dist::INSPEC_PRODUCT}": "#{ChefDK::Dist::INSPEC_CLI}",
         "Test Kitchen": "kitchen",

--- a/lib/chef-dk/command/base.rb
+++ b/lib/chef-dk/command/base.rb
@@ -56,7 +56,7 @@ module ChefDK
           msg(opt_parser.to_s)
           0
         elsif needs_version?(params)
-          msg("#{ChefDK::Dist::PRODUCT} Version: #{ChefDK::VERSION}")
+          msg("#{ChefDK::Dist::PRODUCT} version: #{ChefDK::VERSION}")
           0
         else
           check_license_acceptance if enforce_license

--- a/lib/chef-dk/command/base.rb
+++ b/lib/chef-dk/command/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ require "chef-dk/version"
 require "chef/exceptions"
 require "license_acceptance/acceptor"
 require "license_acceptance/cli_flags/mixlib_cli"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -38,7 +39,7 @@ module ChefDK
       option :version,
         short: "-v",
         long: "--version",
-        description: "Show chef version",
+        description: "Show #{ChefDK::Dist::PRODUCT} version",
         boolean: true
 
       def initialize
@@ -55,7 +56,7 @@ module ChefDK
           msg(opt_parser.to_s)
           0
         elsif needs_version?(params)
-          msg("Chef Development Kit Version: #{ChefDK::VERSION}")
+          msg("#{ChefDK::Dist::PRODUCT} Version: #{ChefDK::VERSION}")
           0
         else
           check_license_acceptance if enforce_license

--- a/lib/chef-dk/command/clean_policy_cookbooks.rb
+++ b/lib/chef-dk/command/clean_policy_cookbooks.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/configurable"
 require "chef-dk/policyfile_services/clean_policy_cookbooks"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -26,11 +27,11 @@ module ChefDK
     class CleanPolicyCookbooks < Base
 
       banner(<<~BANNER)
-        Usage: chef clean-policy-cookbooks [options]
+        Usage: #{ChefDK::Dist::EXEC} clean-policy-cookbooks [options]
 
-        `chef clean-policy-cookbooks` deletes unused policyfile cookbooks. Cookbooks
-        are considered unused when they are not referenced by any policyfile revision
-        on the server. Note that cookbooks which are referenced by "orphaned" policy
+        `#{ChefDK::Dist::EXEC} clean-policy-cookbooks` deletes unused Policyfile cookbooks. Cookbooks
+        are considered unused when they are not referenced by any Policyfile revision
+        on the #{ChefDK::Dist::SERVER_PRODUCT}. Note that cookbooks which are referenced by "orphaned" policy
         revisions are not removed, so you may wish to run `chef clean-policy-revisions`
         to remove orphaned policies before running this command.
 

--- a/lib/chef-dk/command/clean_policy_revisions.rb
+++ b/lib/chef-dk/command/clean_policy_revisions.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/configurable"
 require "chef-dk/policyfile_services/clean_policies"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -26,12 +27,12 @@ module ChefDK
     class CleanPolicyRevisions < Base
 
       banner(<<~BANNER)
-        Usage: chef clean-policy-revisions [options]
+        Usage: #{ChefDK::Dist::EXEC} clean-policy-revisions [options]
 
-        `chef clean-policy-revisions` deletes orphaned policyfile revisions from the Chef
-        Server. Orphaned policyfile revisions are not associated to any group, and
-        therefore not in active use by any nodes. To list orphaned policyfile revisions
-        before deleting them, use `chef show-policy --orphans`.
+        `#{ChefDK::Dist::EXEC} clean-policy-revisions` deletes orphaned Policyfile revisions from the
+        #{ChefDK::Dist::SERVER_PRODUCT}. Orphaned Policyfile revisions are not associated to any group, and
+        therefore not in active use by any nodes. To list orphaned Policyfile revisions before deleting
+        them, use `#{ChefDK::Dist::EXEC} show-policy --orphans`.
 
         See our detailed README for more information:
 

--- a/lib/chef-dk/command/delete_policy.rb
+++ b/lib/chef-dk/command/delete_policy.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/configurable"
 require "chef-dk/policyfile_services/rm_policy"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -26,10 +27,10 @@ module ChefDK
     class DeletePolicy < Base
 
       banner(<<~BANNER)
-        Usage: chef delete-policy POLICY_NAME [options]
+        Usage: #{ChefDK::Dist::EXEC} delete-policy POLICY_NAME [options]
 
-        `chef delete-policy POLICY_NAME` deletes all revisions of the policy
-        `POLICY_NAME` on the configured Chef Infra Server. All policy revisions will be
+        `#{ChefDK::Dist::EXEC} delete-policy POLICY_NAME` deletes all revisions of the policy
+        `POLICY_NAME` on the configured #{ChefDK::Dist::SERVER_PRODUCT}. All policy revisions will be
         backed up locally, allowing you to undo this operation via the `chef undelete`
         command.
 
@@ -68,7 +69,7 @@ module ChefDK
       def run(params)
         return 1 unless apply_params!(params)
         rm_policy_service.run
-        ui.msg("This operation can be reversed by running `chef undelete --last`.")
+        ui.msg("This operation can be reversed by running `#{ChefDK::Dist::EXEC} undelete --last`.")
         0
       rescue PolicyfileServiceError => e
         handle_error(e)

--- a/lib/chef-dk/command/delete_policy_group.rb
+++ b/lib/chef-dk/command/delete_policy_group.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/configurable"
 require "chef-dk/policyfile_services/rm_policy_group"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -26,10 +27,10 @@ module ChefDK
     class DeletePolicyGroup < Base
 
       banner(<<~BANNER)
-        Usage: chef delete-policy-group POLICY_GROUP [options]
+        Usage: #{ChefDK::Dist::EXEC} delete-policy-group POLICY_GROUP [options]
 
-        `chef delete-policy-group POLICY_GROUP` deletes the policy group POLICY_GROUP on
-        the configured Chef Infra Server. Policy Revisions associated to the policy group are
+        `#{ChefDK::Dist::EXEC} delete-policy-group POLICY_GROUP` deletes the policy group POLICY_GROUP on
+        the configured #{ChefDK::Dist::SERVER_PRODUCT}. Policy Revisions associated to the policy group are
         not deleted. The state of the policy group will be backed up locally, allowing
         you to undo this operation via the `chef undelete` command.
 
@@ -68,7 +69,7 @@ module ChefDK
       def run(params)
         return 1 unless apply_params!(params)
         rm_policy_group_service.run
-        ui.msg("This operation can be reversed by running `chef undelete --last`.")
+        ui.msg("This operation can be reversed by running `#{ChefDK::Dist::EXEC} undelete --last`.")
         0
       rescue PolicyfileServiceError => e
         handle_error(e)

--- a/lib/chef-dk/command/describe_cookbook.rb
+++ b/lib/chef-dk/command/describe_cookbook.rb
@@ -1,6 +1,7 @@
 require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/cookbook_profiler/identifiers"
+require "chef-dk/dist"
 
 module ChefDK
   class IdDumper
@@ -48,7 +49,7 @@ module ChefDK
 
     class DescribeCookbook < ChefDK::Command::Base
 
-      banner "Usage: chef describe-cookbook <path/to/cookbook>"
+      banner "Usage: #{ChefDK::Dist::EXEC} describe-cookbook <path/to/cookbook>"
 
       attr_reader :cookbook_path
       attr_reader :ui

--- a/lib/chef-dk/command/diff.rb
+++ b/lib/chef-dk/command/diff.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ require "chef-dk/policyfile/differ"
 require "chef-dk/policyfile/comparison_base"
 require "chef-dk/policyfile/storage_config"
 require "chef-dk/configurable"
+require "chef-dk/dist"
 require "chef/server_api"
 
 module ChefDK
@@ -33,36 +34,36 @@ module ChefDK
       include Policyfile::StorageConfigDelegation
 
       banner(<<~BANNER)
-        Usage: chef diff [POLICYFILE] [--head | --git GIT_REF | POLICY_GROUP | POLICY_GROUP...POLICY_GROUP ]
+        Usage: #{ChefDK::Dist::EXEC} diff [POLICYFILE] [--head | --git GIT_REF | POLICY_GROUP | POLICY_GROUP...POLICY_GROUP ]
 
-        `chef diff` displays an itemized diff comparing two revisions of a
+        `#{ChefDK::Dist::EXEC} diff` displays an itemized diff comparing two revisions of a
         Policyfile lock.
 
-        When the `--git` option is given, `chef diff` either compares a given
+        When the `--git` option is given, `#{ChefDK::Dist::EXEC} diff` either compares a given
         git reference against the current lockfile revision on disk or compares
         between two git references. Examples:
 
-        * `chef diff --git HEAD`: compares the current lock with the latest
+        * `#{ChefDK::Dist::EXEC} diff --git HEAD`: compares the current lock with the latest
           commit on the current branch.
-        * `chef diff --git master` compares the current lock with the latest
+        * `#{ChefDK::Dist::EXEC} diff --git master`: compares the current lock with the latest
           commit to master.
-        * `chef diff --git v1.0.0`: compares the current lock with the revision
+        * `#{ChefDK::Dist::EXEC} diff --git v1.0.0`: compares the current lock with the revision
           as of the `v1.0.0` tag.
-        * `chef diff --git master...dev-branch` compares the Policyfile lock on
+        * `#{ChefDK::Dist::EXEC} diff --git master...dev-branch`: compares the Policyfile lock on
           master with the revision on the `dev-branch` branch.
-        * `chef diff --git v1.0.0...master` compares the Policyfile lock at the
+        * `#{ChefDK::Dist::EXEC} diff --git v1.0.0...master`: compares the Policyfile lock at the
           `v1.0.0` tag with the lastest revision on the master branch.
 
-        `chef diff --head` is a shortcut for `chef diff --git HEAD`.
+        `#{ChefDK::Dist::EXEC} diff --head` is a shortcut for `#{ChefDK::Dist::EXEC} diff --git HEAD`.
 
-        When no git-specific flag is given, `chef diff` either compares the
-        current lockfile revision on disk to one on the server or compares two
-        lockfiles on the server. Lockfiles on the Chef Infra Server are specified by
-        Policy Group. Examples:
+        When no git-specific flag is given, `#{ChefDK::Dist::EXEC} diff` either compares the
+        current lockfile revision on disk to one on the #{ChefDK::Dist::SERVER_PRODUCT} or compares
+        two lockfiles on the #{ChefDK::Dist::SERVER_PRODUCT}. Lockfiles on the #{ChefDK::Dist::SERVER_PRODUCT}
+        are specified by Policy Group. Examples:
 
-        * `chef diff staging`: compares the current lock with the one currently
+        * `#{ChefDK::Dist::EXEC} diff staging`: compares the current lock with the one currently
           assigned to the `staging` Policy Group.
-        * `chef diff production...staging` compares the lock currently assigned
+        * `#{ChefDK::Dist::EXEC} diff production...staging`: compares the lock currently assigned
           to the `production` Policy Group to the lock currently assigned to the
           `staging` Policy Group.
 
@@ -72,28 +73,28 @@ module ChefDK
       option :git,
         short:       "-g GIT_REF",
         long:        "--git GIT_REF",
-        description: "Compare local lock against GIT_REF, or between two git commits"
+        description: "Compare local lock against GIT_REF, or between two git commits."
 
       option :head,
         long:        "--head",
-        description: "Compare local lock against last git commit",
+        description: "Compare local lock against last git commit.",
         boolean:     true
 
       option :pager,
         long:        "--[no-]pager",
-        description: "Enable/disable paged diff ouput (default: enabled)",
+        description: "Enable/disable paged diff ouput (default: enabled).",
         default:     true,
         boolean:     true
 
       option :config_file,
         short:       "-c CONFIG_FILE",
         long:        "--config CONFIG_FILE",
-        description: "Path to configuration file"
+        description: "Path to configuration file."
 
       option :debug,
         short:       "-D",
         long:        "--debug",
-        description: "Enable stacktraces and other debug output",
+        description: "Enable stacktraces and other debug output.",
         default:     false
 
       attr_accessor :ui

--- a/lib/chef-dk/command/env.rb
+++ b/lib/chef-dk/command/env.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,13 +19,14 @@ require "chef-dk/command/base"
 require "chef-dk/cookbook_omnifetch"
 require "chef-dk/ui"
 require "chef-dk/version"
+require "chef-dk/dist"
 require "mixlib/shellout"
 require "yaml"
 
 module ChefDK
   module Command
     class Env < ChefDK::Command::Base
-      banner "Usage: chef env"
+      banner "Usage: #{ChefDK::Dist::EXEC} env"
 
       attr_accessor :ui
 
@@ -36,7 +37,7 @@ module ChefDK
 
       def run(params)
         info = {}
-        info["Chef Development Kit"] = Hash.new.tap do |chefdk_env|
+        info["#{ChefDK::Dist::PRODUCT}"] = Hash.new.tap do |chefdk_env|
           chefdk_env["ChefDK"] = chefdk_info
           chefdk_env["Ruby"] = ruby_info
           chefdk_env["Path"] = paths

--- a/lib/chef-dk/command/exec.rb
+++ b/lib/chef-dk/command/exec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,13 @@
 #
 
 require "chef-dk/command/base"
+require "chef-dk/dist"
 require "mixlib/shellout"
 
 module ChefDK
   module Command
     class Exec < ChefDK::Command::Base
-      banner "Usage: chef exec SYSTEM_COMMAND"
+      banner "Usage: #{ChefDK::Dist::EXEC} exec SYSTEM_COMMAND"
 
       def run(params)
         # Set ENV directly on the "parent" process (us) before running #exec to

--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -31,7 +31,7 @@ module ChefDK
       banner(<<~E)
         Usage: #{ChefDK::Dist::EXEC} export [ POLICY_FILE ] DESTINATION_DIRECTORY [options]
 
-        `chef export` creates a #{ChefDK::Dist::ZERO_PRODUCT} compatible #{ChefDK::Dist::INFRA_PRODUCT} repository containing the
+        `#{ChefDK::Dist::EXEC} export` creates a #{ChefDK::Dist::ZERO_PRODUCT} compatible #{ChefDK::Dist::INFRA_PRODUCT} repository containing the
         cookbooks described in a Policyfile.lock.json. The exported repository also contains
         a .chef/config.rb which configures #{ChefDK::Dist::INFRA_CLIENT_PRODUCT} to apply your policy. Once the
         exported repo is copied to the target machine, you can apply the policy to the

--- a/lib/chef-dk/command/export.rb
+++ b/lib/chef-dk/command/export.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/policyfile_services/export_repo"
 require "chef-dk/configurable"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -28,15 +29,15 @@ module ChefDK
       include Configurable
 
       banner(<<~E)
-        Usage: chef export [ POLICY_FILE ] DESTINATION_DIRECTORY [options]
+        Usage: #{ChefDK::Dist::EXEC} export [ POLICY_FILE ] DESTINATION_DIRECTORY [options]
 
-        `chef export` creates a Chef Zero compatible Chef repository containing the
-        cookbooks described in a Policyfile.lock.json. The exported repository also
-        contains a .chef/config.rb which configures chef to apply your policy. Once the
+        `chef export` creates a #{ChefDK::Dist::ZERO_PRODUCT} compatible #{ChefDK::Dist::INFRA_PRODUCT} repository containing the
+        cookbooks described in a Policyfile.lock.json. The exported repository also contains
+        a .chef/config.rb which configures #{ChefDK::Dist::INFRA_CLIENT_PRODUCT} to apply your policy. Once the
         exported repo is copied to the target machine, you can apply the policy to the
         machine with:
 
-        `chef-client -z`.
+        `#{ChefDK::Dist::INFRA_CLIENT_CLI} -z`.
 
         See our detailed README for more information:
 
@@ -89,7 +90,7 @@ module ChefDK
           ui.msg("")
           ui.msg("To converge this system with the exported policy, run:")
           ui.msg("  cd #{export_dir}")
-          ui.msg("  chef-client -z")
+          ui.msg("  #{ChefDK::Dist::INFRA_CLIENT_CLI} -z")
         end
         0
       rescue ExportDirNotEmpty => e

--- a/lib/chef-dk/command/gem.rb
+++ b/lib/chef-dk/command/gem.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/base"
+require "chef-dk/dist"
 require "rubygems"
 require "rubygems/gem_runner"
 require "rubygems/exceptions"
@@ -26,7 +27,7 @@ module ChefDK
 
     # Forwards all commands to rubygems.
     class GemForwarder < ChefDK::Command::Base
-      banner "Usage: chef gem GEM_COMMANDS_AND_OPTIONS"
+      banner "Usage: #{ChefDK::Dist::EXEC} gem GEM_COMMANDS_AND_OPTIONS"
 
       def run(params)
         retval = Gem::GemRunner.new.run( params.clone )

--- a/lib/chef-dk/command/generate.rb
+++ b/lib/chef-dk/command/generate.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ require "chef-dk/command/generator_commands/repo"
 require "chef-dk/command/generator_commands/policyfile"
 require "chef-dk/command/generator_commands/generator_generator"
 require "chef-dk/command/generator_commands/build_cookbook"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -52,14 +53,14 @@ module ChefDK
       generator(:file, :CookbookFile, "Generate a cookbook file")
       generator(:helpers, :Helpers, "Generate a cookbook helper file in libraries")
       generator(:resource, :Resource, "Generate a custom resource")
-      generator(:repo, :Repo, "Generate a Chef code repository")
+      generator(:repo, :Repo, "Generate a #{ChefDK::Dist::INFRA_PRODUCT} code repository")
       generator(:policyfile, :Policyfile, "Generate a Policyfile for use with the install/push commands")
-      generator(:generator, :GeneratorGenerator, "Copy ChefDK's generator cookbook so you can customize it")
-      generator(:'build-cookbook', :BuildCookbook, "Generate a build cookbook for use with Chef Workflow (Delivery)")
+      generator(:generator, :GeneratorGenerator, "Copy #{ChefDK::Dist::PRODUCT}'s generator cookbook so you can customize it")
+      generator(:'build-cookbook', :BuildCookbook, "Generate a build cookbook for use with #{ChefDK::Dist::WORKFLOW}")
 
       def self.banner_headline
         <<~E
-          Usage: chef generate GENERATOR [options]
+          Usage: #{ChefDK::Dist::EXEC} generate GENERATOR [options]
 
           Available generators:
         E

--- a/lib/chef-dk/command/generator_commands/attribute.rb
+++ b/lib/chef-dk/command/generator_commands/attribute.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/cookbook_code_file"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -23,7 +24,7 @@ module ChefDK
       # chef generate attribute [path/to/cookbook_root] NAME
       class Attribute < CookbookCodeFile
 
-        banner "Usage: chef generate attribute [path/to/cookbook] NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate attribute [path/to/cookbook] NAME [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/generator_commands/build_cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/build_cookbook.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2016 Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/base"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -23,7 +24,7 @@ module ChefDK
 
       class BuildCookbook < Base
 
-        banner "Usage: chef generate build-cookbook NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate build-cookbook NAME [options]"
 
         attr_reader :errors
 

--- a/lib/chef-dk/command/generator_commands/cookbook.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/base"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -29,7 +30,7 @@ module ChefDK
       # the relevant generators.
       class Cookbook < Base
 
-        banner "Usage: chef generate cookbook NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate cookbook NAME [options]"
 
         attr_reader :errors
 
@@ -57,7 +58,7 @@ module ChefDK
         option :workflow,
           short:        "-w",
           long:         "--workflow",
-          description:  "Generate a cookbook with a full Chef Workflow (Delivery) build cookbook.",
+          description:  "Generate a cookbook with a full #{ChefDK::Dist::WORKFLOW} build cookbook.",
           boolean:      true,
           default:      false
 
@@ -70,7 +71,7 @@ module ChefDK
 
         option :pipeline,
           long:         "--pipeline PIPELINE",
-          description:  "Use PIPELINE to set target branch to something other than master for the Workflow build_cookbook",
+          description:  "Use PIPELINE to set target branch to something other than master for the #{ChefDK::Dist::WORKFLOW} build_cookbook",
           default:      "master"
 
         options.merge!(SharedGeneratorOptions.options)

--- a/lib/chef-dk/command/generator_commands/cookbook_file.rb
+++ b/lib/chef-dk/command/generator_commands/cookbook_file.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/cookbook_code_file"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -27,7 +28,7 @@ module ChefDK
           long: "--source SOURCE_FILE",
           description: "Copy content from SOURCE_FILE"
 
-        banner "Usage: chef generate file [path/to/cookbook] NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate file [path/to/cookbook] NAME [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/generator_commands/generator_generator.rb
+++ b/lib/chef-dk/command/generator_commands/generator_generator.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ require "fileutils"
 require "chef-dk/configurable"
 require "chef-dk/ui"
 require "chef-dk/command/generator_commands/base"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -32,7 +33,7 @@ module ChefDK
       # `GeneratorGenerator` to avoid causing a conflict.
       class GeneratorGenerator < Base
 
-        banner "Usage: chef generate generator [ PATH ] [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate generator [ PATH ] [options]"
 
         attr_reader :destination_dir
         attr_accessor :ui
@@ -108,8 +109,8 @@ module ChefDK
         def metadata_rb
           <<~METADATA
             name             '#{cookbook_name}'
-            description      'Custom code generator cookbook for use with ChefDK'
-            long_description 'Custom code generator cookbook for use with ChefDK'
+            description      'Custom code generator cookbook for use with #{ChefDK::Dist::PRODUCT}'
+            long_description 'Custom code generator cookbook for use with #{ChefDK::Dist::PRODUCT}'
             version          '0.1.0'
 
           METADATA

--- a/lib/chef-dk/command/generator_commands/helpers.rb
+++ b/lib/chef-dk/command/generator_commands/helpers.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/cookbook_code_file"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -23,7 +24,7 @@ module ChefDK
       # chef generate helpers [path/to/cookbook_root] NAME
       class Helpers < CookbookCodeFile
 
-        banner "Usage: chef generate helpers [path/to/cookbook] NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate helpers [path/to/cookbook] NAME [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/generator_commands/policyfile.rb
+++ b/lib/chef-dk/command/generator_commands/policyfile.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/base"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -23,7 +24,7 @@ module ChefDK
 
       class Policyfile < Base
 
-        banner "Usage: chef generate policyfile [NAME] [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate policyfile [NAME] [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/generator_commands/recipe.rb
+++ b/lib/chef-dk/command/generator_commands/recipe.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/cookbook_code_file"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -23,7 +24,7 @@ module ChefDK
       # chef generate recipe [path/to/cookbook/root] name
       class Recipe < CookbookCodeFile
 
-        banner "Usage: chef generate recipe [path/to/cookbook] NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate recipe [path/to/cookbook] NAME [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/generator_commands/repo.rb
+++ b/lib/chef-dk/command/generator_commands/repo.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/base"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -27,7 +28,7 @@ module ChefDK
       # Generates a full "chef-repo" directory structure.
       class Repo < Base
 
-        banner "Usage: chef generate repo NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate repo NAME [options]"
 
         attr_reader :errors
         attr_reader :repo_name_or_path

--- a/lib/chef-dk/command/generator_commands/resource.rb
+++ b/lib/chef-dk/command/generator_commands/resource.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/cookbook_code_file"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -23,7 +24,7 @@ module ChefDK
       # chef generate resource [path/to/cookbook_root] NAME
       class Resource < CookbookCodeFile
 
-        banner "Usage: chef generate resource [path/to/cookbook] NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate resource [path/to/cookbook] NAME [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/generator_commands/template.rb
+++ b/lib/chef-dk/command/generator_commands/template.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 #
 
 require "chef-dk/command/generator_commands/cookbook_code_file"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -28,7 +29,7 @@ module ChefDK
           long: "--source SOURCE_FILE",
           description: "Copy content from SOURCE_FILE"
 
-        banner "Usage: chef generate template [path/to/cookbook] NAME [options]"
+        banner "Usage: #{ChefDK::Dist::EXEC} generate template [path/to/cookbook] NAME [options]"
 
         options.merge!(SharedGeneratorOptions.options)
 

--- a/lib/chef-dk/command/install.rb
+++ b/lib/chef-dk/command/install.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/policyfile_services/install"
 require "chef-dk/configurable"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -28,13 +29,13 @@ module ChefDK
       include Configurable
 
       banner(<<~E)
-        Usage: chef install [ POLICY_FILE ] [options]
+        Usage: #{ChefDK::Dist::EXEC} install [ POLICY_FILE ] [options]
 
-        `chef install` evaluates a `Policyfile.rb` to find a compatible set of
+        `#{ChefDK::Dist::EXEC} install` evaluates a `Policyfile.rb` to find a compatible set of
         cookbooks for the policy's run_list and caches them locally. It emits a
         Policyfile.lock.json describing the locked cookbook set. You can use the
         lockfile to install the locked cookbooks on another machine. You can also push
-        the lockfile to a "policy group" on a Chef Infra Server and apply that exact set of
+        the lockfile to a "policy group" on a #{ChefDK::Dist::SERVER_PRODUCT} and apply that exact set of
         cookbooks to nodes in your infrastructure.
 
         See our detailed README for more information:

--- a/lib/chef-dk/command/provision.rb
+++ b/lib/chef-dk/command/provision.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "ostruct"
 
 require "chef-dk/command/base"
 require "chef-dk/chef_runner"
+require "chef-dk/dist"
 
 module ChefDK
 
@@ -26,10 +27,10 @@ module ChefDK
 
     class Provision < Base
 
-      banner("DEPRECATED: Chef provisioning has been removed from ChefDK / Workstation. If you require Chef Provisioning you will need to install an earlier version of these products!")
+      banner("DEPRECATED: Chef provisioning has been removed from #{ChefDK::Dist::PRODUCT}. If you require Chef Provisioning you will need to install an earlier version of these products!")
 
       def run(params = [])
-        raise "Chef provisioning has been removed from ChefDK / Workstation. If you require Chef Provisioning you will need to install an earlier version of these products!"
+        raise "Chef provisioning has been removed from #{ChefDK::Dist::PRODUCT}. If you require Chef Provisioning you will need to install an earlier version of these products!"
       end
 
     end

--- a/lib/chef-dk/command/push.rb
+++ b/lib/chef-dk/command/push.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/policyfile_services/push"
 require "chef-dk/configurable"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -28,9 +29,9 @@ module ChefDK
       include Configurable
 
       banner(<<~E)
-        Usage: chef push POLICY_GROUP [ POLICY_FILE ] [options]
+        Usage: #{ChefDK::Dist::EXEC} push POLICY_GROUP [ POLICY_FILE ] [options]
 
-        `chef push` Uploads an existing Policyfile.lock.json to a Chef Infra Server, along
+        `#{ChefDK::Dist::EXEC} push` Uploads an existing Policyfile.lock.json to a #{ChefDK::Dist::SERVER_PRODUCT}, along
         with all the cookbooks contained in the policy lock. The policy lock is applied
         to a specific POLICY_GROUP, which is a set of nodes that share the same
         run_list and cookbooks.

--- a/lib/chef-dk/command/push_archive.rb
+++ b/lib/chef-dk/command/push_archive.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/policyfile_services/push_archive"
 require "chef-dk/configurable"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -28,9 +29,9 @@ module ChefDK
       include Configurable
 
       banner(<<~E)
-        Usage: chef push-archive POLICY_GROUP ARCHIVE_FILE [options]
+        Usage: #{ChefDK::Dist::EXEC} push-archive POLICY_GROUP ARCHIVE_FILE [options]
 
-        `chef push-archive` publishes a policy archive to a Chef Infra Server. Policy
+        `chef push-archive` publishes a policy archive to a #{ChefDK::Dist::SERVER_PRODUCT}. Policy
         archives can be created with `chef export -a`. The policy will be applied to
         the given POLICY_GROUP, which is a set of nodes that share the same
         run_list and cookbooks.

--- a/lib/chef-dk/command/push_archive.rb
+++ b/lib/chef-dk/command/push_archive.rb
@@ -31,7 +31,7 @@ module ChefDK
       banner(<<~E)
         Usage: #{ChefDK::Dist::EXEC} push-archive POLICY_GROUP ARCHIVE_FILE [options]
 
-        `chef push-archive` publishes a policy archive to a #{ChefDK::Dist::SERVER_PRODUCT}. Policy
+        `#{ChefDK::Dist::EXEC} push-archive` publishes a policy archive to a #{ChefDK::Dist::SERVER_PRODUCT}. Policy
         archives can be created with `chef export -a`. The policy will be applied to
         the given POLICY_GROUP, which is a set of nodes that share the same
         run_list and cookbooks.

--- a/lib/chef-dk/command/shell_init.rb
+++ b/lib/chef-dk/command/shell_init.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ require "erb"
 require "chef-dk/commands_map"
 require "chef-dk/builtin_commands"
 require "chef-dk/command/base"
+require "chef-dk/dist"
 require "mixlib/shellout"
 
 module ChefDK
@@ -44,28 +45,28 @@ module ChefDK
       SUPPORTED_SHELLS = %w{ bash fish zsh sh powershell posh}.map(&:freeze).freeze
 
       banner(<<~HELP)
-        Usage: chef shell-init
+        Usage: #{ChefDK::Dist::EXEC} shell-init
 
-        `chef shell-init` modifies your shell environment to make ChefDK or Workstation your
+        `#{ChefDK::Dist::EXEC} shell-init` modifies your shell environment to make ChefDK or Workstation your
         default Ruby.
 
           To enable for just the current shell session:
 
             In sh, bash, and zsh:
-              eval "$(chef shell-init SHELL_NAME)"
+              eval "$(#{ChefDK::Dist::EXEC} shell-init SHELL_NAME)"
             In fish:
-              eval (chef shell-init fish)
+              eval (#{ChefDK::Dist::EXEC} shell-init fish)
             In Powershell:
-              chef shell-init powershell | Invoke-Expression
+              #{ChefDK::Dist::EXEC} shell-init powershell | Invoke-Expression
 
           To permanently enable:
 
             In sh, bash, and zsh:
-              echo 'eval "$(chef shell-init SHELL_NAME)"' >> ~/.YOUR_SHELL_RC_FILE
+              echo 'eval "$(#{ChefDK::Dist::EXEC} shell-init SHELL_NAME)"' >> ~/.YOUR_SHELL_RC_FILE
             In fish:
-              echo 'eval (chef shell-init SHELL_NAME)' >> ~/.config/fish/config.fish
+              echo 'eval (#{ChefDK::Dist::EXEC} shell-init SHELL_NAME)' >> ~/.config/fish/config.fish
             In Powershell
-              "chef shell-init powershell | Invoke-Expression" >> $PROFILE
+              "#{ChefDK::Dist::EXEC} shell-init powershell | Invoke-Expression" >> $PROFILE
 
         OPTIONS:
 

--- a/lib/chef-dk/command/show_policy.rb
+++ b/lib/chef-dk/command/show_policy.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ require "chef-dk/ui"
 require "chef-dk/configurable"
 require "chef-dk/policyfile/lister"
 require "chef-dk/policyfile_services/show_policy"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -27,9 +28,9 @@ module ChefDK
     class ShowPolicy < Base
 
       banner(<<~BANNER)
-        Usage: chef show-policy [POLICY_NAME [POLICY_GROUP]] [options]
+        Usage: #{ChefDK::Dist::EXEC} show-policy [POLICY_NAME [POLICY_GROUP]] [options]
 
-        `chef show-policy` Displays the revisions of policyfiles on the server. By
+        `#{ChefDK::Dist::EXEC} show-policy` Displays the revisions of policyfiles on the server. By
         default, only active policy revisions are shown. Use the `--orphans` options to
         show policy revisions that are not assigned to any policy group.
 

--- a/lib/chef-dk/command/undelete.rb
+++ b/lib/chef-dk/command/undelete.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ require "chef-dk/command/base"
 require "chef-dk/ui"
 require "chef-dk/configurable"
 require "chef-dk/policyfile_services/undelete"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -26,14 +27,14 @@ module ChefDK
     class Undelete < Base
 
       banner(<<~BANNER)
-        Usage: chef undelete [--list | --id ID] [options]
+        Usage: #{ChefDK::Dist::EXEC} undelete [--list | --id ID] [options]
 
-        `chef undelete` helps you recover quickly if you've deleted a policy or policy
+        `#{ChefDK::Dist::EXEC} undelete` helps you recover quickly if you've deleted a policy or policy
         group in error. When run with no arguements, it lists the available undo
         operations. To undo the last delete operation, use `chef undelete --last`.
 
         CAVEATS:
-        `chef undelete` doesn't detect conflicts. If a deleted item has been recreated,
+        `#{ChefDK::Dist::EXEC} undelete` doesn't detect conflicts. If a deleted item has been recreated,
         running `chef undelete` will overwrite it.
 
         Undo information does not include cookbooks that might be referenced by

--- a/lib/chef-dk/command/update.rb
+++ b/lib/chef-dk/command/update.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ require "chef-dk/ui"
 require "chef-dk/policyfile_services/install"
 require "chef-dk/policyfile_services/update_attributes"
 require "chef-dk/configurable"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -29,9 +30,9 @@ module ChefDK
       include Configurable
 
       banner(<<~BANNER)
-        Usage: chef update [ POLICY_FILE ] [options] [cookbook_1] [...]
+        Usage: #{ChefDK::Dist::EXEC} update [ POLICY_FILE ] [options] [cookbook_1] [...]
 
-        `chef update` reads your `Policyfile.rb`, applies any changes, re-solves the
+        `#{ChefDK::Dist::EXEC} update` reads your `Policyfile.rb`, applies any changes, re-solves the
         dependencies and emits an updated `Policyfile.lock.json`. The new locked policy
         will reflect any changes to the `run_list` and pull in any cookbook updates
         that are compatible with the version constraints stated in your `Policyfile.rb`.

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 require "chef-dk/command/base"
 require "chef-dk/exceptions"
 require "chef-dk/component_test"
+require "chef-dk/dist"
 
 module ChefDK
   module Command
@@ -25,7 +26,7 @@ module ChefDK
 
       include ChefDK::Helpers
 
-      banner "Usage: chef verify [component, ...] [options]"
+      banner "Usage: #{ChefDK::Dist::EXEC} verify [component, ...] [options]"
 
       option :omnibus_dir,
         long: "--omnibus-dir OMNIBUS_DIR",

--- a/lib/chef-dk/dist.rb
+++ b/lib/chef-dk/dist.rb
@@ -1,0 +1,31 @@
+module ChefDK
+  class Dist
+    # This class is not fully implemented, depending on it is not recommended!
+
+    # The full marketing name of the product
+    PRODUCT = "Chef Developmet Kit".freeze
+
+    # the name of the overall infra product
+    INFRA_PRODUCT = "Chef Infra".freeze
+
+    # name of the Infra client product
+    INFRA_CLIENT_PRODUCT = "Chef Infra Client".freeze
+
+    # The client's alias (chef-client)
+    INFRA_CLIENT_CLI = "chef-client".freeze
+
+    INSPEC_PRODUCT = "Chef InSpec".freeze
+    INSPEC_CLI = "inspec".freeze
+
+    # The name of the server product
+    SERVER_PRODUCT = "Chef Infra Server".freeze
+
+    WORKFLOW = "Chef Workflow (Delivery)".freeze
+
+    # The chef executable, as in `chef gem install` or `chef generate cookbook`
+    EXEC = "chef".freeze
+
+    # Chef-Zero's product name
+    ZERO_PRODUCT = "Chef Infra Zero".freeze
+  end
+end

--- a/lib/chef-dk/dist.rb
+++ b/lib/chef-dk/dist.rb
@@ -3,7 +3,7 @@ module ChefDK
     # This class is not fully implemented, depending on it is not recommended!
 
     # The full marketing name of the product
-    PRODUCT = "Chef Developmet Kit".freeze
+    PRODUCT = "Chef Development Kit".freeze
 
     # the name of the overall infra product
     INFRA_PRODUCT = "Chef Infra".freeze

--- a/lib/chef-dk/exceptions.rb
+++ b/lib/chef-dk/exceptions.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,8 +51,10 @@ module ChefDK
   end
 
   class OmnibusInstallNotFound < RuntimeError
+    require "chef-dk/dist"
+
     def initialize
-      super("Can not find omnibus installation directory for Chef.")
+      super("Can not find omnibus installation directory for #{ChefDK::Dist::PRODUCT}.")
     end
   end
 
@@ -66,7 +68,7 @@ module ChefDK
     def initialize(url, reason = nil)
       @url    = url
       @reason = reason
-      msg     = "'#{@url}' is not a valid Policy File Source URI"
+      msg     = "'#{@url}' is not a valid Policyfile Source URI"
       msg << " #{@reason}." unless @reason.nil?
       super(msg)
     end

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -128,8 +128,8 @@ module ChefDK
         end
       rescue Net::ProtocolError => e
         if e.respond_to?(:response) && e.response.code.to_s == "404"
-          raise ChefDK::PolicyfileLockDownloadError.new("No policyfile lock named '#{policy_name}' found with revision '#{revision}' at #{http_client.url}") if revision
-          raise ChefDK::PolicyfileLockDownloadError.new("No policyfile lock named '#{policy_name}' found with policy group '#{policy_group}' at #{http_client.url}") if policy_group
+          raise ChefDK::PolicyfileLockDownloadError.new("No Policyfile lock named '#{policy_name}' found with revision '#{revision}' at #{http_client.url}") if revision
+          raise ChefDK::PolicyfileLockDownloadError.new("No {olicyfile lock named '#{policy_name}' found with policy group '#{policy_group}' at #{http_client.url}") if policy_group
         else
           raise ChefDK::PolicyfileLockDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}")
         end

--- a/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
+++ b/lib/chef-dk/policyfile/chef_server_lock_fetcher.rb
@@ -129,7 +129,7 @@ module ChefDK
       rescue Net::ProtocolError => e
         if e.respond_to?(:response) && e.response.code.to_s == "404"
           raise ChefDK::PolicyfileLockDownloadError.new("No Policyfile lock named '#{policy_name}' found with revision '#{revision}' at #{http_client.url}") if revision
-          raise ChefDK::PolicyfileLockDownloadError.new("No {olicyfile lock named '#{policy_name}' found with policy group '#{policy_group}' at #{http_client.url}") if policy_group
+          raise ChefDK::PolicyfileLockDownloadError.new("No Policyfile lock named '#{policy_name}' found with policy group '#{policy_group}' at #{http_client.url}") if policy_group
         else
           raise ChefDK::PolicyfileLockDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}")
         end

--- a/lib/chef-dk/policyfile/comparison_base.rb
+++ b/lib/chef-dk/policyfile/comparison_base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# Copyright:: Copyright (c) 2015-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,12 +108,12 @@ module ChefDK
           http_client.get("policy_groups/#{group}/policies/#{policy_name}")
         rescue Net::ProtocolError => e
           if e.respond_to?(:response) && e.response.code.to_s == "404"
-            raise PolicyfileDownloadError.new("No policyfile lock named '#{policy_name}' found in policy_group '#{group}' at #{http_client.url}", e)
+            raise PolicyfileDownloadError.new("No Policyfile lock named '#{policy_name}' found in policy_group '#{group}' at #{http_client.url}", e)
           else
-            raise PolicyfileDownloadError.new("HTTP error attempting to fetch policyfile lock from #{http_client.url}", e)
+            raise PolicyfileDownloadError.new("HTTP error attempting to fetch Policyfile lock from #{http_client.url}", e)
           end
         rescue => e
-          raise PolicyfileDownloadError.new("Failed to fetch policyfile lock from #{http_client.url}", e)
+          raise PolicyfileDownloadError.new("Failed to fetch Policyfile lock from #{http_client.url}", e)
         end
 
       end

--- a/lib/chef-dk/policyfile/dsl.rb
+++ b/lib/chef-dk/policyfile/dsl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,7 +151,7 @@ module ChefDK
         validate!
         self
       rescue SyntaxError => e
-        @errors << "Invalid ruby syntax in policyfile '#{policyfile_filename}':\n\n#{e.message}"
+        @errors << "Invalid Ruby syntax in Policyfile '#{policyfile_filename}':\n\n#{e.message}"
       rescue SignalException, SystemExit
         # allow signal from kill, ctrl-C, etc. to bubble up:
         raise

--- a/lib/chef-dk/policyfile_services/export_repo.rb
+++ b/lib/chef-dk/policyfile_services/export_repo.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014-2018 Chef Software Inc.
+# Copyright:: Copyright (c) 2014-2019 Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -242,14 +242,14 @@ module ChefDK
             use_policyfile true
             policy_document_native_api true
 
-            # In order to use this repo, you need a version of Chef Client and Chef Zero
+            # In order to use this repo, you need a version of Chef Infra Client and Chef Zero
             # that supports policyfile "native mode" APIs:
             current_version = Gem::Version.new(Chef::VERSION)
             unless Gem::Requirement.new(">= 12.7").satisfied_by?(current_version)
               puts("!" * 80)
               puts(<<-MESSAGE)
-            This Chef Repo requires features introduced in Chef 12.7, but you are using
-            Chef \#{Chef::VERSION}. Please upgrade to Chef 12.7 or later.
+            This Chef Repo requires features introduced in Chef Infra Client 12.7, but you are using
+            Chef \#{Chef::VERSION}. Please upgrade to Chef Infra Client 12.7 or later.
             MESSAGE
               puts("!" * 80)
               exit!(1)
@@ -262,7 +262,7 @@ module ChefDK
       def create_readme_md
         File.open(readme_staging_path, "wb+") do |f|
           f.print( <<~README )
-            # Exported Chef Repository for Policy '#{policy_name}'
+            # Exported Chef Infra Repository for Policy '#{policy_name}'
 
             Policy revision: #{policyfile_lock.revision_id}
 

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -54,7 +54,7 @@ describe ChefDK::CLI do
     E
   end
 
-  let(:version_message) { "Chef Development Kit Version: #{ChefDK::VERSION}\n" }
+  let(:version_message) { "Chef Development Kit version: #{ChefDK::VERSION}\n" }
 
   def run_cli(expected_exit_code)
     expect(cli).to receive(:exit).with(expected_exit_code)

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -78,12 +78,12 @@ describe ChefDK::Command::Base do
 
   it "should print the version for -v" do
     run_command(["-v"])
-    expect(stdout).to eq("Chef Development Kit Version: #{ChefDK::VERSION}\n")
+    expect(stdout).to eq("Chef Development Kit version: #{ChefDK::VERSION}\n")
   end
 
   it "should print the version for --version" do
     run_command(["--version"])
-    expect(stdout).to eq("Chef Development Kit Version: #{ChefDK::VERSION}\n")
+    expect(stdout).to eq("Chef Development Kit version: #{ChefDK::VERSION}\n")
   end
 
   it "should run the command passing in the custom options for long custom options" do
@@ -129,7 +129,7 @@ describe ChefDK::Command::Base do
                 --chef-license ACCEPTANCE    Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')
             -h, --help                       Show this message
             -u, --user                       If the user exists
-            -v, --version                    Show chef version
+            -v, --version                    Show Chef Development Kit version
 
       E
       expect(stdout).to eq(expected)
@@ -150,7 +150,7 @@ describe ChefDK::Command::Base do
                 --chef-license ACCEPTANCE    Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')
             -h, --help                       Show this message
             -u, --user                       If the user exists
-            -v, --version                    Show chef version
+            -v, --version                    Show Chef Development Kit version
 
       E
       expect(stdout).to eq(expected)

--- a/spec/unit/command/generator_commands/generator_generator_spec.rb
+++ b/spec/unit/command/generator_commands/generator_generator_spec.rb
@@ -182,8 +182,8 @@ describe ChefDK::Command::GeneratorCommands::GeneratorGenerator do
         metadata_content = IO.read(metadata_path)
         expected_metadata = <<~METADATA
           name             'my_cool_generator'
-          description      'Custom code generator cookbook for use with ChefDK'
-          long_description 'Custom code generator cookbook for use with ChefDK'
+          description      'Custom code generator cookbook for use with Chef Development Kit'
+          long_description 'Custom code generator cookbook for use with Chef Development Kit'
           version          '0.1.0'
 
         METADATA

--- a/spec/unit/policyfile/comparison_base_spec.rb
+++ b/spec/unit/policyfile/comparison_base_spec.rb
@@ -268,7 +268,7 @@ describe "Policyfile Comparison Bases" do
           comparison_base.lock
         rescue => exception
           expect(exception).to be_a_kind_of(ChefDK::PolicyfileDownloadError)
-          expect(exception.message).to eq("HTTP error attempting to fetch policyfile lock from https://chef.example/organizations/monkeynews")
+          expect(exception.message).to eq("HTTP error attempting to fetch Policyfile lock from https://chef.example/organizations/monkeynews")
           expect(exception.cause).to eq(http_exception)
         end
         expect(exception).to_not be_nil
@@ -302,7 +302,7 @@ describe "Policyfile Comparison Bases" do
           comparison_base.lock
         rescue => exception
           expect(exception).to be_a_kind_of(ChefDK::PolicyfileDownloadError)
-          expect(exception.message).to eq("No policyfile lock named 'chatserver' found in policy_group 'acceptance' at https://chef.example/organizations/monkeynews")
+          expect(exception.message).to eq("No Policyfile lock named 'chatserver' found in policy_group 'acceptance' at https://chef.example/organizations/monkeynews")
           expect(exception.cause).to eq(http_exception)
         end
         expect(exception).to_not be_nil

--- a/spec/unit/policyfile_evaluation_spec.rb
+++ b/spec/unit/policyfile_evaluation_spec.rb
@@ -53,7 +53,7 @@ describe ChefDK::PolicyfileCompiler do
 
         it "has a syntax error message" do
           expect(policyfile.errors.size).to eq(1)
-          expect(policyfile.errors.first).to match(/Invalid ruby syntax in policyfile 'TestPolicyfile.rb'/)
+          expect(policyfile.errors.first).to match(/Invalid Ruby syntax in Policyfile 'TestPolicyfile.rb'/)
         end
 
       end

--- a/spec/unit/policyfile_services/export_repo_spec.rb
+++ b/spec/unit/policyfile_services/export_repo_spec.rb
@@ -282,14 +282,14 @@ describe ChefDK::PolicyfileServices::ExportRepo do
               use_policyfile true
               policy_document_native_api true
 
-              # In order to use this repo, you need a version of Chef Client and Chef Zero
+              # In order to use this repo, you need a version of Chef Infra Client and Chef Zero
               # that supports policyfile "native mode" APIs:
               current_version = Gem::Version.new(Chef::VERSION)
               unless Gem::Requirement.new(">= 12.7").satisfied_by?(current_version)
                 puts("!" * 80)
                 puts(<<-MESSAGE)
-              This Chef Repo requires features introduced in Chef 12.7, but you are using
-              Chef \#{Chef::VERSION}. Please upgrade to Chef 12.7 or later.
+              This Chef Repo requires features introduced in Chef Infra Client 12.7, but you are using
+              Chef \#{Chef::VERSION}. Please upgrade to Chef Infra Client 12.7 or later.
               MESSAGE
                 puts("!" * 80)
                 exit!(1)

--- a/spec/unit/policyfile_services/show_policy_spec.rb
+++ b/spec/unit/policyfile_services/show_policy_spec.rb
@@ -835,7 +835,7 @@ describe ChefDK::PolicyfileServices::ShowPolicy do
       end
 
       it "prints a message saying there is no policy assigned" do
-        message = "No policyfile lock named 'appserver' found in policy_group 'dev' at https://chef.example/organizations/monkeynews"
+        message = "No Policyfile lock named 'appserver' found in policy_group 'dev' at https://chef.example/organizations/monkeynews"
         expect { show_policy_service.run }.to raise_error(ChefDK::PolicyfileDownloadError, message)
       end
 


### PR DESCRIPTION
This is a requirement for the community edition. It also has some very nice benefits internally for Chef Inc.
	- We get consistent usage of our product names. DK wasn't that bad, but it wasn't great.
	- We provide a single place we can patch in Workstation to change the name in the UI from Chef DK -> Chef Workstation

I also updated a few places were Policyfile wasn't capitalized.

Signed-off-by: Tim Smith <tsmith@chef.io>