### PR TITLE
Update project status to 'maintained'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@
 
 **Umbrella Project**: [Chef Workstation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-workstation.md)
 
-* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Active
-* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
-* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** 14 days
+* **[Project State](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Maintained
+* **Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Never
+* **Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md):** Never
 
-ChefDK brings Chef Infra Client and the development tools developed by the Chef Community together and acts as the consistent interface to this awesomeness. This awesomeness is composed of:
+ChefDK is deprecated as a supported Chef product.  It has been replaced with [Chef Workstation](https://github.com/chef/chef-workstation.git).
+You can also [download](https://downloads.chef.io/chef-workstation/) Chef Workstation for the latest features and tools.
+
+
+[ChefDK](ChefDK) brings Chef Infra Client and the development tools developed by the Chef Community together and acts as the consistent interface to this awesomeness. This awesomeness is composed of:
 
 * [Chef Infra Client][]
 * [Chef InSpec][]


### PR DESCRIPTION
This sets Issue and PR SLA to 'never', and updates status to
'Maintained'.  As a product, Chef DK has been deprecated. Because we're
still releasing security updates, gem version updates, and critical fixes
the repo status of 'maintained' is more correct than 'deprecated'.

Added a description blurb to direct people to the Workstation project
and downloads.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
