### PR TITLE
Add Windows 2019 build verification

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -34,3 +34,4 @@ builder-to-testers-map:
     - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64
+    - windows-2019-x86_64


### PR DESCRIPTION
This will get us a Windows 2019 build on the downloads site.

Signed-off-by: Tim Smith <tsmith@chef.io>