### PR TITLE
Remove references to Travis and Appveyor

### DIFF
--- a/.expeditor/buildkite/verify.ps1
+++ b/.expeditor/buildkite/verify.ps1
@@ -28,7 +28,7 @@ bundle --version
 bundle env
 
 echo "--- bundle install"
-bundle install --jobs=7 --retry=3 --without tools integration travis style omnibus_package aix bsd linux mac_os_x solaris
+bundle install --jobs=7 --retry=3 --without tools integration style omnibus_package aix bsd linux mac_os_x solaris
 
 echo "+++ bundle exec rspec"
 bundle exec rspec

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -1,6 +1,5 @@
 # THIS IS NOW HAND MANAGED, JUST EDIT THE THING
-# .travis.yml and appveyor.yml consume this,
-# try to keep it machine-parsable.
+# Buildkite consume this so keep it machine-parsable.
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock


### PR DESCRIPTION
We don't use either of these anymore

Signed-off-by: Tim Smith <tsmith@chef.io>