### PR TITLE
Update Chef Infra Client to 15.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,13 +54,13 @@ group(:omnibus_package) do
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch
   # fixes.
-  gem "chef", "= 15.1.36"
-  gem "chef-bin", "= 15.1.36"
+  gem "chef", "= 15.2.20"
+  gem "chef-bin", "= 15.2.20"
   gem "cheffish", ">= 14.0.1"
   gem "chefspec", ">= 7.3.0", "< 8"
   gem "fauxhai", "~> 7.0"
-  gem "inspec-bin", "~> 4.3" # the actual inspec CLI binary
-  gem "inspec", "~> 4.3"
+  gem "inspec-bin", "~> 4.10" # the actual inspec CLI binary
+  gem "inspec", "~> 4.10"
   gem "kitchen-azurerm", ">= 0.14"
   gem "kitchen-ec2", ">= 3.0", "< 4"
   gem "kitchen-digitalocean", ">= 0.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,11 +208,11 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (11.0.1)
-    chef (15.1.36)
+    chef (15.2.20)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.1.36)
+      chef-config (= 15.2.20)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -238,11 +238,11 @@ GEM
       train-core (~> 2.0, >= 2.0.12)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (15.1.36-universal-mingw32)
+    chef (15.2.20-universal-mingw32)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.1.36)
+      chef-config (= 15.2.20)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -297,9 +297,9 @@ GEM
       toml-rb
       train
       tty-spinner
-    chef-bin (15.1.36)
-      chef (= 15.1.36)
-    chef-config (15.1.36)
+    chef-bin (15.2.20)
+      chef (= 15.2.20)
+    chef-config (15.2.20)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -968,9 +968,9 @@ DEPENDENCIES
   bcrypt_pbkdf
   berkshelf (>= 7.0.5)
   bundler
-  chef (= 15.1.36)
+  chef (= 15.2.20)
   chef-apply (= 0.3.0)
-  chef-bin (= 15.1.36)
+  chef-bin (= 15.2.20)
   chef-dk!
   chef-sugar
   chef-vault (>= 3.4.1)
@@ -988,8 +988,8 @@ DEPENDENCIES
   ffi-rzmq-core
   foodcritic (>= 16.0)
   guard
-  inspec (~> 4.3)
-  inspec-bin (~> 4.3)
+  inspec (~> 4.10)
+  inspec-bin (~> 4.10)
   kitchen-azurerm (>= 0.14)
   kitchen-digitalocean (>= 0.10.0)
   kitchen-dokken (>= 2.6.7)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: e933bcabe0159a954ca81788b86420b0f7096362
+  revision: 5fa35959f6efb0a5a745c46e4b0431a2826934da
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 33bddeefb10afe23a57ea72807625881ab01990f
+  revision: a0fb4a162261f57ffd7b1fff980911b474970cb9
   branch: master
   specs:
     omnibus (6.1.0)
@@ -33,7 +33,7 @@ GEM
     artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.196.0)
+    aws-partitions (1.199.0)
     aws-sdk-core (3.62.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
@@ -65,11 +65,11 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (15.1.36)
+    chef (15.2.20)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.1.36)
+      chef-config (= 15.2.20)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -95,11 +95,11 @@ GEM
       train-core (~> 2.0, >= 2.0.12)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (15.1.36-universal-mingw32)
+    chef (15.2.20-universal-mingw32)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.1.36)
+      chef-config (= 15.2.20)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -137,7 +137,7 @@ GEM
       win32-service (>= 2.1.2, < 3.0)
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
-    chef-config (15.1.36)
+    chef-config (15.2.20)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
@@ -234,7 +234,7 @@ GEM
     nori (2.6.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (15.1.5)
+    ohai (15.2.5)
       chef-config (>= 12.8, < 16)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)


### PR DESCRIPTION
Also bump the minimum allowed version of inspec.

Signed-off-by: Tim Smith <tsmith@chef.io>