### PR TITLE
Roll back rubygems to 3.0.3 to prevent double bundler

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: efb7d011ff5a7ff648346a388d6f83314d42209c
+  revision: d671c6dadb4fe71aa5f547c0587f949a7d246458
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -32,7 +32,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.186.0)
+    aws-partitions (1.187.0)
     aws-sdk-core (3.59.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,7 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override :rubygems, version: "3.0.4"
+override :rubygems, version: "3.0.3" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which results in performance issues / CLI warnings. Make sure these versions match before bumping either.
 override :bundler, version: "1.17.2" # currently pinned to what ships in Ruby to prevent double bundler
 override "libffi", version: "3.2.1"
 override "libiconv", version: "1.15"


### PR DESCRIPTION
There's nothing important in this release other than a few minor bugfixes. The other alternative was to roll bundler forward to 1.17.3 so that the embedded rubygems bundler matched, but this meant we had bundler 1.17.2 built into ruby 2.6.3 and then 1.17.3 installed on top of that. There's little value in that and it bloats our package size. Let's not do that unless there's a critical bug or CVE we need in rubygems / bundler.

This also bumps omnibus-software to include the new ruby cleanup def that fails if we have double bundler and the new rubygems def that removes the rubygems-update gem once rubygems is installed.

Signed-off-by: Tim Smith <tsmith@chef.io>