### PR TITLE
Exclude omnibus_packages in chef bundle testing

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -118,7 +118,7 @@ do_install() {
   # versions of dependencies already resolved
   pushd "$CACHE_PATH" || exit_with "unable to enter hab-cache directory" 1
     set -x
-    bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "chef" --without "docgen,chefstyle" >/dev/null
+    bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "chef" --without "docgen,chefstyle,omnibus_software" >/dev/null
     bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "dco" "foodcritic" --without "development" >/dev/null
     bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "inspec-bin" --without "deploy,tools,maintenance,integration" >/dev/null
     bundle exec appbundler "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$ruby_bin_dir" "test-kitchen" --without "changelog,debug,docs" >/dev/null

--- a/omnibus/config/software/chef-dk.rb
+++ b/omnibus/config/software/chef-dk.rb
@@ -88,7 +88,7 @@ build do
 
   env["NOKOGIRI_USE_SYSTEM_LIBRARIES"] = "true"
 
-  appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{docgen chefstyle}, env: env
+  appbundle "chef", lockdir: project_dir, gem: "chef", without: %w{docgen chefstyle omnibus_software}, env: env
 
   appbundle "foodcritic", lockdir: project_dir, gem: "foodcritic", without: %w{development}, env: env
   appbundle "test-kitchen", lockdir: project_dir, gem: "test-kitchen", without: %w{changelog debug docs}, env: env


### PR DESCRIPTION
Due to pins in inspec vs. inspec-core in 4.18.51 we're getting failures.
This will be resolved with a new inspec release, but that doesn't
unblock us today.

Signed-off-by: Tim Smith <tsmith@chef.io>