### PR TITLE
Make sure we don't cleanup warning.txt

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup.rb
+++ b/omnibus/config/software/more-ruby-cleanup.rb
@@ -68,7 +68,6 @@ build do
       Manifest
       CHANGES.txt
       CHANGELOG.txt
-      warning.txt
       FAQ.txt
       release-script.txt
       TODO


### PR DESCRIPTION
We use this in the DK gem post install and without this the tests fail

Signed-off-by: Tim Smith <tsmith@chef.io>