### PR TITLE
Remove chef-run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,13 +91,6 @@ group(:omnibus_package) do
   gem "ed25519"
   gem "bcrypt_pbkdf"
 
-  # Right now we must import chef-apply as a gem into the ChefDK because this is where all the gem
-  # dependency resolution occurs. Putting it elsewhere endangers older ChefDK issues of gem version
-  # conflicts post-build.
-  # Version 3.3 switches to ChefCLI instead of ChefDK - we want to lock to
-  # the latest version before that so that we don't pull in ChefCLI.
-  gem "chef-apply", "= 0.3.0"
-
   # For Delivery build node
   gem "chef-sugar"
   gem "mixlib-versioning"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     aws-sdk-kms (1.26.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-lambda (1.33.0)
+    aws-sdk-lambda (1.34.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-organizations (1.17.0)
@@ -293,20 +293,6 @@ GEM
     chef-api (0.10.0)
       logify (~> 0.1)
       mime-types
-    chef-apply (0.3.0)
-      chef (>= 15.0)
-      chef-dk (>= 4.0)
-      chef-telemetry
-      license-acceptance (~> 1.0, >= 1.0.11)
-      mixlib-cli
-      mixlib-config
-      mixlib-install
-      mixlib-log
-      pastel
-      r18n-desktop
-      toml-rb
-      train
-      tty-spinner
     chef-bin (15.5.17)
       chef (= 15.5.17)
     chef-config (15.5.17)
@@ -317,11 +303,6 @@ GEM
       mixlib-shellout (>= 2.0, < 4.0)
       tomlrb (~> 1.2)
     chef-sugar (5.1.9)
-    chef-telemetry (1.0.0)
-      chef-config
-      concurrent-ruby (~> 1.0)
-      ffi-yajl (~> 2.2)
-      http (~> 2.2)
     chef-utils (15.5.17)
     chef-vault (3.4.3)
     chef-zero (14.0.13)
@@ -339,7 +320,6 @@ GEM
       rspec (~> 3.0)
     chefstyle (0.14.0)
       rubocop (= 0.75.1)
-    citrus (3.0.2)
     cleanroom (1.0.0)
     coderay (1.1.2)
     coercible (1.0.0)
@@ -463,15 +443,8 @@ GEM
     hashie (3.6.0)
     highline (1.7.10)
     htmlentities (4.3.4)
-    http (2.2.2)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 1.0.1)
-      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (1.0.3)
-    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
@@ -716,9 +689,6 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.1.1)
-    r18n-core (3.2.0)
-    r18n-desktop (3.2.0)
-      r18n-core (= 3.2.0)
     rack (2.0.7)
     rainbow (3.0.0)
     rake (12.3.2)
@@ -816,8 +786,6 @@ GEM
     thread_safe (0.3.6)
     timeliness (0.3.10)
     tins (1.22.2)
-    toml-rb (2.0.1)
-      citrus (~> 3.0, > 3.0)
     tomlrb (1.2.9)
     train (3.2.0)
       activesupport (~> 5.2.3)
@@ -906,8 +874,6 @@ GEM
       tty-screen (~> 0.7)
       wisper (~> 2.0.0)
     tty-screen (0.7.0)
-    tty-spinner (0.9.1)
-      tty-cursor (~> 0.7)
     tty-table (0.11.0)
       equatable (~> 0.6)
       necromancer (~> 0.5)
@@ -993,7 +959,6 @@ DEPENDENCIES
   berkshelf (>= 7.0.8)
   bundler
   chef (= 15.5.17)
-  chef-apply (= 0.3.0)
   chef-bin (= 15.5.17)
   chef-dk!
   chef-sugar
@@ -1068,4 +1033,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -126,7 +126,6 @@ do_install() {
     export gems_to_appbundle
     gems_to_appbundle=(
       berkshelf
-      chef-apply
       chef-bin
       chef-dk
       chef-vault

--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -185,15 +185,6 @@ module ChefDK
         end
       end
 
-      add_component "chef-apply" do |c|
-        c.gem_base_dir = "chef-apply"
-      #   c.unit_test do
-      #     bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
-      #     sh("#{embedded_bin("bundle")} exec rspec")
-      #   end
-        c.smoke_test { sh("#{bin("chef-run")} -v") }
-      end
-
       add_component "foodcritic" do |c|
         c.gem_base_dir = "foodcritic"
         c.smoke_test { sh("#{embedded_bin("foodcritic --list")}") } # foodcritic -v exits with 2 so use --list which exits 0

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -95,7 +95,7 @@ build do
   appbundle "inspec", lockdir: project_dir, gem: "inspec-bin", without: %w{deploy tools maintenance integration}, env: env
   appbundle "dco", lockdir: project_dir, gem: "dco", without: %w{development}, env: env
 
-  %w{chef-bin chef-dk chef-apply chef-vault ohai opscode-pushy-client cookstyle berkshelf}.each do |gem|
+  %w{chef-bin chef-dk chef-vault ohai opscode-pushy-client cookstyle berkshelf}.each do |gem|
     appbundle gem, lockdir: project_dir, gem: gem, without: %w{changelog}, env: env
   end
 

--- a/spec/unit/command/verify_spec.rb
+++ b/spec/unit/command/verify_spec.rb
@@ -38,7 +38,6 @@ describe ChefDK::Command::Verify do
   let(:default_components) do
     [
       "berkshelf",
-      "chef-apply",
       "chef-client",
       "chef-dk",
       "chef-sugar",


### PR DESCRIPTION
This removes the chef-apply gem, which pulls in the `chef-run` binary.

`chef-run` only works in Workstation; we originally included it in DK
only because we had to in order to have the gem app-bundleable
in the DK-based Workstation build.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-[x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
