### PR TITLE
Refer to the product as ChefDK to match docs + downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chef Development Kit
+# ChefDK
 
 [![Build Status](https://badge.buildkite.com/19dd11f6792c0cf4617ee97195060bd54b76f6a74228fd6e07.svg?branch=master)](https://buildkite.com/chef-oss/chef-chef-dk-master-verify)
 [![Build Status Master](https://ci.appveyor.com/api/projects/status/github/chef/chef-dk?branch=master&svg=true&passingText=master%20-%20Ok&pendingText=master%20-%20Pending&failingText=master%20-%20Failing)](https://ci.appveyor.com/project/Chef/chef-dk/branch/master)

--- a/lib/chef-dk/dist.rb
+++ b/lib/chef-dk/dist.rb
@@ -3,27 +3,23 @@ module ChefDK
     # This class is not fully implemented, depending on it is not recommended!
 
     # The full marketing name of the product
-    PRODUCT = "Chef Development Kit".freeze
+    PRODUCT = "ChefDK".freeze
+
+    # The chef executable, as in `chef gem install` or `chef generate cookbook`
+    EXEC = "chef".freeze
 
     # the name of the overall infra product
     INFRA_PRODUCT = "Chef Infra".freeze
 
-    # name of the Infra client product
     INFRA_CLIENT_PRODUCT = "Chef Infra Client".freeze
-
-    # The client's alias (chef-client)
     INFRA_CLIENT_CLI = "chef-client".freeze
+
+    SERVER_PRODUCT = "Chef Infra Server".freeze
 
     INSPEC_PRODUCT = "Chef InSpec".freeze
     INSPEC_CLI = "inspec".freeze
 
-    # The name of the server product
-    SERVER_PRODUCT = "Chef Infra Server".freeze
-
     WORKFLOW = "Chef Workflow (Delivery)".freeze
-
-    # The chef executable, as in `chef gem install` or `chef generate cookbook`
-    EXEC = "chef".freeze
 
     # Chef-Zero's product name
     ZERO_PRODUCT = "Chef Infra Zero".freeze

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -54,7 +54,7 @@ describe ChefDK::CLI do
     E
   end
 
-  let(:version_message) { "Chef Development Kit version: #{ChefDK::VERSION}\n" }
+  let(:version_message) { "ChefDK version: #{ChefDK::VERSION}\n" }
 
   def run_cli(expected_exit_code)
     expect(cli).to receive(:exit).with(expected_exit_code)

--- a/spec/unit/command/base_spec.rb
+++ b/spec/unit/command/base_spec.rb
@@ -78,12 +78,12 @@ describe ChefDK::Command::Base do
 
   it "should print the version for -v" do
     run_command(["-v"])
-    expect(stdout).to eq("Chef Development Kit version: #{ChefDK::VERSION}\n")
+    expect(stdout).to eq("ChefDK version: #{ChefDK::VERSION}\n")
   end
 
   it "should print the version for --version" do
     run_command(["--version"])
-    expect(stdout).to eq("Chef Development Kit version: #{ChefDK::VERSION}\n")
+    expect(stdout).to eq("ChefDK version: #{ChefDK::VERSION}\n")
   end
 
   it "should run the command passing in the custom options for long custom options" do
@@ -129,7 +129,7 @@ describe ChefDK::Command::Base do
                 --chef-license ACCEPTANCE    Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')
             -h, --help                       Show this message
             -u, --user                       If the user exists
-            -v, --version                    Show Chef Development Kit version
+            -v, --version                    Show ChefDK version
 
       E
       expect(stdout).to eq(expected)
@@ -150,7 +150,7 @@ describe ChefDK::Command::Base do
                 --chef-license ACCEPTANCE    Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')
             -h, --help                       Show this message
             -u, --user                       If the user exists
-            -v, --version                    Show Chef Development Kit version
+            -v, --version                    Show ChefDK version
 
       E
       expect(stdout).to eq(expected)

--- a/spec/unit/command/generator_commands/generator_generator_spec.rb
+++ b/spec/unit/command/generator_commands/generator_generator_spec.rb
@@ -182,8 +182,8 @@ describe ChefDK::Command::GeneratorCommands::GeneratorGenerator do
         metadata_content = IO.read(metadata_path)
         expected_metadata = <<~METADATA
           name             'my_cool_generator'
-          description      'Custom code generator cookbook for use with Chef Development Kit'
-          long_description 'Custom code generator cookbook for use with Chef Development Kit'
+          description      'Custom code generator cookbook for use with ChefDK'
+          long_description 'Custom code generator cookbook for use with ChefDK'
           version          '0.1.0'
 
         METADATA

--- a/warning.txt
+++ b/warning.txt
@@ -1,9 +1,8 @@
-Thanks for installing chef-dk! Unfortunately, since Chef Development Kit is
+Thanks for installing chef-dk! Unfortunately, since ChefDK is
 supposed to be installed as the omnibus binaries in order to support various
 platforms, this is not the official way to install chef-dk.
 
 Please download the latest version for your operating system from the URL below,
 and make sure you have uninstalled your chef-dk gem to avoid conflicts:
 
-https://downloads.chef.io/chef-dk/
-
+https://downloads.chef.io/chefdk


### PR DESCRIPTION
Use the same name for this project everywhere.

Signed-off-by: Tim Smith <tsmith@chef.io>