### PR TITLE
pin chefspec to < 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group(:omnibus_package) do
   gem "chef", "= 15.1.36"
   gem "chef-bin", "= 15.1.36"
   gem "cheffish", ">= 14.0.1"
-  gem "chefspec", ">= 7.3.0"
+  gem "chefspec", ">= 7.3.0", "< 8"
   gem "fauxhai", "~> 7.0"
   gem "inspec-bin", "~> 4.3" # the actual inspec CLI binary
   gem "inspec", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -979,7 +979,7 @@ DEPENDENCIES
   chef-sugar
   chef-vault (>= 3.4.1)
   cheffish (>= 14.0.1)
-  chefspec (>= 7.3.0)
+  chefspec (>= 7.3.0, < 8)
   chefstyle
   cookstyle (~> 5.0)
   cucumber


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

ChefSpec 8 and later pull in ChefCLI, which is a fork of
the ChefDK gem. In order to avoid pulling ChefCLI into ChefDK,
we'll pin chefspec to < 8.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

