### PR TITLE
Replace usage of deprecated Net::HTTPServerException error class

### DIFF
--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -79,7 +79,7 @@ module ChefDK
 
       def data_bag_create
         http_client.post("data", { "name" => COMPAT_MODE_DATA_BAG_NAME })
-      rescue Net::HTTPClientException  => e
+      rescue Net::HTTPClientException => e
         raise e unless e.response.code == "409"
       end
 
@@ -214,7 +214,7 @@ module ChefDK
 
       def upload_lockfile_as_data_bag_item(policy_id, data_item)
         http_client.put("data/#{COMPAT_MODE_DATA_BAG_NAME}/#{policy_id}", data_item)
-      rescue Net::HTTPClientException  => e
+      rescue Net::HTTPClientException => e
         raise e unless e.response.code == "404"
 
         http_client.post("data/#{COMPAT_MODE_DATA_BAG_NAME}", data_item)

--- a/lib/chef-dk/policyfile/uploader.rb
+++ b/lib/chef-dk/policyfile/uploader.rb
@@ -79,7 +79,7 @@ module ChefDK
 
       def data_bag_create
         http_client.post("data", { "name" => COMPAT_MODE_DATA_BAG_NAME })
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException  => e
         raise e unless e.response.code == "409"
       end
 
@@ -214,7 +214,7 @@ module ChefDK
 
       def upload_lockfile_as_data_bag_item(policy_id, data_item)
         http_client.put("data/#{COMPAT_MODE_DATA_BAG_NAME}/#{policy_id}", data_item)
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException  => e
         raise e unless e.response.code == "404"
 
         http_client.post("data/#{COMPAT_MODE_DATA_BAG_NAME}", data_item)

--- a/lib/chef-dk/policyfile_services/rm_policy.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy.rb
@@ -134,7 +134,7 @@ module ChefDK
       def fetch_policy_revision_data
         @policy_revision_data = http_client.get("/policies/#{policy_name}")
         @policy_exists = true
-      rescue Net::HTTPClientException  => e
+      rescue Net::HTTPClientException => e
         raise unless e.response.code == "404"
 
         @policy_exists = false

--- a/lib/chef-dk/policyfile_services/rm_policy.rb
+++ b/lib/chef-dk/policyfile_services/rm_policy.rb
@@ -134,7 +134,7 @@ module ChefDK
       def fetch_policy_revision_data
         @policy_revision_data = http_client.get("/policies/#{policy_name}")
         @policy_exists = true
-      rescue Net::HTTPServerException => e
+      rescue Net::HTTPClientException  => e
         raise unless e.response.code == "404"
 
         @policy_exists = false

--- a/spec/unit/policyfile/uploader_spec.rb
+++ b/spec/unit/policyfile/uploader_spec.rb
@@ -319,14 +319,14 @@ describe ChefDK::Policyfile::Uploader do
 
       it "does not error when the 'policyfiles' data bag exists" do
         response = double("Net::HTTP response", code: "409")
-        error = Net::HTTPServerException.new("conflict", response)
+        error = Net::HTTPClientException .new("conflict", response)
         expect(http_client).to receive(:post).with("data", { "name" => "policyfiles" }).and_raise(error)
         expect { uploader.data_bag_create }.to_not raise_error
       end
 
       it "uploads the policyfile as a data bag item" do
         response = double("Net::HTTP response", code: "404")
-        error = Net::HTTPServerException.new("Not Found", response)
+        error = Net::HTTPClientException .new("Not Found", response)
         expect(http_client).to receive(:put)
           .with("data/policyfiles/example-unit-test", policyfile_as_data_bag_item)
           .and_raise(error)

--- a/spec/unit/policyfile_services/clean_policies_spec.rb
+++ b/spec/unit/policyfile_services/clean_policies_spec.rb
@@ -213,7 +213,7 @@ describe ChefDK::PolicyfileServices::CleanPolicies do
           it "deletes what it can, then raises an error" do
             expected_message = <<~ERROR
               Failed to delete some policy revisions:
-              - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPServerException 403 \"Unauthorized\"
+              - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPClientException  403 \"Unauthorized\"
             ERROR
 
             expect { clean_policies_service.run }.to raise_error do |error|

--- a/spec/unit/policyfile_services/clean_policies_spec.rb
+++ b/spec/unit/policyfile_services/clean_policies_spec.rb
@@ -211,9 +211,11 @@ describe ChefDK::PolicyfileServices::CleanPolicies do
           end
 
           it "deletes what it can, then raises an error" do
+            # Ruby 2.6 deprecated HTTPServerException but the errors are still initialized using it, so
+            # this will continue to print that out until they remove HTTPServerException
             expected_message = <<~ERROR
               Failed to delete some policy revisions:
-              - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPClientException  403 \"Unauthorized\"
+              - appserver (4444444444444444444444444444444444444444444444444444444444444444): Net::HTTPServerException 403 \"Unauthorized\"
             ERROR
 
             expect { clean_policies_service.run }.to raise_error do |error|

--- a/spec/unit/service_exception_inspectors/http_spec.rb
+++ b/spec/unit/service_exception_inspectors/http_spec.rb
@@ -64,7 +64,7 @@ describe ChefDK::ServiceExceptionInspectors::HTTP do
   end
 
   let(:exception) do
-    Net::HTTPServerException.new(message, response).tap { |e| e.chef_rest_request = request }
+    Net::HTTPClientException .new(message, response).tap { |e| e.chef_rest_request = request }
   end
 
   subject(:inspector) { described_class.new(exception) }


### PR DESCRIPTION
Using this results in spam to the console. This is really annoying during our tests.

Signed-off-by: Tim Smith <tsmith@chef.io>