### PR TITLE
Appbundle DCO without the development gems

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -117,9 +117,9 @@ do_install() {
   pushd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
     set -x
     bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "chef" --without "docgen,chefstyle" >/dev/null
-    bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "foodcritic" --without "development" >/dev/null
-    bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "test-kitchen" --without "changelog,debug,docs" >/dev/null
+    bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "dco" "foodcritic" --without "development" >/dev/null
     bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "inspec-bin" --without "deploy,tools,maintenance,integration" >/dev/null
+    bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "test-kitchen" --without "changelog,debug,docs" >/dev/null
 
     export gems_to_appbundle
     gems_to_appbundle=(

--- a/habitat/tests.sh
+++ b/habitat/tests.sh
@@ -35,6 +35,5 @@ chef-vault -h
 # TODO(afiune) fix this since it currently doesn't work
 echo "skip: Chef CLI (not-working)"
 #chef -v
-#dco help # missing git
 
 # TODO(afiune) add more tests

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -93,8 +93,9 @@ build do
   appbundle "foodcritic", lockdir: project_dir, gem: "foodcritic", without: %w{development}, env: env
   appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs}, env: env
   appbundle "inspec", lockdir: project_dir, gem: "inspec-bin", without: %w{deploy tools maintenance integration}, env: env
+  appbundle "dco", lockdir: project_dir, gem: "dco", without: %w{development}, env: env
 
-  %w{chef-bin chef-dk chef-apply chef-vault ohai opscode-pushy-client cookstyle dco berkshelf}.each do |gem|
+  %w{chef-bin chef-dk chef-apply chef-vault ohai opscode-pushy-client cookstyle berkshelf}.each do |gem|
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 


### PR DESCRIPTION
dco has a development dep on rspec-command which depends on
mixlib-shellout 2.x and we use 3.x in chef-client now. This is breaking
omnibus builds.

Signed-off-by: Tim Smith <tsmith@chef.io>