### PR TITLE
Improve packaging Chef-DK with Habitat

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -64,3 +64,11 @@ steps:
     executor:
       docker:
         image: ruby:2.6-stretch
+
+- label: hab-package-build-test
+  command:
+    - habitat/scripts/ci_integration_tests.sh
+  expeditor:
+    executor:
+      docker:
+        privileged: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ coverage
 .DS_Store
 pkg/*
 *.gem
+*.swp
 */tags
 *~
 gem_graph.png

--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This is the place where we can extend the funcitonality of the studio
+#
+
+hab pkg install chef/studio-common >/dev/null
+source "$(hab pkg path chef/studio-common)/bin/studio-common"
+
+function build_install_and_tests() {
+  build
+  if [[ $? != 0 ]]; then
+    return 1
+  fi
+
+  OPTS="--binlink --force" install
+  if [[ $? != 0 ]]; then
+    return 1
+  fi
+
+  ./habitat/tests.sh
+}

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -35,11 +35,6 @@ pkg_deps=(
 
 pkg_svc_user=root
 
-do_before() {
-  do_default_before
-  update_pkg_version
-}
-
 do_download() {
   # Instead of downloading, build a gem based on the source in src/
   cd $PLAN_CONTEXT/..

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -8,7 +8,6 @@ pkg_svc_user=root
 pkg_build_deps=(
   core/make
   core/gcc
-  core/coreutils
   core/git
 )
 
@@ -65,8 +64,10 @@ do_prepare() {
   export RUBY_ABI_VERSION=$(ls $(pkg_path_for ${ruby_pkg})/lib/ruby/gems)
   build_line "Ruby ABI version appears to be ${RUBY_ABI_VERSION}"
 
-  build_line "Setting link for /usr/bin/env to 'coreutils'"
-  [ ! -f /usr/bin/env ] && ln -s "$(pkg_path_for coreutils)/bin/env" /usr/bin/env || return 0
+  build_line "Setting link for /usr/bin/env to 'busybox-static'"
+  if [ ! -f /usr/bin/env ]; then
+    ln -s "$(pkg_interpreter_for core/busybox-static bin/env)" /usr/bin/env
+  fi
 }
 
 do_build() {
@@ -140,8 +141,8 @@ do_install() {
     wrap_ruby_bin "$(basename "${exe}")"
   done
 
-  if [[ `readlink /usr/bin/env` = "$(pkg_path_for coreutils)/bin/env" ]]; then
-    build_line "Removing the symlink we created for '/usr/bin/env'"
+  if [ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/busybox-static bin/env)" ]; then
+    build_line "Removing the symlink created for '/usr/bin/env'"
     rm /usr/bin/env
   fi
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -5,6 +5,7 @@ pkg_description="The Chef Developer Kit"
 pkg_version=$(cat ../VERSION)
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
+pkg_svc_user=root
 pkg_build_deps=(
   core/make
   core/gcc
@@ -33,8 +34,6 @@ pkg_deps=(
   core/libarchive
 )
 
-pkg_svc_user=root
-
 do_download() {
   build_line "Building gem from source. (${SRC_PATH}/${pkg_name}.gemspec)"
   gem build "${SRC_PATH}/${pkg_name}.gemspec"
@@ -59,9 +58,7 @@ do_prepare() {
   build_line "Ruby ABI version appears to be ${RUBY_ABI_VERSION}"
 
   build_line "Setting link for /usr/bin/env to 'coreutils'"
-  [[ ! -f /usr/bin/env ]] && ln -s $(pkg_path_for coreutils)/bin/env /usr/bin/env
-
-  return 0
+  [ ! -f /usr/bin/env ] && ln -s "$(pkg_path_for coreutils)/bin/env" /usr/bin/env || return 0
 }
 
 do_build() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -62,26 +62,34 @@ do_prepare() {
 }
 
 do_build() {
-  cd $CACHE_PATH
-  export CPPFLAGS="${CPPFLAGS} ${CFLAGS}"
+  local _bundler_dir
+  local _libxml2_dir
+  local _libxslt_dir
+  local _zlib_dir
+  export NOKOGIRI_CONFIG
+  export GEM_HOME
+  export GEM_PATH
 
-  local _bundler_dir=$(pkg_path_for bundler)
-  local _libxml2_dir=$(pkg_path_for libxml2)
-  local _libxslt_dir=$(pkg_path_for libxslt)
-  local _zlib_dir=$(pkg_path_for zlib)
+  _bundler_dir=$(pkg_path_for bundler)
+  _libxml2_dir=$(pkg_path_for libxml2)
+  _libxslt_dir=$(pkg_path_for libxslt)
+  _zlib_dir=$(pkg_path_for zlib)
 
-  export GEM_HOME=${pkg_prefix}
-  export GEM_PATH=${_bundler_dir}:${GEM_HOME}
+  NOKOGIRI_CONFIG="--use-system-libraries \
+    --with-zlib-dir=${_zlib_dir} \
+    --with-xslt-dir=${_libxslt_dir} \
+    --with-xml2-include=${_libxml2_dir}/include/libxml2 \
+    --with-xml2-lib=${_libxml2_dir}/lib \
+    --without-iconv"
+  GEM_HOME="$pkg_prefix"
+  GEM_PATH="${_bundler_dir}:${GEM_HOME}"
 
-  export NOKOGIRI_CONFIG="--use-system-libraries --with-zlib-dir=${_zlib_dir} --with-xslt-dir=${_libxslt_dir} --with-xml2-include=${_libxml2_dir}/include/libxml2 --with-xml2-lib=${_libxml2_dir}/lib --without-iconv"
-  bundle config --local build.nokogiri "${NOKOGIRI_CONFIG}"
-
-  bundle config --local silence_root_warning 1
-
-  bundle install --without dep_selector --no-deployment --jobs 2 --retry 5 --path $pkg_prefix
-
-  gem build chef-dk.gemspec
-  gem install --no-doc chef-dk-*.gem
+  ( cd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
+    bundle config --local build.nokogiri "$NOKOGIRI_CONFIG"
+    bundle config --local silence_root_warning 1
+    bundle install --without dep_selector --no-deployment --jobs 2 --retry 5 --path "$pkg_prefix"
+    gem build ${pkg_name}.gemspec
+  )
 }
 
 do_install() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -2,7 +2,6 @@ pkg_name=chef-dk
 pkg_origin=chef
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 pkg_description="The Chef Developer Kit"
-pkg_version=$(cat ../VERSION)
 pkg_license=('Apache-2.0')
 pkg_bin_dirs=(bin)
 pkg_svc_user=root
@@ -33,6 +32,15 @@ pkg_deps=(
   core/libffi
   core/libarchive
 )
+
+pkg_version() {
+  cat "$SRC_PATH/VERSION"
+}
+
+do_before() {
+  do_default_before
+  update_pkg_version
+}
 
 do_download() {
   build_line "Building gem from source. (${SRC_PATH}/${pkg_name}.gemspec)"

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -145,21 +145,26 @@ do_strip() {
 
 # Copied from https://github.com/habitat-sh/core-plans/blob/f84832de42b300a64f1b38c54d659c4f6d303c95/bundler/plan.sh#L32
 wrap_ruby_bin() {
-  local bin_basename="$1"
-  local real_cmd="$pkg_prefix/ruby-bin/$bin_basename"
-  local wrapper="$pkg_prefix/bin/$bin_basename"
+  local bin_basename
+  local real_cmd
+  local wrapper
+  bin_basename="$1"
+  real_cmd="$ruby_bin_dir/$bin_basename"
+  wrapper="$pkg_prefix/bin/$bin_basename"
 
-  build_line "Adding wrapper $wrapper to $real_cmd"
+  build_line "Adding wrapper for $bin_basename."
+  build_line " - from: $wrapper"
+  build_line " -   to: $real_cmd"
   cat <<EOF > "$wrapper"
 #!$(pkg_path_for busybox-static)/bin/sh
 set -e
-if test -n "$DEBUG"; then set -x; fi
+if test -n "\$DEBUG"; then set -x; fi
 export GEM_HOME="$pkg_prefix/ruby/${RUBY_ABI_VERSION}/"
 export GEM_PATH="$(pkg_path_for ${ruby_pkg})/lib/ruby/gems/${RUBY_ABI_VERSION}:$(hab pkg path core/bundler):$pkg_prefix/ruby/${RUBY_ABI_VERSION}/:$GEM_HOME"
 export SSL_CERT_FILE=$(pkg_path_for core/cacerts)/ssl/cert.pem
 export APPBUNDLER_ALLOW_RVM=true
 unset RUBYOPT GEMRC
-exec $(pkg_path_for ${ruby_pkg})/bin/ruby ${real_cmd} \$@
+exec $(pkg_path_for ${ruby_pkg})/bin/ruby ${real_cmd} "\$@"
 EOF
   chmod -v 755 "$wrapper"
 }

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -36,9 +36,8 @@ pkg_deps=(
 pkg_svc_user=root
 
 do_download() {
-  # Instead of downloading, build a gem based on the source in src/
-  cd $PLAN_CONTEXT/..
-  gem build $pkg_name.gemspec
+  build_line "Building gem from source. (${SRC_PATH}/${pkg_name}.gemspec)"
+  gem build "${SRC_PATH}/${pkg_name}.gemspec"
 }
 
 do_verify() {
@@ -48,7 +47,8 @@ do_verify() {
 do_unpack() {
   # Unpack the gem we built to the source cache path. Building then unpacking
   # the gem reuses the file inclusion/exclusion rules defined in the gemspec.
-  gem unpack $PLAN_CONTEXT/../$pkg_name-$pkg_version.gem --target=$HAB_CACHE_SRC_PATH
+  build_line "Unpacking gem into hab-cache directory. ($HAB_CACHE_SRC_PATH)"
+  gem unpack "${SRC_PATH}/${pkg_name}-${pkg_version}.gem" --target="$HAB_CACHE_SRC_PATH"
 }
 
 do_prepare() {

--- a/habitat/scripts/ci_integration_tests.sh
+++ b/habitat/scripts/ci_integration_tests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Build chef-dk hart package and run the integration tests
+#
+
+set -eo pipefail
+
+log_line() {
+    echo "--- [$(date -u)] $*"
+}
+
+export HAB_ORIGIN=chef
+export HAB_STUDIO_SUP=false
+export HAB_NONINTERACTIVE=true
+export HAB_LICENSE="accept-no-persist"
+
+log_line "generate ephemeral origin key"
+hab origin key generate $HAB_ORIGIN
+
+log_line "build chef-dk hart package"
+hab pkg build .
+
+log_line "install chef-dk hart package"
+source "results/last_build.env"
+hab pkg install -b "results/$pkg_artifact"
+
+log_line "run chef-dk integration tests"
+./habitat/tests.sh

--- a/habitat/tests.sh
+++ b/habitat/tests.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Tests for the Chef-DK habitat package.
+# Assume package has already been installed.
+#
+
+set -eo pipefail
+
+# Execute all commands that currently work
+echo -n "Chef Inspec "
+inspec -v
+echo "Chef Infra"
+echo -n " - knife "
+knife -v | awk {'print $NF'}
+echo -n " - chef-client "
+chef-client -v | awk {'print $NF'}
+echo -n " - chef-solo "
+chef-solo -v | awk {'print $NF'}
+echo -n " - chef-apply "
+chef-apply -v | awk {'print $NF'}
+echo -n " - chef-shell "
+chef-shell -v | awk {'print $NF'}
+# TODO(afiune) do we still use this? because it doesn't work
+echo " - chef-zero (not-working)"
+#chef-zero -v
+echo -n "Berkshelf "
+berks -v
+cookstyle -v
+foodcritic -V
+ohai -v
+kitchen -v
+echo "Chef-Vault (only-help)"
+chef-vault -h
+
+# TODO(afiune) fix this since it currently doesn't work
+echo "skip: Chef CLI (not-working)"
+#chef -v
+#dco help # missing git
+
+# TODO(afiune) add more tests


### PR DESCRIPTION
Improvements to the way we package Chef-DK with Habitat (for Linux systems)

## Description

- Restructure `wrap_ruby_bin` to respect `DEBUG` env-var
- Restructure `do_install` to execute in a sub-shell
- Restructure `do_build` to execute in a sub-shell
- Use `SRC_PATH` instead of `PLAN_CONTEXT/..`
- Remove unnecessary `do_before` callback
- Use `pkg_interpreter_for` and remove `core/coreutils` dependency
- Makes `pkg_version` a func to use `update_pkg_version` 
- Adds buildtike job to test habitat package to prevent regressions
- Quick general styling

## Related Issue
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
