### PR TITLE
Stop producing Windows 2008 R2 builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -28,7 +28,6 @@ builder-to-testers-map:
   windows-2012r2-i386:
     - windows-2012r2-i386
   windows-2012r2-x86_64:
-    - windows-2008r2-x86_64
     - windows-2012-x86_64
     - windows-2012r2-x86_64
     - windows-2016-x86_64


### PR DESCRIPTION
Windows 2008 R2 is EOL as of 1/14/2020.

Signed-off-by: Tim Smith <tsmith@chef.io>