### PR TITLE
Update license scout dependency to unblock chef versions

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -15,7 +15,7 @@ group :development do
   gem "berkshelf", ">= 7.0"
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem "test-kitchen", ">= 1.23"
+  gem "test-kitchen", ">= 2"
   gem "kitchen-vagrant"
   gem "winrm-elevated"
 end

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 48a66d6d84c3fc05bee69bbf5d6673f8bdc1a8f2
+  revision: f81ec7b4c2f2d54696703d3e1e2b6978f9050983
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -64,11 +64,12 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (15.2.20)
+    chef (15.5.15)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.2.20)
+      chef-config (= 15.5.15)
+      chef-utils (= 15.5.15)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -80,10 +81,10 @@ GEM
       iniparse (~> 1.4)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (~> 2.1)
+      mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 2.4, < 4.0)
+      mixlib-shellout (>= 3.0.3, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -91,14 +92,16 @@ GEM
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
-      train-core (~> 2.0, >= 2.0.12)
+      train-core (~> 3.1)
+      train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
-    chef (15.2.20-universal-mingw32)
+    chef (15.5.15-universal-mingw32)
       addressable
       bcrypt_pbkdf (~> 1.0)
       bundler (>= 1.10)
-      chef-config (= 15.2.20)
+      chef-config (= 15.5.15)
+      chef-utils (= 15.5.15)
       chef-zero (>= 14.0.11)
       diff-lcs (~> 1.2, >= 1.2.4)
       ed25519 (~> 1.2)
@@ -111,10 +114,10 @@ GEM
       iso8601 (~> 0.12.1)
       license-acceptance (~> 1.0, >= 1.0.5)
       mixlib-archive (>= 0.4, < 2.0)
-      mixlib-authentication (~> 2.1)
+      mixlib-authentication (>= 2.1, < 4)
       mixlib-cli (>= 2.1.1, < 3.0)
       mixlib-log (>= 2.0.3, < 4.0)
-      mixlib-shellout (>= 2.4, < 4.0)
+      mixlib-shellout (>= 3.0.3, < 4.0)
       net-sftp (~> 2.1, >= 2.1.2)
       net-ssh (>= 4.2, < 6)
       net-ssh-multi (~> 1.2, >= 1.2.1)
@@ -122,7 +125,8 @@ GEM
       plist (~> 3.2)
       proxifier (~> 1.0)
       syslog-logger (~> 1.6)
-      train-core (~> 2.0, >= 2.0.12)
+      train-core (~> 3.1)
+      train-winrm (>= 0.2.5)
       tty-screen (~> 0.6)
       uuidtools (~> 2.1.5)
       win32-api (~> 1.5.3)
@@ -137,13 +141,15 @@ GEM
       win32-taskscheduler (~> 2.0)
       wmi-lite (~> 1.0)
     chef-cleanroom (1.0.2)
-    chef-config (15.2.20)
+    chef-config (15.5.15)
       addressable
+      chef-utils (= 15.5.15)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
+    chef-utils (15.5.15)
     chef-zero (14.0.13)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -191,9 +197,9 @@ GEM
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
       tty-prompt (~> 0.18)
-    license_scout (1.0.28)
+    license_scout (1.0.29)
       ffi-yajl (~> 2.2)
-      mixlib-shellout (~> 2.2)
+      mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (~> 1.0)
     little-plugger (1.1.4)
     logging (2.2.2)
@@ -204,7 +210,7 @@ GEM
       mixlib-log
     mixlib-archive (1.0.1-universal-mingw32)
       mixlib-log
-    mixlib-authentication (2.1.1)
+    mixlib-authentication (3.0.4)
     mixlib-cli (2.1.1)
     mixlib-config (3.0.5)
       tomlrb
@@ -213,8 +219,8 @@ GEM
       mixlib-versioning
       thor
     mixlib-log (3.0.1)
-    mixlib-shellout (2.4.4)
-    mixlib-shellout (2.4.4-universal-mingw32)
+    mixlib-shellout (3.0.7)
+    mixlib-shellout (3.0.7-universal-mingw32)
       win32-process (~> 0.8.2)
       wmi-lite (~> 1.0)
     mixlib-versioning (1.2.7)
@@ -297,11 +303,12 @@ GEM
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.8)
-    train-core (2.1.19)
+    train-core (3.1.8)
       json (>= 1.8, < 3.0)
       mixlib-shellout (>= 2.0, < 4.0)
       net-scp (>= 1.2, < 3.0)
       net-ssh (>= 2.9, < 6.0)
+    train-winrm (0.2.5)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
     tty-box (0.5.0)
@@ -380,7 +387,7 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   pedump
-  test-kitchen (>= 1.23)
+  test-kitchen (>= 2)
   winrm-elevated
 
 BUNDLED WITH


### PR DESCRIPTION
Bring in newer deps by bumping license scout and loosening
mixlib-shellout

Signed-off-by: Tim Smith <tsmith@chef.io>