### PR TITLE
Remove Foodcritic tests / Foodcritic from the readme

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -24,14 +24,6 @@ steps:
       docker:
         image: ruby:2.6-buster
 
-- label: foodcritic-generator-cb-tests-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh "rake style:foodcritic"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
-
 - label: cookstyle-generator-cb-tests-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh "rake style:cookstyle"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ChefDK
 
 [![Build Status](https://badge.buildkite.com/19dd11f6792c0cf4617ee97195060bd54b76f6a74228fd6e07.svg?branch=master)](https://buildkite.com/chef-oss/chef-chef-dk-master-verify)
-[![Build Status Master](https://ci.appveyor.com/api/projects/status/github/chef/chef-dk?branch=master&svg=true&passingText=master%20-%20Ok&pendingText=master%20-%20Pending&failingText=master%20-%20Failing)](https://ci.appveyor.com/project/Chef/chef-dk/branch/master)
 [![](https://img.shields.io/badge/Release%20Policy-Cadence%20Release-brightgreen.svg)](https://github.com/chef/chef-rfc/blob/master/rfc086-chef-oss-project-policies.md#cadence-release)
 [![Docker Stars](https://img.shields.io/docker/stars/chef/chefdk.svg?maxAge=2592000)](https://hub.docker.com/r/chef/chefdk)
 [![Docker Pulls](https://img.shields.io/docker/pulls/chef/chefdk.svg?maxAge=2592000)](https://hub.docker.com/r/chef/chefdk)

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 ChefDK brings Chef Infra Client and the development tools developed by the Chef Community together and acts as the consistent interface to this awesomeness. This awesomeness is composed of:
 
 * [Chef Infra Client][]
-* [Berkshelf][]
+* [Chef InSpec][]
 * [Test Kitchen][]
 * [ChefSpec][]
-* [Foodcritic][]
 * [Cookstyle][]
 * [Delivery CLI][]
 * [Push Jobs Client][]
+* [Berkshelf][]
 
 This repository contains the code for the `chef` command. The full
 package is built with omnibus. Project and component build definitions
@@ -43,7 +43,7 @@ system bin directory, ready to use.
 The following commands will download the latest ChefDK package from the `current` channel.  The `current` channel holds builds that have passed testing and are candidates for release.
 More information about flags supported by install.sh available here: https://docs.chef.io/api_omnitruck.html
 
-#### Linux and OS/X:
+#### Linux and macOS
 
 In a terminal, run:
 
@@ -313,11 +313,11 @@ packaging, and building works.
 
 [Berkshelf]: https://docs.chef.io/berkshelf.html "Berkshelf"
 [Chef Infra Client]: https://www.chef.io/products/chef-infra/ "Chef Infra Client"
+[Chef InSpec]: https://www.inspec.io/ "Chef InSpec"
 [ChefDK]: https://downloads.chef.io/chefdk/ "ChefDK"
 [Chef Documentation]: https://docs.chef.io "Chef Documentation"
 [ChefSpec]: http://chefspec.github.io/chefspec/ "ChefSpec"
 [Cookstyle]: https://docs.chef.io/cookstyle.html "Cookstyle"
-[Foodcritic]: http://foodcritic.io "Foodcritic"
 [Learn Chef]: https://learn.chef.io "Learn Chef"
 [Test Kitchen]: http://kitchen.ci "Test Kitchen"
 [Delivery CLI]: https://docs.chef.io/delivery_cli.html "Delivery CLI"

--- a/Rakefile
+++ b/Rakefile
@@ -49,27 +49,11 @@ namespace :style do
       spec/unit/fixtures/local_path_cookbooks
     })
 
-    desc "Run Chef Ruby style checks"
+    desc "Run Cookstyle style checks"
     RuboCop::RakeTask.new(:chefstyle) do |t|
       t.requires = ["chefstyle"]
       t.patterns = `rubocop --list-target-files`.split("\n").reject { |f| f =~ ignore_dirs }
       t.options = ["--display-cop-names"]
-    end
-  rescue LoadError => e
-    puts ">>> Gem load error: #{e}, omitting #{task.name}" unless ENV["CI"]
-  end
-
-  begin
-    require "foodcritic"
-
-    desc "Run Chef Cookbook (Foodcritic) style checks"
-    FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
-      t.options = {
-        fail_tags: ["any"],
-        tags: ["~FC071", "~supermarket", "~FC031"],
-        cookbook_paths: ["lib/chef-dk/skeletons/code_generator"],
-        progress: true,
-      }
     end
   rescue LoadError => e
     puts ">>> Gem load error: #{e}, omitting #{task.name}" unless ENV["CI"]

--- a/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/README.md
+++ b/lib/chef-dk/skeletons/code_generator/files/default/build_cookbook/README.md
@@ -129,7 +129,7 @@ delivery review
 
 ## FAQ
 
-### Why don't I just run rspec and foodcritic/rubocop on my local system?
+### Why don't I just run rspec and cookstyle/chefspec on my local system?
 
 An objection to the Test Kitchen approach is that it is much faster to run the unit, lint, and syntax commands for the project on the local system. That is totally true, and also totally valid. Do that for the really fast feedback loop. However, the dance we do with Test Kitchen brings a much higher degree of confidence in the changes we're making, that everything will run on the build nodes in Chef Workflow. We strongly encourage this approach before actually pushing the changes to Workflow.
 


### PR DESCRIPTION
De-emphasize Foodcritic as we've replaced it with Cookstyle

Signed-off-by: Tim Smith <tsmith@chef.io>