### PR TITLE
Fix deprecated chef provision command to not fail

### DIFF
--- a/lib/chef-dk/builtin_commands.rb
+++ b/lib/chef-dk/builtin_commands.rb
@@ -59,4 +59,7 @@ ChefDK.commands do |c|
                                                     desc: "Prints cookbook checksum information used for cookbook identifier"
 
   c.builtin "verify", :Verify, desc: "Test the embedded #{ChefDK::Dist::PRODUCT} applications", hidden: true
+
+  # deprecated command that throws a failure warning if used. This was removed 4.2019
+  c.builtin "provision", :Provision, desc: "Provision VMs and clusters via cookbook", hidden: true
 end


### PR DESCRIPTION
This should be a valid command since we have a class for it. The class throws the friendly warning let folks know it's deprecated

Signed-off-by: Tim Smith <tsmith@chef.io>