### PR TITLE
Remove EOL Debian 8 / RHEL 8 packages

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -7,12 +7,9 @@ fips-platforms:
   - el-*-x86_64
   - windows-*
 builder-to-testers-map:
-  debian-8-x86_64:
-    - debian-8-x86_64
+  debian-9-x86_64:
     - debian-9-x86_64
     - debian-10-x86_64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64


### PR DESCRIPTION
These are both EOL platforms now

Signed-off-by: Tim Smith <tsmith@chef.io>