### PR TITLE
[ci] Add artifactory to omnibus/Gemfile and update omnibus gem

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "omnibus", git: "https://github.com/chef/omnibus.git", branch: "master"
 gem "omnibus-software", git: "https://github.com/chef/omnibus-software.git", branch: "master"
+gem "artifactory"
 
 gem "pedump"
 

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 0077920a97ab9e5550f3c3767825f9c1f805bdce
+  revision: 33bddeefb10afe23a57ea72807625881ab01990f
   branch: master
   specs:
-    omnibus (6.0.31)
+    omnibus (6.1.0)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,10 +30,11 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.194.0)
-    aws-sdk-core (3.61.2)
+    aws-partitions (1.196.0)
+    aws-sdk-core (3.62.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -371,6 +372,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
+  artifactory
   berkshelf (>= 7.0)
   kitchen-vagrant
   omnibus!


### PR DESCRIPTION
### Description

This change only affects CI. A new version of omnibus is required and the artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22