### PR TITLE
Pin ruby-prof < 1.4 to avoid x64-mingw32 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,7 +115,7 @@ end
 
 # Everything except AIX
 group(:ruby_prof) do
-  gem "ruby-prof"
+  gem "ruby-prof", "< 1.4" # 1.4 introduces a x64-mingw32 gem that causes failures
 end
 
 # Everything except Windows

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -760,8 +760,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-prof (1.4.1)
-    ruby-prof (1.4.1-x64-mingw32)
+    ruby-prof (1.3.2)
     ruby-progressbar (1.10.1)
     ruby-shadow (2.5.0)
     rubyntlm (0.6.2)
@@ -1046,7 +1045,7 @@ DEPENDENCIES
   rspec-core (~> 3.0)
   rspec-expectations (~> 3.0)
   rspec-mocks (~> 3.0)
-  ruby-prof
+  ruby-prof (< 1.4)
   ruby-shadow
   stove (>= 7.1.5)
   test-kitchen (>= 2.0)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: cb69c7248212091e74b263b7518e4d14dbe7cf0e
+  revision: 1193dc710f66809eb4abd69ea29b23234527acc5
   branch: master
   specs:
     omnibus-software (4.0.0)


### PR DESCRIPTION
This gem seems to cause failures for us since there's no 32bit version

Signed-off-by: Tim Smith <tsmith@chef.io>