### PR TITLE
Remove explicit dependency on rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,6 @@ group(:omnibus_package) do
   gem "pry-remote"
   gem "pry-stack_explorer"
   gem "rb-readline"
-  gem "rubocop"
   gem "winrm-fs"
   gem "winrm-elevated"
   gem "cucumber"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -951,7 +951,6 @@ DEPENDENCIES
   rspec-core (~> 3.0)
   rspec-expectations (~> 3.0)
   rspec-mocks (~> 3.0)
-  rubocop
   ruby-prof
   ruby-shadow
   stove


### PR DESCRIPTION
This already comes in via cookstyle so this is basically just simplifying our gemfile/lock.

Signed-off-by: Tim Smith <tsmith@chef.io>