### PR TITLE
Fixes all notarization issues

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 1b2dfe467cbc22e0e2e232e2648af3482830bfd7
+  revision: ad7ed679f1b34c20f8be34365d38cb1c21e737cd
   branch: master
   specs:
     omnibus-software (4.0.0)
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 70855aab656d333622c51171828b4f41d04f6ef5
+  revision: d642ae6fd57f4a74846e325fecadebb132069894
   branch: master
   specs:
-    omnibus (6.1.21)
+    omnibus (7.0.1)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-sugar (>= 3.3)

--- a/omnibus/config/patches/rb-fsevent-gem.patch
+++ b/omnibus/config/patches/rb-fsevent-gem.patch
@@ -1,0 +1,24 @@
+diff --git a/bin/fsevent_watch b/bin/fsevent_watch
+index 889204f..17b894b 100755
+Binary files a/bin/fsevent_watch and b/bin/fsevent_watch differ
+diff --git a/ext/rakefile.rb b/ext/rakefile.rb
+index d7789bd..fd8ec36 100644
+--- a/ext/rakefile.rb
++++ b/ext/rakefile.rb
+@@ -48,13 +48,13 @@ CLOBBER.include $final_exe.to_s
+ task :sw_vers do
+   $mac_product_version = `sw_vers -productVersion`.strip
+   $mac_build_version = `sw_vers -buildVersion`.strip
+-  $MACOSX_DEPLOYMENT_TARGET = ENV["MACOSX_DEPLOYMENT_TARGET"] || $mac_product_version.sub(/\.\d*$/, '')
+-  $CFLAGS = "#{$CFLAGS} -mmacosx-version-min=#{$MACOSX_DEPLOYMENT_TARGET}"
++  $MACOSX_MIN_TARGET = $mac_product_version.sub(/\.\d*$/, '')
++  $CFLAGS = "#{$CFLAGS} -mmacosx-version-min=#{$MACOSX_MIN_TARGET}"
+ end
+ 
+ task :get_sdk_info => :sw_vers do
+   $SDK_INFO = {}
+-  version_info = `xcodebuild -version -sdk macosx#{$MACOSX_DEPLOYMENT_TARGET}`
++  version_info = `xcodebuild -version -sdk macosx`
+   raise "invalid SDK" unless !!$?.exitstatus
+   version_info.strip.each_line do |line|
+     next if line.strip.empty?

--- a/omnibus/config/projects/chefdk.rb
+++ b/omnibus/config/projects/chefdk.rb
@@ -98,7 +98,7 @@ end
 
 package :pkg do
   identifier "com.getchef.pkg.chefdk"
-  signing_identity "Developer ID Installer: Chef Software, Inc. (EU3VF8YLX2)"
+  signing_identity "Chef Software, Inc. (EU3VF8YLX2)"
 end
 
 package :msi do

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -74,6 +74,11 @@ dependency "bundler" # technically a gem, but we gotta solve the chicken-egg pro
 # for train
 dependency "google-protobuf"
 
+# This is a transative dep but we need to build from source so binaries are built on current sdk.
+# Only matters on mac.
+# TODO: Contact gem mainter about getting new release.
+dependency "rb-fsevent-gem" if mac_os_x?
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/omnibus/config/software/git-custom-bindir.rb
+++ b/omnibus/config/software/git-custom-bindir.rb
@@ -41,6 +41,8 @@ version("2.24.1") { source sha256: "ad5334956301c86841eb1e5b1bb20884a6bad89a10a6
 
 source url: "https://www.kernel.org/pub/software/scm/git/git-#{version}.tar.gz"
 
+bin_dirs ["#{install_dir}/gitbin", "#{install_dir}/embedded/libexec/git-core"]
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/omnibus/config/software/rb-fsevent-gem.rb
+++ b/omnibus/config/software/rb-fsevent-gem.rb
@@ -1,0 +1,36 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rb-fsevent-gem"
+default_version "master"
+
+source git: "https://github.com/thibaudgg/rb-fsevent.git"
+
+license "Apache-2.0"
+license_file "https://raw.githubusercontent.com/thibaudgg/rb-fsevent/master/LICENSE.txt"
+
+dependency "ruby"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  # Look up active sdk version.
+  sdk_ver = `xcrun --sdk macosx --show-sdk-version`.strip
+  env["MACOSX_DEPLOYMENT_TARGET"] = sdk_ver
+
+  bundle "install", env: env
+  bundle "exec rake replace_exe", env: env, cwd: "#{project_dir}/ext"
+  bundle "exec rake install:local", env: env
+end


### PR DESCRIPTION
## Description
    This changes makes the neccessary changes to enable the pkg to pass Apple's notarization requirements.

    1. Update omnibus and omnibus-software to versions that support deep signing
    2. Drop 'Developer ID Installer:' from signing key. This lets sigining pick up the correct key for what is being signed.
    3. Add bin_dirs and lib_dirs to chefdk and git-custom-bindir software definitions so siging can find their binaries and libraries.
    4. Add software definition for rb-fsevent-gem so we build the gem. This resolves an issue where the shipped binary is build on to old an sdk.
    5. Patch rb-fsevent-gem build to work in our environment. Set minimum target to current os and discover the sdk version.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

## Related Issue
https://github.com/chef/omnibus/pull/924
https://github.com/chef/omnibus-software/pull/1146

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
