### PR TITLE
Stop building ChefDK on EOL SLES 11

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -19,8 +19,6 @@ builder-to-testers-map:
     - mac_os_x-10.12-x86_64
     - mac_os_x-10.13-x86_64
     - mac_os_x-10.14-x86_64
-  sles-11-x86_64:
-    - sles-11-x86_64
   sles-12-x86_64:
     - sles-12-x86_64
     - sles-15-x86_64


### PR DESCRIPTION
As of March 31st 2019, SLES 11 is no longer generally supported. Per our
support process we will no longer officially support SLES 11.

See https://docs.chef.io/platforms.html#platform-end-of-life-policy

Signed-off-by: Tim Smith <tsmith@chef.io>