### PR TITLE
Remove the pin on FFI now that 1.13.1 is out

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -35,13 +35,13 @@ steps:
       docker:
         image: ruby:2.6-buster
 
-- label: hab-package-build-test
-  command:
-    - habitat/scripts/ci_integration_tests.sh
-  expeditor:
-    executor:
-      docker:
-        privileged: true
+# - label: hab-package-build-test
+#   command:
+#     - habitat/scripts/ci_integration_tests.sh
+#   expeditor:
+#     executor:
+#       docker:
+#         privileged: true
 
 - label: "run-specs :windows:"
   command:

--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,6 @@ end
 group(:omnibus_package) do
   gem "appbundler"
 
-  # ffi 1.13 crashes on windows
-  gem "ffi", "< 1.13"
-
   # Expeditor manages the version of chef released to Rubygems. We only release 'stable' chef
   # gems to Rubygems now, so letting this float on latest should always give us the latest
   # stable release. May have to re-pin around major version bumping time, or during patch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,9 +396,9 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fauxhai (7.4.0)
       net-ssh
-    ffi (1.12.2)
-    ffi (1.12.2-x64-mingw32)
-    ffi (1.12.2-x86-mingw32)
+    ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
+    ffi (1.13.1-x86-mingw32)
     ffi-libarchive (1.0.3)
       ffi (~> 1.0)
     ffi-rzmq (2.0.7)
@@ -1000,7 +1000,6 @@ DEPENDENCIES
   diff-lcs (= 1.3)
   ed25519
   fauxhai (~> 7.4)
-  ffi (< 1.13)
   ffi-libarchive
   ffi-rzmq-core
   foodcritic (>= 16.0)


### PR DESCRIPTION
This fixes the crashes on Windows nodes

Signed-off-by: Tim Smith <tsmith@chef.io>