### PR TITLE
Remove Windows 2008 R2 from the build pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -28,7 +28,6 @@ builder-to-testers-map:
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:
-    - windows-2008r2-x86_64
     - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64


### PR DESCRIPTION
Windows 2008 R2 is now officially EOL so we should no longer push builds
to downloads.chef.io

Signed-off-by: Tim Smith <tsmith@chef.io>