### PR TITLE
Ensure we don't pull chef gem from git in chefspec

### DIFF
--- a/lib/chef-dk/command/verify.rb
+++ b/lib/chef-dk/command/verify.rb
@@ -293,8 +293,8 @@ module ChefDK
       add_component "chefspec" do |c|
         c.gem_base_dir = "chefspec"
         c.unit_test do
-          bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install") }
-          sh("#{embedded_bin("bundle")} exec #{embedded_bin("rake")} unit")
+          bundle_install_mutex.synchronize { sh("#{embedded_bin("bundle")} install", env: { "GEMFILE_MOD" => "true" } ) }
+          sh("#{embedded_bin("bundle")} exec #{embedded_bin("rake")} unit", env: { "GEMFILE_MOD" => "true" })
         end
         c.smoke_test do
           tmpdir do |cwd|


### PR DESCRIPTION
chefspec is failing verification because it's pulling `chef` from git
master.  I was not able to find any related changes in the repository or deps 
that would account for the change in behavior since the last good build in January,
 but I do see thatby specifing a no-op `GEMFILE_MOD` we'll stick with the same
chef gem version that is in the gemspec.

Applying this change specifically to the `chefspec` unit test will
prevent the env var from affecting other tests.

I've verified this corrects the issue locally, but we'll hold on merging until  for the verification pipeline completes. 

Fixes #2754

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
