### PR TITLE
Introduce a shared scm context

### DIFF
--- a/lib/chef-dk/policyfile/cookbook_locks.rb
+++ b/lib/chef-dk/policyfile/cookbook_locks.rb
@@ -278,7 +278,7 @@ module ChefDK
       # given, it is resolved relative to #relative_paths_root
       attr_accessor :source
 
-      def initialize(name, storage_config)
+      def initialize(name, storage_config, shared_scm_context = {})
         @name = name
         @identifier = nil
         @storage_config = storage_config
@@ -287,6 +287,7 @@ module ChefDK
         @version_updated = false
         @cookbook_in_git_repo = nil
         @scm_info = nil
+        @shared_scm_context = shared_scm_context
       end
 
       def cookbook_path
@@ -295,7 +296,7 @@ module ChefDK
 
       def scm_profiler
         if cookbook_in_git_repo?
-          CookbookProfiler::Git.new(cookbook_path)
+          CookbookProfiler::Git.new(cookbook_path, @shared_scm_context)
         else
           CookbookProfiler::NullSCM.new(cookbook_path)
         end

--- a/lib/chef-dk/policyfile_lock.rb
+++ b/lib/chef-dk/policyfile_lock.rb
@@ -114,6 +114,8 @@ module ChefDK
       @included_policy_locks = []
 
       @install_report = InstallReport.new(ui: @ui, policyfile_lock: self)
+
+      @shared_scm_context = {}
     end
 
     def lock_data_for(cookbook_name)
@@ -127,7 +129,7 @@ module ChefDK
     end
 
     def local_cookbook(name)
-      local_cookbook = Policyfile::LocalCookbook.new(name, storage_config)
+      local_cookbook = Policyfile::LocalCookbook.new(name, storage_config, @shared_scm_context)
       yield local_cookbook if block_given?
       @cookbook_locks[name] = local_cookbook
     end

--- a/spec/unit/command/generator_commands/cookbook_spec.rb
+++ b/spec/unit/command/generator_commands/cookbook_spec.rb
@@ -267,7 +267,7 @@ describe ChefDK::Command::GeneratorCommands::Cookbook do
             # Cookbook:: build_cookbook
             # Recipe:: publish
             #
-            # Copyright:: 2020, The Authors, All Rights Reserved.
+            # Copyright:: 2021, The Authors, All Rights Reserved.
 
             include_recipe 'delivery-truck::publish'
           CONFIG_DOT_JSON


### PR DESCRIPTION
In some situations, when a lot of local cookbooks are used, tests can
spend a lot of time doing several times the same git commands for each
one of them. It can be particularly unefficient when they share the same
git repo.

With this change, we make sure commands are launched only once and
results are reused if necessary.