### PR TITLE
Update license_scout to 1.1.3

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
       tty-prompt (~> 0.18)
-    license_scout (1.1.2)
+    license_scout (1.1.3)
       ffi-yajl (~> 2.2)
       mixlib-shellout (>= 2.2, < 4.0)
       toml-rb (>= 1, < 3)


### PR DESCRIPTION
I typo'd the location of the sync gem license file

Signed-off-by: Tim Smith <tsmith@chef.io>