### PR TITLE
Lock chef-apply to =0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,9 @@ group(:omnibus_package) do
   # Right now we must import chef-apply as a gem into the ChefDK because this is where all the gem
   # dependency resolution occurs. Putting it elsewhere endangers older ChefDK issues of gem version
   # conflicts post-build.
-  gem "chef-apply"
+  # Version 3.3 switches to ChefCLI instead of ChefDK - we want to lock to
+  # the latest version before that so that we don't pull in ChefCLI.
+  gem "chef-apply", "= 0.3.0"
 
   # For Delivery build node
   gem "chef-sugar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -877,7 +877,7 @@ DEPENDENCIES
   berkshelf (>= 7.0.5)
   bundler
   chef (= 15.1.36)
-  chef-apply
+  chef-apply (= 0.3.0)
   chef-bin (= 15.1.36)
   chef-dk!
   chef-sugar


### PR DESCRIPTION
The next released version of chef-run (chef-apply) , 0.3.3, pulls in the ChefCLI library.
This doesn't belong in ChefDK since ChefCLI is a fork of DK's libraries
for future Workstation development, so we'll pin to 0.3.0 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
