### PR TITLE
Commented example to accept chef license

### DIFF
--- a/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
+++ b/lib/chef-dk/skeletons/code_generator/templates/default/kitchen.yml.erb
@@ -20,6 +20,10 @@ provisioner:
   ## see the Chef documentation for more details: https://docs.chef.io/config_yml_kitchen.html
   #  product_name: chef
   #  product_version: 15
+  
+  ## Accept the chef license within test kitchen
+  # client_rb:
+  #  chef_license: accept
 
 verifier:
   name: inspec


### PR DESCRIPTION
Test kitchen can get blocked by the license acceptance prompt.  This PR
Adds a commented example for how to accept the license for test kitchen
in the default `.kitchen.yml` from a `chef generate repo`.

## Description

This lowers the barrier to a new user getting back on track after generating a brand new repository from `chef generate repo` and being blocked form using test kitchen because of the license acceptance prompt.  

A user facing that prompt from a test kitchen stalling out on license acceptance could just
edit `.kitchen.yml` and uncomment the two lines needed to accept the license inside test kitchen.


## Related Issue

See https://github.com/test-kitchen/test-kitchen/issues/1553 for more details.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
