### PR TITLE
Pin FFI to avoid warnings on Windows hosts when running knife

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,10 @@ gemspec
 
 gem "bundler"
 
+## avoid ffi warnings about overwriting struct layouts which 1.12 introduced
+# https://github.com/chef/chef-workstation/issues/904 tracks fixing this in win32-service
+gem "ffi", "< 1.12"
+
 ## Until we resolve https://github.com/inspec/train/issues/548
 gem "train", "=3.2.0"
 gem "train-core", "=3.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,9 +389,9 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fauxhai (7.4.0)
       net-ssh
-    ffi (1.12.1)
-    ffi (1.12.1-x64-mingw32)
-    ffi (1.12.1-x86-mingw32)
+    ffi (1.11.3)
+    ffi (1.11.3-x64-mingw32)
+    ffi (1.11.3-x86-mingw32)
     ffi-libarchive (1.0.0)
       ffi (~> 1.0)
     ffi-rzmq (2.0.7)
@@ -989,6 +989,7 @@ DEPENDENCIES
   dep_selector
   ed25519
   fauxhai (~> 7.4)
+  ffi (< 1.12)
   ffi-libarchive
   ffi-rzmq-core
   foodcritic (>= 16.0)


### PR DESCRIPTION
FFI is being more strict now and throwing deprecations. Pin until we can work around this.

Signed-off-by: Tim Smith <tsmith@chef.io>