### PR TITLE
Use a sha256 checksum file to avoid compressing / uploading one every run

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -2,7 +2,7 @@
 #
 # This script runs a passed in command, but first setups up the bundler caching on the repo
 
-set -evx
+set -e
 
 export USER="root"
 
@@ -12,7 +12,8 @@ apt-get install awscli -y
 
 # grab the s3 bundler if it's there and use it for all operations in bundler
 echo "Fetching bundle cache archive from s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.bz2"
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.bz2" bundle.tar.bz2 || echo 'Could not pull the bundler directory to s3 for caching. Builds may be slower than usual as all gems will have to install.'
+aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.bz2" bundle.tar.bz2 || echo 'Could not pull the bundler archive from s3 for caching. Builds may be slower than usual as all gems will have to install.'
+aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" bundle.sha256 || echo "Could not pull the sha256 hash of the vendor/bundle directory from s3. Without this we will compress and upload the bundler archive to S3 even if it hasn't changed"
 
 echo "Restoring the bundle cache archive to vendor/bundle"
 if [ -f bundle.tar.bz2 ]; then
@@ -23,9 +24,21 @@ bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
 bundle exec $1
 
-# shove the current contents into s3 overwriting the existing bundle if anything changed
+if [[ -f bundle.tar.bz2 && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
+  if shasum --check bundle.sha256 --status; then # if the the sha matches we're done
+    echo "Bundled gems have not changed. Skipping upload to s3"
+    exit
+  fi
+fi
+
+echo "Generating sha256 hash file of the vendor/bundle directory to ship to s3"
+shasum -a 256 vendor/bundle > bundle.sha256
 
 echo "Creating the tar.bz2 to of the vendor/bundle directory to ship to s3"
 tar -cjf bundle.tar.bz2 vendor/
+
 echo "Uploading the tar.bz2 of the vendor/bundle directory to s3"
 aws s3 cp bundle.tar.bz2 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.bz2" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
+
+echo "Uploading the sha256 hash of the vendor/bundle directory to s3"
+aws s3 cp bundle.sha256 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'


### PR DESCRIPTION
The compression / upload is time consuming and costly.

Signed-off-by: Tim Smith <tsmith@chef.io>